### PR TITLE
feat: add DialText and DialTitle components

### DIFF
--- a/src/components/Typography/Text.spec.tsx
+++ b/src/components/Typography/Text.spec.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { DialText } from './Text';
+import { TextAlign, TextColor, TextVariant } from '@/types/typography';
+
+describe('Dial UI Kit :: DialText', () => {
+  test('renders as <span> by default with Small variant and default leading', () => {
+    render(<DialText>Hello</DialText>);
+    const el = screen.getByText('Hello');
+    expect(el.tagName.toLowerCase()).toBe('span');
+    expect(el.className).toContain('text-[14px]');
+    expect(el.className).toContain('leading-[16px]');
+    expect(el.className).toContain('font-normal');
+    expect(el.className).toContain('text-primary');
+  });
+
+  test('applies Body variant size and leading', () => {
+    render(<DialText variant={TextVariant.Body}>Body</DialText>);
+    const el = screen.getByText('Body');
+    expect(el.className).toContain('text-[16px]');
+    expect(el.className).toContain('leading-[28px]');
+  });
+
+  test('applies 150% line-height when lineHeight150 is true', () => {
+    render(
+      <DialText variant={TextVariant.Small} lineHeight150>
+        Small 150
+      </DialText>,
+    );
+    const el = screen.getByText('Small 150');
+    expect(el.className).toContain('leading-[150%]');
+  });
+
+  test('respects component override to <p>', () => {
+    render(<DialText component="p">Paragraph</DialText>);
+    const el = screen.getByText('Paragraph');
+    expect(el.tagName.toLowerCase()).toBe('p');
+  });
+
+  test('adds alignment utility class', () => {
+    render(
+      <DialText align={TextAlign.Center} variant={TextVariant.Tiny}>
+        Centered
+      </DialText>,
+    );
+    const el = screen.getByText('Centered');
+    expect(el.className).toContain('text-center');
+  });
+
+  test('applies color class from enum', () => {
+    render(<DialText color={TextColor.Error}>Danger</DialText>);
+    const el = screen.getByText('Danger');
+    expect(el.className).toContain('text-error');
+  });
+
+  test('merges custom cssClass', () => {
+    render(<DialText cssClass="underline">Decorated</DialText>);
+    const el = screen.getByText('Decorated');
+    expect(el.className).toContain('underline');
+  });
+
+  test('applies bold font weight when bold is true', () => {
+    render(<DialText bold>Bold Text</DialText>);
+    const el = screen.getByText('Bold Text');
+    expect(el.className).toContain('font-semibold');
+  });
+});

