### PR TITLE
fix: Fix containerCssClass not being applied for TextAreaField

### DIFF
--- a/src/components/TextAreaField/TextAreaField.spec.tsx
+++ b/src/components/TextAreaField/TextAreaField.spec.tsx
@@ -36,10 +36,14 @@ describe('Dial UI Kit :: DialTextAreaField', () => {
         fieldTitle="Test Field"
         elementId="test-textarea"
         elementCssClass="custom-class"
+        containerCssClass="container-class"
       />,
     );
 
     const textarea = screen.getByRole('textbox', { name: 'Test Field' });
     expect(textarea).toHaveClass('custom-class');
+
+    const container = textarea.parentElement?.parentElement;
+    expect(container).toHaveClass('container-class');
   });
 });

--- a/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -5,11 +5,13 @@ import {
   DialTextAreaField,
 } from './TextAreaField';
 
-const InteractiveTextAreaField = (args: DialTextAreaFieldProps) => {
+const InteractiveTextAreaField = (
+  args: DialTextAreaFieldProps & { cssClass?: string },
+) => {
   const [value, setValue] = useState(args.value || '');
 
   return (
-    <div className="w-full text-primary">
+    <div className={args.cssClass ? args.cssClass : 'w-full text-primary'}>
       <DialTextAreaField
         {...args}
         value={value}
@@ -129,6 +131,21 @@ export const Disabled: Story = {
     placeholder: 'This field is disabled',
     value: 'This textarea field is disabled and cannot be edited',
     disabled: true,
+  },
+};
+
+export const FullParentHeightWithScroll = {
+  render: InteractiveTextAreaField,
+  args: {
+    fieldTitle: 'Detailed Description',
+    elementId: 'full-height-textarea-field',
+    placeholder: 'Enter a detailed description...',
+    value: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+  `,
+    cssClass: 'h-[100px] w-[300px] flex flex-col',
+    containerCssClass: 'flex-1 bg-layer-1',
   },
 };
 

--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import classNames from 'classnames';
 
 import { DialErrorText } from '@/components/ErrorText/ErrorText';
 import { DialFieldLabel } from '@/components/Field/Field';
@@ -32,14 +33,13 @@ export interface DialTextAreaFieldProps extends DialInputFieldBaseProps {
  * @param [errorText] - Error message to display below the textarea
  * @param [optional=false] - Whether to show optional indicator next to the label
  * @param [readonly=false] - Whether the textarea is read-only (no user input allowed)
- * @param [elementCssClass] - Additional CSS classes to apply to the textarea element
  * @param [disabled=false] - Whether the input is disabled and cannot be interacted with
  * @param [invalid=false] - Whether the input has validation errors (applies error styling)
  * @param [defaultEmptyText="None"] - Text to display when readonly and value is empty
  * @param [iconBefore] - Icon or element to display before the input
  * @param [iconAfter] - Icon or element to display after the input
  * @param [textBeforeInput] - Text to display before the input
- * @param [elementContainerCssClass] - Additional CSS classes to apply to the input container
+ * @param [elementCssClass] - Additional CSS classes to apply to the textarea element
  * @param [containerCssClass] - Additional CSS classes to apply to the outer container
  */
 export const DialTextAreaField: FC<DialTextAreaFieldProps> = ({
@@ -47,11 +47,12 @@ export const DialTextAreaField: FC<DialTextAreaFieldProps> = ({
   optional,
   elementId,
   elementCssClass,
+  containerCssClass,
   errorText,
   ...props
 }) => {
   return (
-    <div className="flex flex-col">
+    <div className={classNames('flex flex-col', containerCssClass)}>
       <DialFieldLabel
         fieldTitle={fieldTitle}
         optional={optional}

--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import classNames from 'classnames';
+import { mergeClasses } from '@/utils/merge-classes';
 
 import { DialErrorText } from '@/components/ErrorText/ErrorText';
 import { DialFieldLabel } from '@/components/Field/Field';
@@ -52,7 +52,7 @@ export const DialTextAreaField: FC<DialTextAreaFieldProps> = ({
   ...props
 }) => {
   return (
-    <div className={classNames('flex flex-col', containerCssClass)}>
+    <div className={mergeClasses('flex flex-col', containerCssClass)}>
       <DialFieldLabel
         fieldTitle={fieldTitle}
         optional={optional}


### PR DESCRIPTION
**Description:**

TextAreaField container styling wasn't being applied, fixed that (containerCssClass). Also removed duplicated property that did nothing (elementContainerCssClass)

Issues:

- Issue #<TICKET_ID>

**UI changes**

Styling applies to outer container now, added story about that

<img width="1902" height="1036" alt="image" src="https://github.com/user-attachments/assets/d3fa359e-6339-4556-9ab6-3a5175eb1edd" />


**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added