### PR TITLE
feat: add support for indicator element in DialFileIcon component

### DIFF
--- a/src/components/FileIcon/FileIcon.spec.tsx
+++ b/src/components/FileIcon/FileIcon.spec.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import { DialFileIcon } from './FileIcon';
-import { supportedExtensions } from './constants';
+import { fileIconFactories, supportedExtensions } from './constants';
+import { IconArrowUpRight } from '@tabler/icons-react';
+import { BASE_ICON_PROPS } from '@/constants/icon';
 
 describe('Dial UI Kit :: DialFileIcon', () => {
   test('renders as role="img" by default with computed label', () => {
@@ -30,6 +32,20 @@ describe('Dial UI Kit :: DialFileIcon', () => {
     expect(imgs.length).toBe(0);
   });
 
+  test('applies indicator element when provided', () => {
+    render(
+      <DialFileIcon
+        extension=".pdf"
+        indicator={
+          <IconArrowUpRight role="img" aria-label="Upload indicator" />
+        }
+      />,
+    );
+    expect(
+      screen.getByRole('img', { name: /Upload indicator/i }),
+    ).toBeInTheDocument();
+  });
+
   test.each(supportedExtensions)(
     'renders label for supported extension %s',
     (ext) => {
@@ -41,4 +57,25 @@ describe('Dial UI Kit :: DialFileIcon', () => {
       expect(screen.getByRole('img', { name: expected })).toBeInTheDocument();
     },
   );
+
+  test('tabler icon renders with correct default props if not provided', () => {
+    const node = fileIconFactories['.pdf']({});
+    const { container } = render(<>{node}</>);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg!.getAttribute('width')).toBe(String(BASE_ICON_PROPS.size));
+    expect(svg!.getAttribute('height')).toBe(String(BASE_ICON_PROPS.size));
+    expect(svg!.getAttribute('stroke-width')).toBe(
+      String(BASE_ICON_PROPS.stroke),
+    );
+  });
+
+  test('svgr icon renders with correct default props if not provided', () => {
+    const node = fileIconFactories['.cpp']({});
+    const { container } = render(<>{node}</>);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg!.getAttribute('width')).toBe(String(BASE_ICON_PROPS.size));
+    expect(svg!.getAttribute('height')).toBe(String(BASE_ICON_PROPS.size));
+  });
 });

--- a/src/components/FileIcon/FileIcon.stories.tsx
+++ b/src/components/FileIcon/FileIcon.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DialFileIcon, type DialFileIconProps } from './FileIcon';
 import { supportedExtensions } from './constants';
+import { IconArrowUpRight } from '@tabler/icons-react';
 
 const meta = {
   title: 'FileManager/DialFileIcon',
@@ -49,4 +50,26 @@ export const AllVariants: Story = {
     </div>
   ),
   args: { size: 24, decorative: false },
+};
+
+export const WithIndicator: Story = {
+  render: (args) => (
+    <div className="w-12 h-12 flex items-center justify-center bg-layer-3">
+      <DialFileIcon
+        {...args}
+        indicator={
+          <IconArrowUpRight
+            size={10}
+            className="text-accent-primary bg-layer-3"
+          />
+        }
+      />
+    </div>
+  ),
+  args: {
+    extension: 'default',
+    size: 18,
+    decorative: false,
+    cssClass: 'text-primary bg-layer-3',
+  },
 };

--- a/src/components/FileIcon/FileIcon.tsx
+++ b/src/components/FileIcon/FileIcon.tsx
@@ -13,6 +13,7 @@ export interface DialFileIconProps {
   cssClass?: string;
   decorative?: boolean;
   label?: string;
+  indicator?: ReactNode;
 }
 
 /**
@@ -33,6 +34,7 @@ export interface DialFileIconProps {
  * @param [cssClass] - Additional classes on the container
  * @param [decorative=false] - Whether the icon should be hidden from assistive technologies
  * @param [label] - Accessible label when not decorative; defaults to "<EXT> file icon"
+ * @param [indicator] - Optional indicator element to display alongside the icon
  */
 export const DialFileIcon: FC<DialFileIconProps> = ({
   extension,
@@ -41,6 +43,7 @@ export const DialFileIcon: FC<DialFileIconProps> = ({
   cssClass,
   decorative = false,
   label,
+  indicator,
 }) => {
   const normalized = (() => {
     const raw = extension.trim().toLowerCase();
@@ -59,12 +62,15 @@ export const DialFileIcon: FC<DialFileIconProps> = ({
 
   return (
     <span
-      className={classNames('inline-flex', cssClass)}
+      className={classNames('inline-flex relative', cssClass)}
       {...(decorative
         ? { 'aria-hidden': true }
         : { role: 'img', 'aria-label': computedLabel })}
     >
       <DialIcon icon={icon} className="inline-block align-middle" />
+      {indicator && (
+        <span className="absolute bottom-0 left-0">{indicator}</span>
+      )}
     </span>
   );
 };


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="118" height="99" alt="image" src="https://github.com/user-attachments/assets/875124e9-942b-40f3-8490-412da596b40b" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added