--- a/src/components/Typography/Text.stories.tsx
+++ b/src/components/Typography/Text.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialText, type DialTextProps } from './Text';
+import { TextVariant, TextColor, TextAlign } from '@/types/typography';
+
+const meta = {
+  title: 'Components/Typography/Text',
+  component: DialText,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: Object.values(TextVariant),
+    },
+    color: { control: { type: 'select' }, options: Object.values(TextColor) },
+    align: { control: { type: 'select' }, options: Object.values(TextAlign) },
+    component: {
+      control: { type: 'select' },
+      options: [
+        'span',
+        'p',
+        'div',
+        'label',
+        'strong',
+        'em',
+        'code',
+        'blockquote',
+        'li',
+      ],
+    },
+    cssClass: { control: { type: 'text' } },
+    lineHeight150: { control: { type: 'boolean' } },
+    bold: { control: { type: 'boolean' } },
+    children: { control: { type: 'text' } },
+  },
+  args: {
+    variant: TextVariant.Small,
+    color: TextColor.Primary,
+    component: 'span',
+    lineHeight150: false,
+    children: 'Sample text',
+  },
+} satisfies Meta<DialTextProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Body: Story = {
+  args: { variant: TextVariant.Body, children: 'Body — 16/28' },
+};
+
+export const Tiny150: Story = {
+  name: 'Tiny • 150% line-height',
+  args: {
+    variant: TextVariant.Tiny,
+    lineHeight150: true,
+    children: 'Tiny with 150% LH (was 12/18)',
+  },
+};
+
+export const CaptionErrorCentered: Story = {
+  name: 'Caption • Error • Centered',
+  args: {
+    variant: TextVariant.Caption,
+    color: TextColor.Error,
+    align: TextAlign.Center,
+    children: 'Caption in error color and centered',
+  },
+};
+
+export const AsParagraph: Story = {
+  name: 'Rendered as <p>',
+  args: { component: 'p', children: 'Paragraph text' },
+};
+
+export const Showcase: Story = {
+  render: () => (
+    <div className="gap-2 flex flex-col">
+      <DialText variant={TextVariant.Body}>
+        Body — 16/28 (default leading)
+      </DialText>
+      <DialText variant={TextVariant.Body} lineHeight150>
+        Body — 150% leading
+      </DialText>
+      <DialText variant={TextVariant.Small}>Small — 14/16</DialText>
+      <DialText variant={TextVariant.Small} lineHeight150>
+        Small — 150% leading (≈14/21)
+      </DialText>
+      <DialText variant={TextVariant.Tiny}>Tiny — 12/14</DialText>
+      <DialText variant={TextVariant.Tiny} lineHeight150>
+        Tiny — 150% leading (≈12/18)
+      </DialText>
+      <DialText variant={TextVariant.Caption} color={TextColor.Secondary}>
+        Caption — 10/12 secondary
+      </DialText>
+      <DialText component="label">Rendered as &lt;label&gt;</DialText>
+      <DialText variant={TextVariant.Body} bold>
+        Body bold
+      </DialText>
+    </div>
+  ),
+};
+
+export const TextVariants: Story = {
+  render: () => (
+    <div className="gap-4 flex flex-col">
+      {Object.values(TextVariant).map((variant) => (
+        <DialText key={variant} variant={variant}>
+          Variant: {variant}
+        </DialText>
+      ))}
+    </div>
+  ),
+};
+
+export const TextColors: Story = {
+  render: () => (
+    <div className="gap-4 flex flex-col">
+      {Object.values(TextColor).map((color) => (
+        <DialText key={color} color={color}>
+          Color: {color}
+        </DialText>
+      ))}
+    </div>
+  ),
+};
+
+export const TextAlignments: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-[300px]">
+      {Object.values(TextAlign).map((align) => (
+        <DialText key={align} align={align} variant={TextVariant.Body}>
+          {align} aligned text
+        </DialText>
+      ))}
+    </div>
+  ),
+};
+
+export const CustomClass: Story = {
+  name: 'With custom cssClass',
+  args: {
+    cssClass: 'underline decoration-dotted',
+    children: 'Underlined with dotted decoration',
+  },
+};

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,0 +1,73 @@
+import {
+  TextColor,
+  type DialTypographyBaseProps,
+  TextVariant,
+} from '@/types/typography';
+import type { ElementType, FC } from 'react';
+import {
+  alignClassMap,
+  textColors,
+  textDefaultLeadingClassMap,
+  textVariantClassMap,
+} from './constants';
+import { mergeClasses } from '@/utils/merge-classes';
+
+export interface DialTextProps extends DialTypographyBaseProps {
+  variant?: TextVariant;
+  component?: ElementType;
+  bold?: boolean;
+}
+
+/**
+ * Text component.
+ *
+ * Use `component` to render any tag (e.g., 'span', 'p', 'label', custom component).
+ * Toggle `lineHeight150` to set line-height to 150%.
+ *
+ * @example
+ * ```tsx
+ * <DialText>Body text</DialText>
+ * <DialText component="p" variant={TextVariant.Small} color={TextColor.Secondary}>Paragraph small text</DialText>
+ * <DialText variant={TextVariant.Small} lineHeight150>Small with 150% LH</DialText>
+ * ```
+ *
+ * @param [variant=TextVariant.Body] - Visual text style
+ * @param [color=TextColor.Primary] - Text color token (CSS variable powered)
+ * @param [align] - Text alignment
+ * @param [component='span'] - Rendered tag/component
+ * @param [lineHeight150=false] - When true, applies `line-height: 150%`
+ * @param [cssClass] - Additional utility classes for the container
+ * @param [bold=false] - When true, applies `font-weight: 600`
+ * @param children - Text content
+ */
+export const DialText: FC<DialTextProps> = ({
+  variant = TextVariant.Small,
+  color = TextColor.Primary,
+  align,
+  component = 'span',
+  cssClass,
+  lineHeight150 = false,
+  children,
+  bold = false,
+}) => {
+  const Tag = component;
+  const leading = lineHeight150
+    ? 'leading-[150%]'
+    : textDefaultLeadingClassMap[variant];
+
+  return (
+    <Tag
+      className={mergeClasses(
+        'font-normal',
+        textVariantClassMap[variant],
+        textColors[color],
+        leading,
+        align ? alignClassMap[align] : undefined,
+        bold ? 'font-semibold' : undefined,
+        cssClass,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+};

--- a/src/components/Typography/Title.spec.tsx
+++ b/src/components/Typography/Title.spec.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { DialTitle } from './Title';
+import { TextAlign, TextColor } from '@/types/typography';
+
+describe('Dial UI Kit :: Title', () => {
+  test('renders level 1 as <h1> with base classes and default leading', () => {
+    render(<DialTitle>Level 1</DialTitle>);
+    const h = screen.getByRole('heading', { level: 1 });
+    expect(h).toBeInTheDocument();
+    expect(h.tagName.toLowerCase()).toBe('h1');
+    expect(h.className).toContain('text-[20px]');
+    expect(h.className).toContain('font-semibold');
+    expect(h.className).toContain('leading-[24px]');
+  });
+
+  test('renders level 2 as <h2> with correct weight and leading', () => {
+    render(<DialTitle level={2}>Level 2</DialTitle>);
+    const h = screen.getByRole('heading', { level: 2 });
+    expect(h.tagName.toLowerCase()).toBe('h2');
+    expect(h.className).toContain('text-[20px]');
+    expect(h.className).toContain('font-normal');
+    expect(h.className).toContain('leading-[24px]');
+  });
+
+  test('renders level 3 as <h3> with correct size/leading', () => {
+    render(<DialTitle level={3}>Level 3</DialTitle>);
+    const h = screen.getByRole('heading', { level: 3 });
+    expect(h.tagName.toLowerCase()).toBe('h3');
+    expect(h.className).toContain('text-[16px]');
+    expect(h.className).toContain('font-semibold');
+    expect(h.className).toContain('leading-[18px]');
+  });
+
+  test('applies color utility class from enum', () => {
+    render(<DialTitle color={TextColor.Error}>Danger</DialTitle>);
+    const el = screen.getByText('Danger');
+    expect(el.className).toContain('text-error');
+  });
+
+  test('applies alignment utility class', () => {
+    render(
+      <DialTitle level={2} align={TextAlign.Center}>
+        Centered Heading
+      </DialTitle>,
+    );
+    const el = screen.getByText('Centered Heading');
+    expect(el.className).toContain('text-center');
+  });
+
+  test('merges custom cssClass', () => {
+    render(
+      <DialTitle cssClass="underline decoration-dotted">Decorated</DialTitle>,
+    );
+    const el = screen.getByText('Decorated');
+    expect(el.className).toContain('underline');
+    expect(el.className).toContain('decoration-dotted');
+  });
+
+  test('sets id attribute when provided', () => {
+    render(<DialTitle id="title-id">With ID</DialTitle>);
+    const el = screen.getByText('With ID');
+    expect(el).toHaveAttribute('id', 'title-id');
+  });
+});

--- a/src/components/Typography/Title.stories.tsx
+++ b/src/components/Typography/Title.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialTitle, type DialTitleProps } from './Title';
+import { TextColor, TextAlign } from '@/types/typography';
+
+const meta = {
+  title: 'Components/Typography/Title',
+  component: DialTitle,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    level: { control: { type: 'radio' }, options: [1, 2, 3] },
+    color: { control: { type: 'select' }, options: Object.values(TextColor) },
+    align: { control: { type: 'select' }, options: Object.values(TextAlign) },
+    cssClass: { control: { type: 'text' } },
+    children: { control: { type: 'text' } },
+  },
+  args: {
+    level: 1,
+    color: TextColor.Primary,
+    children: 'Heading',
+  },
+} satisfies Meta<DialTitleProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Level1: Story = {
+  args: { level: 1, children: 'Level 1 — 20/24 semibold' },
+};
+
+export const Level2: Story = {
+  args: { level: 2, children: 'Level 2 — 20/24 normal' },
+};
+
+export const Level3: Story = {
+  args: { level: 3, children: 'Level 3 — 16/18 semibold' },
+};
+
+export const CenteredError: Story = {
+  name: 'Centered • Error',
+  args: {
+    level: 2,
+    align: TextAlign.Center,
+    color: TextColor.Error,
+    children: 'Important notice',
+  },
+};
+
+export const Showcase: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <DialTitle>Level 1 — default</DialTitle>
+      <DialTitle level={2} color={TextColor.Secondary}>
+        Level 2 — secondary
+      </DialTitle>
+      <DialTitle level={3} color={TextColor.AccentPrimary}>
+        Level 3 — accent primary
+      </DialTitle>
+      <DialTitle level={2} align={TextAlign.Right}>
+        Right aligned
+      </DialTitle>
+      <DialTitle level={1} cssClass="underline decoration-dotted">
+        Custom class (underline dotted)
+      </DialTitle>
+    </div>
+  ),
+};
+
+export const TitleLevels: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {[1, 2, 3].map((level) => (
+        <DialTitle key={level} level={level as 1 | 2 | 3}>
+          Level {level}
+        </DialTitle>
+      ))}
+    </div>
+  ),
+};
+
+export const TitleColors: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {Object.values(TextColor).map((color) => (
+        <DialTitle key={color} level={2} color={color}>
+          Color: {color}
+        </DialTitle>
+      ))}
+    </div>
+  ),
+};
+
+export const TitleAlignments: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-[360px]">
+      {Object.values(TextAlign).map((align) => (
+        <DialTitle key={align} level={2} align={align}>
+          {align} aligned title
+        </DialTitle>
+      ))}
+    </div>
+  ),
+};
+
+export const CustomClass: Story = {
+  name: 'With custom cssClass',
+  args: {
+    cssClass: 'underline decoration-dotted',
+    children: 'Underlined with dotted decoration',
+  },
+};

