### PR TITLE
feat: add custom footer option to DialConfirmationPopup and update confirmLabel default

### DIFF
--- a/src/components/ConfirmationPopup/ConfirmationPopup.stories.tsx
+++ b/src/components/ConfirmationPopup/ConfirmationPopup.stories.tsx
@@ -33,12 +33,6 @@ const meta = {
   args: {
     title: 'Title',
     description: 'Body area',
-    confirmLabel: 'Confirm',
-    cancelLabel: 'Cancel',
-    dividers: false,
-    isLoading: false,
-    disableConfirmButton: false,
-    variant: ConfirmationPopupVariant.Info,
   },
 } satisfies Meta<DialConfirmationPopupProps>;
 
@@ -165,6 +159,25 @@ export const Loading: Story = {
 export const WithDividers: Story = {
   render: StatefulRender,
   args: { dividers: true, onClose: () => null, onConfirm: () => null },
+};
+
+export const CustomFooter: Story = {
+  render: StatefulRender,
+  args: {
+    footer: (
+      <div className="flex justify-between items-center px-6 py-3">
+        <span className="text-secondary dial-small-150">Custom footer</span>
+        <button
+          className="px-3 py-1.5 rounded bg-accent-primary text-primary hover:opacity-90 dial-small"
+          onClick={() => alert('Custom action')}
+        >
+          Action
+        </button>
+      </div>
+    ),
+    onClose: () => null,
+    onConfirm: () => null,
+  },
 };
 
 export const CustomClasses: Story = {

--- a/src/components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -6,6 +6,7 @@ import { DialPopup, type DialPopupProps } from '@/components/Popup/Popup';
 import {
   actionsBaseClasses,
   defaultCancelLabel,
+  defaultConfirmLabel,
   descriptionBaseClasses,
   variantConfig,
 } from './constants';
@@ -17,7 +18,7 @@ import { PopupSize } from '@/types/popup';
 export interface DialConfirmationPopupProps extends DialPopupProps {
   description?: string | ReactNode;
   descriptionCssClass?: string;
-  confirmLabel: string;
+  confirmLabel?: string;
   cancelLabel?: string;
   isLoading?: boolean;
   disableConfirmButton?: boolean;
@@ -50,7 +51,7 @@ export interface DialConfirmationPopupProps extends DialPopupProps {
  * @param [description] - Secondary text (ignored when `children` set)
  * @param [descriptionCssClass] - Custom CSS class for the description
  * @param [open=false] - Controls visibility of the popup
- * @param confirmLabel - Label for the confirm button
+ * @param [confirmLabel="Ok"] - Label for the confirm button
  * @param [cancelLabel="Cancel"] - Label for the cancel button
  * @param [isLoading=false] - Shows loader placeholder and hides actions
  * @param [disableConfirmButton=false] - Disables the confirm button
@@ -69,7 +70,7 @@ export const DialConfirmationPopup: FC<DialConfirmationPopupProps> = ({
   description,
   descriptionCssClass,
   open = false,
-  confirmLabel,
+  confirmLabel = defaultConfirmLabel,
   cancelLabel = defaultCancelLabel,
   isLoading = false,
   disableConfirmButton = false,
@@ -82,8 +83,9 @@ export const DialConfirmationPopup: FC<DialConfirmationPopupProps> = ({
   dividers = false,
   variant = ConfirmationPopupVariant.Info,
   size = PopupSize.Sm,
+  footer,
 }) => {
-  const footer = !isLoading ? (
+  const defaultFooter = !isLoading ? (
     <div className={actionsBaseClasses}>
       <DialButton
         variant={ButtonVariant.Secondary}
@@ -133,7 +135,7 @@ export const DialConfirmationPopup: FC<DialConfirmationPopupProps> = ({
       cssClass={classNames(variantConfig[variant].container, cssClass)}
       dividers={dividers}
       onClose={() => onClose?.()}
-      footer={footer}
+      footer={footer ?? defaultFooter}
       size={size}
     >
       {renderContent()}

--- a/src/components/ConfirmationPopup/constants.ts
+++ b/src/components/ConfirmationPopup/constants.ts
@@ -7,6 +7,8 @@ export const descriptionBaseClasses = 'text-secondary dial-small-150 px-6 py-4';
 
 export const defaultCancelLabel = 'Cancel';
 
+export const defaultConfirmLabel = 'Ok';
+
 export const variantConfig: Record<
   ConfirmationPopupVariant,
   {


### PR DESCRIPTION

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="284" height="130" alt="image" src="https://github.com/user-attachments/assets/d32ff2e3-4933-4445-b0df-ca8ffd045201" />
<img width="495" height="267" alt="image" src="https://github.com/user-attachments/assets/864cace7-1fe8-497e-9f34-466b7330deeb" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added