### PR TITLE
feat: add support for custom header and footer in DialDropdown menu

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -378,4 +378,153 @@ describe('Dial UI Kit :: Dropdown', () => {
     expect(onMenu).not.toHaveBeenCalled();
     expect(screen.getByRole('menu')).toBeInTheDocument();
   });
+
+  test('renders menu.header (function) above items and footer (node) below items', () => {
+    const footerText = 'Times are displayed in UTC';
+    const headerText = 'Custom Time Range';
+
+    render(
+      <DialDropdown
+        menu={{
+          header: () => <div>{headerText}</div>,
+          footer: <div>{footerText}</div>,
+          items,
+        }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+
+    const menuEl = screen.getByRole('menu');
+    const headerEl = screen.getByText(headerText);
+    const firstItem = screen.getByRole('menuitem', { name: 'Profile' });
+    const footerEl = screen.getByText(footerText);
+    const lastItem = screen.getByRole('menuitem', { name: 'Logout' });
+
+    expect(
+      headerEl.compareDocumentPosition(firstItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(
+      lastItem.compareDocumentPosition(footerEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(menuEl).toContainElement(headerEl);
+    expect(menuEl).toContainElement(footerEl);
+  });
+
+  test('contextmenu does not open when disabled=true even if ContextMenu is in triggers', () => {
+    render(
+      <DialDropdown
+        disabled
+        trigger={[DropdownTrigger.ContextMenu]}
+        menu={{ items }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+  test('menu.header (function) renders above items and does not close on click', () => {
+    const headerText = 'Custom Time Range';
+    const simpleItems: DropdownItem[] = [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ];
+
+    render(
+      <DialDropdown
+        menu={{
+          header: () => <div role="hdr">{headerText}</div>,
+          items: simpleItems,
+        }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+
+    const menu = screen.getByRole('menu');
+    const headerEl = screen.getByRole('hdr');
+    const firstItem = screen.getByRole('menuitem', { name: 'A' });
+
+    expect(menu).toContainElement(headerEl);
+
+    expect(
+      headerEl.compareDocumentPosition(firstItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(
+      screen.queryByRole('menuitem', { name: headerText }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(headerEl);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('menu.header (ReactNode) renders when provided as a node', () => {
+    const headerText = 'Filters';
+    render(
+      <DialDropdown
+        menu={{
+          header: <div>{headerText}</div>,
+          items: [
+            { key: 'a', label: 'A' },
+            { key: 'b', label: 'B' },
+          ],
+        }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+
+    const headerEl = screen.getByText(headerText);
+    expect(headerEl).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('menuitem', { name: headerText }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('menu.footer (function) is invoked and its content renders after items', () => {
+    const footerText = 'Times are displayed in UTC';
+    const footerFn = vi.fn(() => <div role="footer">{footerText}</div>);
+
+    render(
+      <DialDropdown
+        menu={{
+          items: [
+            { key: 'a', label: 'A' },
+            { key: 'b', label: 'B' },
+          ],
+          footer: footerFn,
+        }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+
+    expect(footerFn.mock.calls.length).toBeGreaterThan(0);
+
+    const footerEl = screen.getByRole('footer');
+    expect(footerEl).toBeInTheDocument();
+    expect(screen.getByText(footerText)).toBeInTheDocument();
+
+    const lastItem = screen.getByRole('menuitem', { name: 'B' });
+    expect(
+      lastItem.compareDocumentPosition(footerEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -219,3 +219,113 @@ export const AllowedPlacements: Story = {
     </div>
   ),
 };
+
+const timeItems = [
+  { key: '15m', label: 'Last 15m' },
+  { key: '30m', label: 'Last 30m' },
+  { key: '1h', label: 'Last 1h' },
+  { key: '3h', label: 'Last 3h' },
+  { key: '6h', label: 'Last 6h' },
+  { key: '12h', label: 'Last 12h' },
+  { key: '24h', label: 'Last 24h' },
+  { key: 'd', label: 'Last 2d' },
+  { key: '7d', label: 'Last 7d' },
+  { key: '30d', label: 'Last 30d' },
+].map((i) => ({ key: i.key, label: i.label }));
+
+export const WithCustomHeader: Story = {
+  name: 'With custom header',
+  args: {
+    placement: 'bottom-start',
+    menu: {
+      header: (
+        <div className="px-3 pt-2">
+          <div className="flex items-center justify-between text-secondary">
+            <span className="dial-small font-medium">Custom Time Range</span>
+            <IconChevronDown size={14} />
+          </div>
+        </div>
+      ),
+      items: [{ key: 'divider', type: DropdownItemType.Divider }, ...timeItems],
+    },
+  },
+};
+
+export const WithCustomFooter: Story = {
+  name: 'With custom footer',
+  args: {
+    placement: 'bottom-start',
+    menu: {
+      items: timeItems,
+      footer: (
+        <div className="px-3 py-2 border-t">
+          <span className="dial-small text-primary font-medium">
+            Footer content
+          </span>
+        </div>
+      ),
+    },
+  },
+};
+
+export const WithHeaderAndFooter: Story = {
+  name: 'With header and footer',
+  args: {
+    placement: 'bottom-start',
+    menu: {
+      header: (
+        <div className="px-3 py-2 border-b">
+          <span className="dial-small text-primary font-medium">
+            Select time range
+          </span>
+        </div>
+      ),
+      items: timeItems,
+      footer: (
+        <div className="px-3 py-2 border-t">
+          <span className="dial-small text-primary font-medium">
+            Footer content
+          </span>
+        </div>
+      ),
+    },
+  },
+};
+
+const FooterActionsExample = (args: DialDropdownProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DialDropdown
+      {...args}
+      trigger={[DropdownTrigger.Click]}
+      open={open}
+      onOpenChange={setOpen}
+      menu={{
+        items: timeItems,
+        footer: () => (
+          <div className="px-2 pb-2 pt-1 border-t border-divider">
+            <div className="flex items-center justify-end gap-2">
+              <DialButton
+                variant={ButtonVariant.Secondary}
+                title="Cancel"
+                onClick={() => setOpen(false)}
+              />
+              <DialButton
+                variant={ButtonVariant.Primary}
+                title="Apply"
+                onClick={() => setOpen(false)}
+              />
+            </div>
+          </div>
+        ),
+      }}
+    >
+      <TriggerBtn label="With footer actions" />
+    </DialDropdown>
+  );
+};
+
+export const WithFooterActionsControlled: Story = {
+  render: (args) => <FooterActionsExample {...args} />,
+};

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -46,6 +46,8 @@ import { DropdownItemType } from '@/types/dropdown';
 export interface DropdownMenuProps {
   items: DropdownItem[];
   onClick?: (info: { key: string; domEvent: MouseEvent }) => void;
+  header?: ReactNode | (() => ReactNode);
+  footer?: ReactNode | (() => ReactNode);
 }
 
 export interface DialDropdownProps {
@@ -247,54 +249,68 @@ export const DialDropdown: FC<DialDropdownProps> = ({
   const overlayContent: ReactNode = renderOverlay
     ? renderOverlay()
     : menu && (
-        <div role="none" className="py-1">
-          {menu.items.map((it) => {
-            if (it.type === DropdownItemType.Divider) {
+        <>
+          {menu.header && (
+            <>
+              {typeof menu.header === 'function' ? menu.header() : menu.header}
+            </>
+          )}
+
+          <div role="none" className="py-1">
+            {menu.items.map((it) => {
+              if (it.type === DropdownItemType.Divider) {
+                return (
+                  <div
+                    key={it.key}
+                    role="separator"
+                    className={dropdownDividerClasses}
+                  />
+                );
+              }
               return (
-                <div
+                <button
                   key={it.key}
-                  role="separator"
-                  className={dropdownDividerClasses}
-                />
-              );
-            }
-            return (
-              <button
-                key={it.key}
-                role="menuitem"
-                type="button"
-                aria-disabled={!!it.disabled}
-                className={classNames(
-                  dropdownItemBaseClasses,
-                  it.disabled && dropdownItemDisabledClasses,
-                  it.danger && dropdownItemDangerClasses,
-                )}
-                disabled={it.disabled}
-                onClick={handleItemClick(it)}
-              >
-                {it.icon && (
+                  role="menuitem"
+                  type="button"
+                  aria-disabled={!!it.disabled}
+                  className={classNames(
+                    dropdownItemBaseClasses,
+                    it.disabled && dropdownItemDisabledClasses,
+                    it.danger && dropdownItemDangerClasses,
+                  )}
+                  disabled={it.disabled}
+                  onClick={handleItemClick(it)}
+                >
+                  {it.icon && (
+                    <span
+                      className={classNames(
+                        it.danger && 'text-error',
+                        it.disabled && 'text-secondary',
+                      )}
+                    >
+                      <DialIcon icon={it.icon} />
+                    </span>
+                  )}
                   <span
                     className={classNames(
+                      'flex-1 truncate text-left',
                       it.danger && 'text-error',
                       it.disabled && 'text-secondary',
                     )}
                   >
-                    <DialIcon icon={it.icon} />
+                    {it.label}
                   </span>
-                )}
-                <span
-                  className={classNames(
-                    'flex-1 truncate text-left',
-                    it.danger && 'text-error',
-                    it.disabled && 'text-secondary',
-                  )}
-                >
-                  {it.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+                </button>
+              );
+            })}
+          </div>
+
+          {menu.footer && (
+            <>
+              {typeof menu.footer === 'function' ? menu.footer() : menu.footer}
+            </>
+          )}
+        </>
       );
 
   return (


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="308" height="480" alt="image" src="https://github.com/user-attachments/assets/e4476333-01db-461c-899d-5205ee067304" />

<img width="284" height="500" alt="image" src="https://github.com/user-attachments/assets/930041a8-2cae-49eb-8f48-ecc8d47ab996" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added