--- a/src/components/Typography/Title.tsx
+++ b/src/components/Typography/Title.tsx
@@ -1,0 +1,60 @@
+import type { FC } from 'react';
+import { TextColor, type DialTypographyBaseProps } from '@/types/typography';
+import {
+  alignClassMap,
+  defaultTitleTagByLevel,
+  textColors,
+  titleLevelClassMap,
+} from './constants';
+import { mergeClasses } from '@/utils/merge-classes';
+
+export interface DialTitleProps extends DialTypographyBaseProps {
+  level?: 1 | 2 | 3;
+}
+
+/**
+ * Title with levels (1–3).
+ *
+ * Uses Tailwind utility classes sourced from constants and supports:
+ * - color, alignment, custom classes via shared base props
+ *
+ * @example
+ * ```tsx
+ * <DialTitle>Dashboard</DialTitle>
+ * <DialTitle level={2} color={TextColor.Secondary}>Section</DialTitle>
+ * <DialTitle level={3}>Subsection</DialTitle>
+ * ```
+ *
+ * @param [level=1] - Visual level (1–3)
+ * @param [color=TextColor.Primary] - Text color token (utility class)
+ * @param [align] - Text alignment
+ * @param [cssClass] - Additional utility classes
+ * @param [id] - Optional id attribute
+ * @param children - Title text
+ */
+export const DialTitle: FC<DialTitleProps> = ({
+  level = 1,
+  color = TextColor.Primary,
+  align,
+  cssClass,
+  id,
+  children,
+}) => {
+  const Tag = defaultTitleTagByLevel[level];
+
+  return (
+    <Tag
+      id={id}
+      className={mergeClasses(
+        titleLevelClassMap[level],
+        textColors[color],
+        align ? alignClassMap[align] : undefined,
+        cssClass,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export default DialTitle;

--- a/src/components/Typography/constants.ts
+++ b/src/components/Typography/constants.ts
@@ -1,0 +1,49 @@
+import { TextAlign, TextColor, TextVariant } from '@/types/typography';
+
+export const textVariantClassMap: Record<TextVariant, string> = {
+  body: 'text-[16px]',
+  small: 'text-[14px]',
+  tiny: 'text-[12px]',
+  caption: 'text-[10px]',
+};
+
+export const textDefaultLeadingClassMap: Record<TextVariant, string> = {
+  [TextVariant.Body]: 'leading-[28px]',
+  [TextVariant.Small]: 'leading-[16px]',
+  [TextVariant.Tiny]: 'leading-[14px]',
+  [TextVariant.Caption]: 'leading-[12px]',
+};
+
+export const textColors: Record<TextColor, string> = {
+  [TextColor.Transparent]: 'text-transparent',
+  [TextColor.Primary]: 'text-primary',
+  [TextColor.Secondary]: 'text-secondary',
+  [TextColor.Error]: 'text-error',
+  [TextColor.Warning]: 'text-warning',
+  [TextColor.Info]: 'text-info',
+  [TextColor.Success]: 'text-success',
+  [TextColor.White]: 'text-white',
+  [TextColor.AccentPrimary]: 'text-accent-primary',
+  [TextColor.AccentSecondary]: 'text-accent-secondary',
+  [TextColor.AccentTertiary]: 'text-accent-tertiary',
+  [TextColor.ControlsPermanent]: 'text-controls-permanent',
+  [TextColor.ControlsTemporary]: 'text-controls-temporary',
+};
+
+export const alignClassMap: Record<TextAlign, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};
+
+export const defaultTitleTagByLevel = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+} as const;
+
+export const titleLevelClassMap = {
+  1: 'text-[20px] font-semibold leading-[24px]',
+  2: 'text-[20px] font-normal leading-[24px]',
+  3: 'text-[16px] font-semibold leading-[18px]',
+} as const;

--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -1,0 +1,7 @@
+import { DialText } from './Text';
+import { DialTitle } from './Title';
+
+export const DialTypography = {
+  Text: DialText,
+  Title: DialTitle,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { DialTag } from './components/Tag/Tag';
 export { DialEllipsisTooltip } from './components/EllipsisTooltip/EllipsisTooltip';
 export { DialTabs } from './components/Tabs/Tabs';
 export { DialTab } from './components/Tab/Tab';
+export { DialTypography } from './components/Typography';
 
 // Buttons
 export { DialButton } from './components/Button/Button';

--- a/src/types/typography.ts
+++ b/src/types/typography.ts
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+export interface DialTypographyBaseProps {
+  color?: TextColor;
+  lineHeight150?: boolean;
+  align?: TextAlign;
+  cssClass?: string;
+  children: ReactNode;
+  id?: string;
+}
+
+export enum TextVariant {
+  Body = 'body',
+  Small = 'small',
+  Tiny = 'tiny',
+  Caption = 'caption',
+}
+
+export enum TextColor {
+  Primary = 'primary',
+  Secondary = 'secondary',
+  Error = 'error',
+  Transparent = 'transparent',
+  Warning = 'warning',
+  Success = 'success',
+  White = 'white',
+  AccentPrimary = 'accent-primary',
+  AccentSecondary = 'accent-secondary',
+  AccentTertiary = 'accent-tertiary',
+  ControlsPermanent = 'controls-permanent',
+  ControlsTemporary = 'controls-temporary',
+  Info = 'info',
+}
+
+export enum TextAlign {
+  Left = 'left',
+  Center = 'center',
+  Right = 'right',
+}


### PR DESCRIPTION
**Description:**

add DialText and DialTitle components

Issues:

- Issue #78 

**UI changes**

<img width="1004" height="1031" alt="image" src="https://github.com/user-attachments/assets/0b289616-ad8d-4b4a-96cc-2ef02fdae837" />
<img width="1018" height="1065" alt="image" src="https://github.com/user-attachments/assets/fb1834e8-3ee7-48fc-bced-72d338540e58" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added