### PR TITLE
feat: add LoadedFileAreaField with its components, tests and stories (Issue #37)

### DIFF
--- a/src/components/LoadFileArea/EmptyFileArea.tsx
+++ b/src/components/LoadFileArea/EmptyFileArea.tsx
@@ -23,13 +23,51 @@ export interface DialEmptyFileAreaProps {
   emptyButtonLabel?: string;
   acceptTypes: string;
   maxFilesCount?: number;
-  isMultiple?: boolean;
+  multiple?: boolean;
   fileFormatError?: string;
   fileCountError?: string;
   getIsFileFormatError?: (fileItems: File[] | DataTransferItem[]) => boolean;
   onChange: (files: File[]) => void;
 }
 
+/**
+ * A drag-and-drop file upload area component that allows users to upload files
+ * either by dragging them into the drop zone or selecting them via the file picker.
+ * Displays customizable helper text, an upload button, and validation messages for file format
+ * or maximum file count errors. Integrates with `react-dnd` for drag-and-drop behavior.
+ *
+ * @example
+ * ```tsx
+ * <DialEmptyFileArea
+ *   onChange={(files) => console.log('Selected files:', files)}
+ *   emptyTextFirstLine="Drag & drop files here"
+ *   emptyTextSecondLine="or click below to select files"
+ *   emptyButtonLabel="Choose files"
+ *   acceptTypes="application/pdf, application/txt, image/svg+xml"
+ *   maxFilesCount={3}
+ *   multiple
+ *   fileFormatError="Only PNG and JPG files are allowed"
+ *   fileCountError="You can upload up to 3 files"
+ *   getIsFileFormatError={(files) =>
+ *     files.some(file => !file.name.endsWith('.png') && !file.name.endsWith('.jpg'))
+ *   }
+ * />
+ * ```
+ *
+ * @param {DialEmptyFileAreaProps} props - The properties for the empty file area component.
+ * @param {(files: File[]) => void} props.onChange - Callback fired when valid files are selected or dropped.
+ * @param {string} [props.emptyTextFirstLine] - Text displayed as the first line inside the drop area.
+ * @param {string} [props.emptyTextSecondLine] - Text displayed as the second line inside the drop area.
+ * @param {string} [props.emptyButtonLabel] - Label for the upload button shown below the text.
+ * @param {string} [props.acceptTypes] - Comma-separated list of accepted file MIME types (e.g., "application/pdf").
+ * @param {number} [props.maxFilesCount] - Maximum allowed number of files that can be uploaded at once.
+ * @param {boolean} [props.multiple=false] - Whether multiple file uploads are allowed.
+ * @param {string} [props.fileFormatError] - Error message shown when an invalid file format is detected.
+ * @param {string} [props.fileCountError] - Error message shown when the selected files exceed the limit.
+ * @param {(files: File[] | DataTransferItem[]) => boolean} [props.getIsFileFormatError] - Optional validation function that returns `true` if selected files have invalid formats.
+ *
+ * @returns {JSX.Element} The rendered drag-and-drop upload area with file validation feedback.
+ */
 export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
   onChange,
   emptyTextFirstLine,
@@ -37,7 +75,7 @@ export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
   emptyButtonLabel,
   acceptTypes,
   maxFilesCount,
-  isMultiple,
+  multiple,
   fileFormatError,
   fileCountError,
   getIsFileFormatError,
@@ -164,7 +202,7 @@ export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
           )}
         </label>
         <input
-          multiple={isMultiple}
+          multiple={multiple}
           id="file"
           type="file"
           ref={fileInputRef}

--- a/src/components/LoadFileArea/EmptyFileArea.tsx
+++ b/src/components/LoadFileArea/EmptyFileArea.tsx
@@ -20,7 +20,7 @@ import { DialErrorText } from '@/components/ErrorText/ErrorText';
 export interface DialEmptyFileAreaProps {
   emptyTextFirstLine?: string;
   emptyTextSecondLine?: string;
-  emptyButtonLabel: string;
+  emptyButtonLabel?: string;
   acceptTypes: string;
   maxFilesCount?: number;
   isMultiple?: boolean;
@@ -155,11 +155,13 @@ export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
           {emptyTextSecondLine && (
             <p className="mb-0.5"> {emptyTextSecondLine}</p>
           )}
-          <DialButton
-            variant={ButtonVariant.Tertiary}
-            title={emptyButtonLabel}
-            onClick={() => fileInputRef.current?.click()}
-          />
+          {emptyButtonLabel && (
+            <DialButton
+              variant={ButtonVariant.Tertiary}
+              title={emptyButtonLabel}
+              onClick={() => fileInputRef.current?.click()}
+            />
+          )}
         </label>
         <input
           multiple={isMultiple}

--- a/src/components/LoadFileArea/EmptyFileArea.tsx
+++ b/src/components/LoadFileArea/EmptyFileArea.tsx
@@ -1,0 +1,185 @@
+import classNames from 'classnames';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type FC,
+  type KeyboardEvent,
+} from 'react';
+import type { DropTargetMonitor } from 'react-dnd';
+import { useDrop } from 'react-dnd';
+import { NativeTypes } from 'react-dnd-html5-backend';
+import { DialButton } from '@/components/Button/Button';
+import { ButtonVariant } from '@/types/button';
+import { DialErrorText } from '@/components/ErrorText/ErrorText';
+
+export interface DialEmptyFileAreaProps {
+  emptyTextFirstLine?: string;
+  emptyTextSecondLine?: string;
+  emptyButtonLabel: string;
+  acceptTypes: string;
+  maxFilesCount?: number;
+  isMultiple?: boolean;
+  fileFormatError?: string;
+  fileCountError?: string;
+  getIsFileFormatError?: (fileItems: File[] | DataTransferItem[]) => boolean;
+  onChange: (files: File[]) => void;
+}
+
+export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
+  onChange,
+  emptyTextFirstLine,
+  emptyTextSecondLine,
+  emptyButtonLabel,
+  acceptTypes,
+  maxFilesCount,
+  isMultiple,
+  fileFormatError,
+  fileCountError,
+  getIsFileFormatError,
+}) => {
+  const dropRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<File[] | DataTransferItem[]>([]);
+  const [isErrorFileFormat, setIsErrorFileFormat] = useState<boolean>(false);
+
+  const onFileChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const filesList = e.target.files;
+      if (filesList && filesList.length > 0) {
+        const selectedFiles = Array.from(filesList);
+        const isFormatError = getIsFileFormatError?.(selectedFiles);
+
+        if (!isFormatError) {
+          onChange(selectedFiles);
+        } else {
+          setIsErrorFileFormat(true);
+        }
+      }
+    },
+    [getIsFileFormatError, onChange],
+  );
+
+  const getIsFileCountError = useCallback(
+    (fileItems: File[] | DataTransferItem[]) => {
+      return maxFilesCount && fileItems?.length > maxFilesCount;
+    },
+    [maxFilesCount],
+  );
+
+  const isFileValidationError = useMemo(() => {
+    return isErrorFileFormat || getIsFileCountError(files);
+  }, [isErrorFileFormat, files, getIsFileCountError]);
+
+  const clearErrorState = () => {
+    setFiles([]);
+    setIsErrorFileFormat(false);
+  };
+
+  useEffect(() => {
+    clearErrorState();
+  }, [acceptTypes]);
+
+  const [{ isOver, canDrop }, drop] = useDrop(
+    () => ({
+      accept: [NativeTypes.FILE],
+      drop(selectedFiles: { files: File[] }) {
+        const files = selectedFiles.files;
+        if (!getIsFileFormatError?.(files) && !getIsFileCountError(files)) {
+          onChange(files);
+        }
+        clearErrorState();
+      },
+      collect: (monitor: DropTargetMonitor) => {
+        return {
+          isOver: monitor.isOver(),
+          canDrop: monitor.canDrop(),
+        };
+      },
+    }),
+    [onFileChange],
+  );
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLLabelElement>) => {
+    if (event.key === 'Enter' || event.key === 'Space') {
+      event.preventDefault(); // Prevent scrolling on space press
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    event?.preventDefault();
+
+    const fileItems = Array.from(event.dataTransfer?.items ?? []);
+
+    setIsErrorFileFormat(!!getIsFileFormatError?.(fileItems));
+    setFiles(fileItems);
+  };
+
+  const handleDragLeave = (event: DragEvent) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    clearErrorState();
+  };
+
+  const containerCssClasses = classNames(
+    'border border-dashed rounded w-full cursor-pointer relative h-full hover:border-hover',
+    !canDrop && !isFileValidationError && 'border-primary',
+    canDrop && (!isOver ? 'border-hover' : 'border-accent-primary'),
+    isFileValidationError && 'border-error',
+  );
+
+  drop(dropRef);
+
+  return (
+    <>
+      <div
+        className={containerCssClasses}
+        ref={dropRef}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+      >
+        <label
+          htmlFor="file"
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+          className="flex flex-col items-center cursor-pointer h-full w-full text-secondary dial-tiny justify-center"
+        >
+          {emptyTextFirstLine && <p className="mb-1">{emptyTextFirstLine}</p>}
+          {emptyTextSecondLine && (
+            <p className="mb-0.5"> {emptyTextSecondLine}</p>
+          )}
+          <DialButton
+            variant={ButtonVariant.Tertiary}
+            title={emptyButtonLabel}
+            onClick={() => fileInputRef.current?.click()}
+          />
+        </label>
+        <input
+          multiple={isMultiple}
+          id="file"
+          type="file"
+          ref={fileInputRef}
+          hidden
+          accept={acceptTypes}
+          onChange={onFileChange}
+        />
+      </div>
+      <>
+        {isErrorFileFormat ? (
+          <DialErrorText errorText={fileFormatError} />
+        ) : (
+          getIsFileCountError(files) && (
+            <DialErrorText errorText={fileCountError} />
+          )
+        )}
+      </>
+    </>
+  );
+};

--- a/src/components/LoadFileArea/EmptyFileArea.tsx
+++ b/src/components/LoadFileArea/EmptyFileArea.tsx
@@ -191,7 +191,7 @@ export const DialEmptyFileArea: FC<DialEmptyFileAreaProps> = ({
         >
           {emptyTextFirstLine && <p className="mb-1">{emptyTextFirstLine}</p>}
           {emptyTextSecondLine && (
-            <p className="mb-0.5"> {emptyTextSecondLine}</p>
+            <p className="mb-0.5">{emptyTextSecondLine}</p>
           )}
           {emptyButtonLabel && (
             <DialButton

--- a/src/components/LoadFileArea/FilledInput.tsx
+++ b/src/components/LoadFileArea/FilledInput.tsx
@@ -1,0 +1,37 @@
+import { type FC } from 'react';
+
+import { IconExclamationCircle } from '@tabler/icons-react';
+import classNames from 'classnames';
+import { BASE_ICON_PROPS } from '@/constants/icon';
+import { DialInput, type DialInputProps } from '@/components/Input/Input';
+
+interface DialFilledInputProps extends DialInputProps {
+  errorText?: string;
+  onClick?: () => void;
+}
+
+export const DialFilledInput: FC<DialFilledInputProps> = ({
+  iconBefore,
+  cssClass,
+  errorText,
+  ...props
+}) => {
+  const isInvalid = props.invalid;
+
+  const getIcon = () => (
+    <div className="mr-2">
+      {isInvalid ? <IconExclamationCircle {...BASE_ICON_PROPS} /> : iconBefore}
+    </div>
+  );
+
+  return (
+    <DialInput
+      {...props}
+      iconBefore={getIcon()}
+      tooltipTriggerClassName="flex-1 min-w-0"
+      cssClass={classNames(isInvalid ? 'text-error' : '', cssClass)}
+      tooltipText={isInvalid && errorText ? errorText : undefined}
+      hideBorder
+    />
+  );
+};

--- a/src/components/LoadFileArea/FilledInput.tsx
+++ b/src/components/LoadFileArea/FilledInput.tsx
@@ -10,6 +10,28 @@ interface DialFilledInputProps extends DialInputProps {
   onClick?: () => void;
 }
 
+/**
+ * A styled input component that wraps `DialInput` and provides built-in
+ * error handling and icon display.
+ *
+ * - Displays an error icon (`IconExclamationCircle`) when the input is invalid.
+ * - Supports an optional `errorText` tooltip shown on hover when invalid.
+ *
+ * @example
+ * <DialFilledInput
+ *   value={username}
+ *   onChange={handleChange}
+ *   invalid={!username}
+ *   errorText="Username is required"
+ *   iconBefore={<UserIcon />}
+ * />
+ *
+ * @component
+ * @param {DialFilledInputProps} props - The properties for the filled input component.
+ * @param {string} [props.errorText] - Optional text to display in a tooltip when the input is invalid.
+ * @param {() => void} [props.onClick] - Optional click handler for the input container.
+ * @returns {JSX.Element} The rendered filled input component.
+ */
 export const DialFilledInput: FC<DialFilledInputProps> = ({
   iconBefore,
   cssClass,

--- a/src/components/LoadFileArea/FilledInput.tsx
+++ b/src/components/LoadFileArea/FilledInput.tsx
@@ -42,7 +42,11 @@ export const DialFilledInput: FC<DialFilledInputProps> = ({
 
   const getIcon = () => (
     <div className="mr-2">
-      {isInvalid ? <IconExclamationCircle {...BASE_ICON_PROPS} /> : iconBefore}
+      {isInvalid ? (
+        <IconExclamationCircle {...BASE_ICON_PROPS} className="text-error" />
+      ) : (
+        iconBefore
+      )}
     </div>
   );
 

--- a/src/components/LoadFileArea/LoadFileArea.tsx
+++ b/src/components/LoadFileArea/LoadFileArea.tsx
@@ -1,0 +1,70 @@
+import type { FC, MouseEvent, ReactNode } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import {
+  DialEmptyFileArea,
+  type DialEmptyFileAreaProps,
+} from './EmptyFileArea';
+import { DialFilledInput } from './FilledInput';
+import { DialRemoveButton } from '@/components/RemoveButton/RemoveButton';
+
+export interface DialLoadFileAreaProps extends DialEmptyFileAreaProps {
+  files?: File[];
+  dynamicIcon?: (name: string) => ReactNode;
+  iconBeforeInput?: ReactNode;
+  isInvalid?: (file: File) => boolean;
+  errorText?: string;
+  removeButtonAriaLabel?: string;
+}
+
+export const DialLoadFileArea: FC<DialLoadFileAreaProps> = (props) => {
+  const {
+    files,
+    iconBeforeInput,
+    dynamicIcon,
+    onChange: onChangeFile,
+    isInvalid,
+    errorText,
+    removeButtonAriaLabel,
+  } = props;
+
+  const removeClick = (e: MouseEvent, fileUrl: string) => {
+    e.stopPropagation();
+    onChangeFile(files?.filter((f) => f.name !== fileUrl) || []);
+  };
+
+  const removeFile = (fileUrl: string) => (
+    <DialRemoveButton
+      ariaLabel={removeButtonAriaLabel}
+      onClick={(e) => removeClick(e, fileUrl)}
+    />
+  );
+
+  const onChange = (files: File[]) => {
+    onChangeFile(files);
+  };
+
+  return !files || files.length === 0 ? (
+    <DndProvider backend={HTML5Backend}>
+      <DialEmptyFileArea {...props} onChange={onChange} />
+    </DndProvider>
+  ) : (
+    <div className="flex-1 min-h-0 border border-solid border-primary rounded">
+      {files && files.length > 0 && (
+        <div className="max-h-full overflow-y-auto">
+          {files.map((file, index) => (
+            <DialFilledInput
+              key={file.name + index}
+              elementId={file.name}
+              value={file.name}
+              iconAfter={removeFile(file.name)}
+              iconBefore={iconBeforeInput || dynamicIcon?.(file.name)}
+              invalid={isInvalid?.(file)}
+              errorText={errorText}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/LoadFileArea/LoadFileArea.tsx
+++ b/src/components/LoadFileArea/LoadFileArea.tsx
@@ -17,6 +17,41 @@ export interface DialLoadFileAreaProps extends DialEmptyFileAreaProps {
   removeButtonAriaLabel?: string;
 }
 
+/**
+ * A drag-and-drop file upload area component that allows users to upload files
+ * either by dragging them into the area or by selecting them through the file picker.
+ * Displays helpful text, button prompts, and validation errors for file format or count limits.
+ *
+ * @example
+ * ```tsx
+ * <DialEmptyFileArea
+ *   onChange={(files) => console.log(files)}
+ *   emptyTextFirstLine="Drag & drop your files here"
+ *   emptyTextSecondLine="or click the button below to upload"
+ *   emptyButtonLabel="Upload files"
+ *   acceptTypes="application/pdf, application/txt, image/svg+xml"
+ *   maxFilesCount={5}
+ *   isMultiple
+ *   fileFormatError="Unsupported file format"
+ *   fileCountError="You can upload up to 5 files only"
+ *   getIsFileFormatError={(files) => files.some(file => !file.name.endsWith('.jpg') && !file.name.endsWith('.png'))}
+ * />
+ * ```
+ *
+ * @param {DialEmptyFileAreaProps} props - The properties for the empty file area component.
+ * @param {(files: File[]) => void} props.onChange - Callback fired when valid files are selected or dropped.
+ * @param {string} [props.emptyTextFirstLine] - Optional text displayed as the first line in the empty area.
+ * @param {string} [props.emptyTextSecondLine] - Optional text displayed as the second line in the empty area.
+ * @param {string} [props.emptyButtonLabel] - Label text for the upload button.
+ * @param {string} [props.acceptTypes] - Comma-separated list of accepted file MIME types (e.g., "application/pdf").
+ * @param {number} [props.maxFilesCount] - Maximum allowed number of files to upload at once.
+ * @param {boolean} [props.multiple=false] - Whether multiple file uploads are allowed.
+ * @param {string} [props.fileFormatError] - Error message displayed when an invalid file format is detected.
+ * @param {string} [props.fileCountError] - Error message displayed when the file count exceeds the limit.
+ * @param {(files: File[]) => boolean} [props.getIsFileFormatError] - Optional validation callback that checks whether selected files have valid formats.
+ *
+ * @returns {JSX.Element} The rendered drag-and-drop file upload area with optional validation feedback.
+ */
 export const DialLoadFileArea: FC<DialLoadFileAreaProps> = (props) => {
   const {
     files,

--- a/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
@@ -12,7 +12,7 @@ describe('Dial UI Kit :: DialLoadFileAreaField', () => {
         emptyTextFirstLine="empty"
         emptyButtonLabel="Browse"
         onChange={vi.fn()}
-        isMultiple={true}
+        multiple={true}
         acceptTypes="image/png"
       />,
     );

--- a/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
@@ -59,21 +59,6 @@ describe('Dial UI Kit :: DialLoadFileAreaField', () => {
     expect(onChangeFile).toHaveBeenCalledWith([]);
   });
 
-  // test('Should call file input click when add button is clicked', () => {
-  //   render(
-  //     <DialLoadFileAreaField
-  //       fieldTitle="Files"
-  //       elementId="file-input"
-  //       files={[new File([''], 'file1.png', { type: 'image/png' })]}
-  //       onChange={vi.fn()}
-  //       acceptTypes="image/png"
-  //       emptyTextFirstLine="empty"
-  //       emptyButtonLabel="Browse"
-  //     />,
-  //   );
-  //   expect(screen.getByText('Files: 1')).toBeInTheDocument();
-  // });
-
   test('Should show tooltip with errorText by hovering on invalid file', async () => {
     const user = userEvent.setup();
 

--- a/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { DialLoadFileAreaField } from './LoadFileAreaField';
+import userEvent from '@testing-library/user-event';
 
 describe('Dial UI Kit :: DialLoadFileAreaField', () => {
   test('Should render label and LoadFileArea', () => {
@@ -58,18 +59,151 @@ describe('Dial UI Kit :: DialLoadFileAreaField', () => {
     expect(onChangeFile).toHaveBeenCalledWith([]);
   });
 
-  test('Should call file input click when add button is clicked', () => {
+  // test('Should call file input click when add button is clicked', () => {
+  //   render(
+  //     <DialLoadFileAreaField
+  //       fieldTitle="Files"
+  //       elementId="file-input"
+  //       files={[new File([''], 'file1.png', { type: 'image/png' })]}
+  //       onChange={vi.fn()}
+  //       acceptTypes="image/png"
+  //       emptyTextFirstLine="empty"
+  //       emptyButtonLabel="Browse"
+  //     />,
+  //   );
+  //   expect(screen.getByText('Files: 1')).toBeInTheDocument();
+  // });
+
+  test('Should show tooltip with errorText by hovering on invalid file', async () => {
+    const user = userEvent.setup();
+
     render(
       <DialLoadFileAreaField
         fieldTitle="Files"
         elementId="file-input"
         files={[new File([''], 'file1.png', { type: 'image/png' })]}
         onChange={vi.fn()}
-        acceptTypes="image/png"
+        acceptTypes="image/jpg"
         emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+        errorText="invalid format"
+        isInvalid={(file) => !!file}
+      />,
+    );
+
+    const input = screen.getByDisplayValue('file1.png') as HTMLInputElement;
+
+    await user.hover(input);
+
+    await waitFor(() => {
+      expect(screen.getByText('invalid format')).toBeInTheDocument();
+    });
+  });
+
+  test('Should display empty texts and button label when there is an empty area', () => {
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        files={[]}
+        onChange={vi.fn()}
+        acceptTypes="image/jpg"
+        emptyTextFirstLine="Drop file here"
+        emptyTextSecondLine="or"
         emptyButtonLabel="Browse"
       />,
     );
-    expect(screen.getByText('Files: 1')).toBeInTheDocument();
+
+    expect(screen.getByText('Drop file here')).toBeInTheDocument();
+    expect(screen.getByText('or')).toBeInTheDocument();
+    expect(screen.getByText('Browse')).toBeInTheDocument();
+  });
+
+  test('Should call onChange on files select', () => {
+    const mockOnChange = vi.fn();
+
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        files={[]}
+        onChange={mockOnChange}
+        acceptTypes="image/png"
+        emptyTextFirstLine="Drop file here"
+        emptyTextSecondLine="or"
+        emptyButtonLabel="Browse"
+      />,
+    );
+
+    const fileInput = document.querySelector('input[type="file"]');
+    expect(fileInput).toBeInTheDocument();
+
+    const file = new File(['file content'], 'example.png', {
+      type: 'image/png',
+    });
+    const mockFileList = {
+      length: 1,
+      item: (index: number) => (index === 0 ? file : null),
+      0: file,
+    };
+
+    fireEvent.change(fileInput!, { target: { files: mockFileList } });
+
+    expect(mockOnChange).toHaveBeenCalledWith([file]);
+  });
+
+  test('Should display fileFormatError when invalid format file is selected', () => {
+    const mockOnChange = vi.fn();
+
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        files={[]}
+        onChange={mockOnChange}
+        acceptTypes="image/jpg"
+        fileFormatError="Invalid format"
+      />,
+    );
+
+    const fileInput = document.querySelector('input[type="file"]');
+    expect(fileInput).toBeInTheDocument();
+
+    const file = new File(['file content'], 'example.png', {
+      type: 'image/png',
+    });
+    const mockFileList = {
+      length: 1,
+      item: (index: number) => (index === 0 ? file : null),
+      0: file,
+    };
+
+    fireEvent.change(fileInput!, { target: { files: mockFileList } });
+
+    expect(screen.getByText('Invalid format')).toBeInTheDocument();
+  });
+
+  test('Should trigger clink on input by clicking Browse button', () => {
+    const mockOnChange = vi.fn();
+
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        onChange={mockOnChange}
+        acceptTypes="image/jpg"
+        emptyButtonLabel="Browse"
+      />,
+    );
+
+    const fileInput = document.querySelector('input[type="file"]');
+    expect(fileInput).toBeInTheDocument();
+
+    const clickSpy = vi.spyOn(fileInput as HTMLInputElement, 'click');
+
+    const button = screen.getByText('Browse');
+    fireEvent.click(button);
+
+    expect(clickSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { DialLoadFileAreaField } from './LoadFileAreaField';
+
+describe('Dial UI Kit :: DialLoadFileAreaField', () => {
+  test('Should render label and LoadFileArea', () => {
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+        onChange={vi.fn()}
+        isMultiple={true}
+        acceptTypes="image/png"
+      />,
+    );
+    expect(screen.getByText('Files: 0')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Browse' })).toBeInTheDocument();
+  });
+
+  test('Should render delete and add buttons when files exist', () => {
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+        files={[new File([''], 'file1.png', { type: 'image/png' })]}
+        onChange={vi.fn()}
+        acceptTypes="image/png"
+        deleteAllButtonLabel="Delete All"
+        addButtonLabel="Add"
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Delete All' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+  });
+
+  test('Should call onChangeFile([]) when delete-all button is clicked', () => {
+    const onChangeFile = vi.fn();
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        maxFilesCount={3}
+        files={[new File([''], 'file1.png', { type: 'image/png' })]}
+        onChange={onChangeFile}
+        acceptTypes="image/png"
+        emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+        deleteAllButtonLabel="Delete all"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete all' }));
+    expect(onChangeFile).toHaveBeenCalledWith([]);
+  });
+
+  test('Should call file input click when add button is clicked', () => {
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        files={[new File([''], 'file1.png', { type: 'image/png' })]}
+        onChange={vi.fn()}
+        acceptTypes="image/png"
+        emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+      />,
+    );
+    expect(screen.getByText('Files: 1')).toBeInTheDocument();
+  });
+});

--- a/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import {
+  DialLoadFileAreaField,
+  type DialLoadFileAreaFieldProps,
+} from './LoadFileAreaField';
+import {
+  IconFile,
+  IconFileTypePdf,
+  IconFileText,
+  IconFileTypeSvg,
+} from '@tabler/icons-react';
+import { BASE_ICON_PROPS } from '@/constants/icon';
+
+const meta: Meta<typeof DialLoadFileAreaField> = {
+  title: 'Form/LoadFileAreaField',
+  component: DialLoadFileAreaField,
+  tags: ['upload', 'file', 'drag and drop', 'form', 'input'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '`LoadFileAreaField` combines a field label, upload buttons (add/remove), and the `DialLoadFileArea` dropzone. It handles file validation, multiple uploads, and deletion logic.',
+      },
+    },
+  },
+  argTypes: {
+    fieldTitle: {
+      control: 'text',
+      description: 'Label for the file upload field',
+    },
+    maxFilesCount: {
+      control: 'number',
+      description: 'Maximum allowed file count',
+    },
+    acceptTypes: {
+      control: 'text',
+      description: 'Accepted MIME types (e.g. image/*, .pdf)',
+    },
+    isMultiple: {
+      control: 'boolean',
+      description: 'Allows multiple file selection',
+    },
+    deleteAllButtonLabel: {
+      control: 'text',
+      description: 'Label for delete-all button',
+    },
+    addButtonLabel: { control: 'text', description: 'Label for add button' },
+    fileFormatError: {
+      control: 'text',
+      description: 'Displayed when an unsupported file is uploaded',
+    },
+    fileCountError: {
+      control: 'text',
+      description: 'Displayed when max file count exceeded',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const InteractiveLoadFileAreaField = (args: DialLoadFileAreaFieldProps) => {
+  const [files, setFiles] = useState<File[]>(args.files || []);
+
+  const getIcon = (fileName: string) => {
+    if (fileName.endsWith('.pdf'))
+      return <IconFileTypePdf {...BASE_ICON_PROPS} />;
+    if (fileName.endsWith('.txt')) return <IconFileText {...BASE_ICON_PROPS} />;
+    if (fileName.endsWith('.svg'))
+      return <IconFileTypeSvg {...BASE_ICON_PROPS} />;
+    return <IconFile {...BASE_ICON_PROPS} />;
+  };
+
+  return (
+    <div className="h-[250px] w-[480px]">
+      <DialLoadFileAreaField
+        {...args}
+        files={files}
+        onChange={setFiles}
+        dynamicIcon={(file) => getIcon(file)}
+      />
+    </div>
+  );
+};
+
+export const Empty: Story = {
+  render: (args) => <InteractiveLoadFileAreaField {...args} />,
+  args: {
+    fieldTitle: 'Documents',
+    elementId: 'upload-docs',
+    acceptTypes: 'application/pdf, application/txt, image/svg+xml',
+    isMultiple: true,
+    maxFilesCount: 5,
+    deleteAllButtonLabel: 'Delete all',
+    addButtonLabel: 'Add files',
+    fileFormatError: 'Invalid file format',
+    fileCountError: 'Too many files selected',
+    emptyTextFirstLine: 'Drop file here',
+    emptyTextSecondLine: 'or',
+    emptyButtonLabel: 'Browse',
+  },
+};
+
+export const WithFiles: Story = {
+  render: (args) => {
+    const mockFiles = [
+      new File(['text'], 'report.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'notes.txt', { type: 'text/plain' }),
+    ];
+    return <InteractiveLoadFileAreaField {...args} files={mockFiles} />;
+  },
+  args: {
+    ...Empty.args,
+  },
+};
+
+export const FileCountExceeded: Story = {
+  render: (args) => {
+    const mockFiles = [
+      new File(['data'], 'file1.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'file2.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'file3.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'file4.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'file5.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'file6.pdf', { type: 'application/pdf' }),
+    ];
+    return <InteractiveLoadFileAreaField {...args} files={mockFiles} />;
+  },
+  args: {
+    ...Empty.args,
+    maxFilesCount: 5,
+    fileCountError: 'Maximum of 5 files allowed',
+  },
+};
+
+export const InvalidFormat: Story = {
+  render: (args) => {
+    const mockFiles = [
+      new File(['fake'], 'malware.exe', { type: 'application/x-msdownload' }),
+    ];
+    return <InteractiveLoadFileAreaField {...args} files={mockFiles} />;
+  },
+  args: {
+    ...Empty.args,
+    fileFormatError: 'Unsupported file type',
+    isInvalid: (file: File) => file.name.endsWith('.exe'),
+  },
+};
+
+export const WithDynamicIcons: Story = {
+  render: (args) => {
+    const mockFiles = [
+      new File(['data'], 'manual.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'summary.txt', { type: 'text/plain' }),
+      new File(['data'], 'generic.file', { type: 'application/octet-stream' }),
+    ];
+
+    return <InteractiveLoadFileAreaField {...args} files={mockFiles} />;
+  },
+  args: {
+    ...Empty.args,
+  },
+};

--- a/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta<typeof DialLoadFileAreaField> = {
       control: 'text',
       description: 'Accepted MIME types (e.g. image/*, .pdf)',
     },
-    isMultiple: {
+    multiple: {
       control: 'boolean',
       description: 'Allows multiple file selection',
     },
@@ -91,7 +91,7 @@ export const Empty: Story = {
     fieldTitle: 'Documents',
     elementId: 'upload-docs',
     acceptTypes: 'application/pdf, application/txt, image/svg+xml',
-    isMultiple: true,
+    multiple: true,
     maxFilesCount: 5,
     deleteAllButtonLabel: 'Delete all',
     addButtonLabel: 'Add files',

--- a/src/components/LoadFileArea/LoadFileAreaField.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.tsx
@@ -1,0 +1,119 @@
+import { type ChangeEvent, type FC, useCallback, useRef } from 'react';
+import { IconPlus, IconTrashX } from '@tabler/icons-react';
+import { DialLoadFileArea, type DialLoadFileAreaProps } from './LoadFileArea';
+import { BASE_ICON_PROPS } from '@/constants/icon';
+import { DialFieldLabel } from '@/components/Field/Field';
+import { DialButton } from '@/components/Button/Button';
+import { ButtonVariant } from '@/types/button';
+
+export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
+  fieldTitle: string;
+  elementId: string;
+  deleteAllButtonLabel?: string;
+  addButtonLabel?: string;
+}
+
+export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
+  onChange,
+  fieldTitle,
+  elementId,
+  files,
+  maxFilesCount,
+  fileFormatError,
+  fileCountError,
+  isMultiple = true,
+  acceptTypes,
+  deleteAllButtonLabel,
+  addButtonLabel,
+  ...props
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onAddFiles = () => fileInputRef.current?.click();
+
+  const onRemoveFiles = () => {
+    onChange([]);
+  };
+
+  const getIsFileFormatError = useCallback(
+    (fileItems: File[] | DataTransferItem[]) => {
+      return fileItems?.some(
+        (fileItem) =>
+          fileItem.type === '' ||
+          !(
+            acceptTypes === '/' ||
+            acceptTypes?.toLowerCase()?.includes(fileItem?.type?.toLowerCase())
+          ),
+      );
+    },
+    [acceptTypes],
+  );
+
+  const onFileChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const filesList = e.target.files;
+      if (filesList && filesList.length > 0) {
+        const selectedFiles = Array.from(filesList);
+        const isFileFormatError = getIsFileFormatError(selectedFiles);
+
+        if (!isFileFormatError) {
+          onChange([...(files || []), ...selectedFiles]);
+        }
+      }
+    },
+    [onChange, files, getIsFileFormatError],
+  );
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex justify-between items-center pb-1 min-h-[42px]">
+        <DialFieldLabel
+          fieldTitle={`${fieldTitle}: ${isMultiple ? files?.length || 0 : ''}`}
+          htmlFor={elementId}
+        />
+        {isMultiple && !!files?.length && (
+          <div className="flex flex-row items-center gap-x-2">
+            <DialButton
+              variant={ButtonVariant.Tertiary}
+              cssClass="!text-error"
+              iconBefore={<IconTrashX {...BASE_ICON_PROPS} />}
+              title={deleteAllButtonLabel}
+              onClick={onRemoveFiles}
+            />
+
+            {(maxFilesCount ? maxFilesCount > files?.length : true) && (
+              <DialButton
+                variant={ButtonVariant.Tertiary}
+                iconBefore={<IconPlus {...BASE_ICON_PROPS} />}
+                title={addButtonLabel}
+                onClick={onAddFiles}
+              />
+            )}
+          </div>
+        )}
+      </div>
+      {files && files.length > 0 && (
+        <input
+          id="file"
+          type="file"
+          multiple={isMultiple}
+          ref={fileInputRef}
+          hidden
+          accept={acceptTypes}
+          onChange={onFileChange}
+        />
+      )}
+      <DialLoadFileArea
+        files={files}
+        onChange={onChange}
+        acceptTypes={acceptTypes}
+        maxFilesCount={maxFilesCount}
+        isMultiple={isMultiple}
+        fileFormatError={fileFormatError}
+        fileCountError={fileCountError}
+        getIsFileFormatError={getIsFileFormatError}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/components/LoadFileArea/LoadFileAreaField.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.tsx
@@ -13,6 +13,48 @@ export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
   addButtonLabel?: string;
 }
 
+/**
+ * A composite file upload field that combines a label, file list management,
+ * and a drag-and-drop upload area. Allows users to add, remove, and validate files
+ * with customizable restrictions on file types and count.
+ *
+ * The component displays a header showing the field title and file count,
+ * along with "Add" and "Delete All" buttons (when multiple uploads are enabled).
+ * It integrates with `DialLoadFileArea` for drag-and-drop functionality and
+ * provides file validation for both format and maximum file count.
+ *
+ * @example
+ * ```tsx
+ * <DialLoadFileAreaField
+ *   fieldTitle="Attachments"
+ *   elementId="attachments"
+ *   files={uploadedFiles}
+ *   onChange={setUploadedFiles}
+ *   maxFilesCount={5}
+ *   acceptTypes="image/png,image/jpeg"
+ *   fileFormatError="Only PNG and JPEG images are allowed"
+ *   fileCountError="You can upload up to 5 files"
+ *   deleteAllButtonLabel="Remove all"
+ *   addButtonLabel="Add more"
+ * />
+ * ```
+ *
+ * @param {DialLoadFileAreaFieldProps} props - The properties for the file area field component.
+ * @param {(files: File[]) => void} props.onChange - Callback fired when files are added or removed.
+ * @param {string} props.fieldTitle - The label displayed above the file upload area.
+ * @param {string} props.elementId - The unique `id` used for accessibility and input association.
+ * @param {File[]} [props.files] - The list of currently selected or uploaded files.
+ * @param {number} [props.maxFilesCount] - The maximum number of files allowed.
+ * @param {string} [props.fileFormatError] - Error message shown for invalid file formats.
+ * @param {string} [props.fileCountError] - Error message shown when exceeding the file count limit.
+ * @param {boolean} [props.multiple=true] - Whether multiple file uploads are allowed.
+ * @param {string} [props.acceptTypes] - Comma-separated list of allowed MIME types or file extensions.
+ * @param {string} [props.deleteAllButtonLabel] - Label for the "Delete All" button shown when files exist.
+ * @param {string} [props.addButtonLabel] - Label for the "Add" button used to select additional files.
+ * @param {object} [props.props] - Additional props passed to the underlying `DialLoadFileArea`.
+ *
+ * @returns {JSX.Element} A file upload field with label, action buttons, and a drag-and-drop area.
+ */
 export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
   onChange,
   fieldTitle,
@@ -21,7 +63,7 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
   maxFilesCount,
   fileFormatError,
   fileCountError,
-  isMultiple = true,
+  multiple = true,
   acceptTypes,
   deleteAllButtonLabel,
   addButtonLabel,
@@ -68,10 +110,10 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
     <div className="h-full flex flex-col">
       <div className="flex justify-between items-center pb-1 min-h-[42px]">
         <DialFieldLabel
-          fieldTitle={`${fieldTitle}: ${isMultiple ? files?.length || 0 : ''}`}
+          fieldTitle={`${fieldTitle}: ${multiple ? files?.length || 0 : ''}`}
           htmlFor={elementId}
         />
-        {isMultiple && !!files?.length && (
+        {multiple && !!files?.length && (
           <div className="flex flex-row items-center gap-x-2">
             <DialButton
               variant={ButtonVariant.Tertiary}
@@ -96,7 +138,7 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
         <input
           id="file"
           type="file"
-          multiple={isMultiple}
+          multiple={multiple}
           ref={fileInputRef}
           hidden
           accept={acceptTypes}
@@ -108,7 +150,7 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
         onChange={onChange}
         acceptTypes={acceptTypes}
         maxFilesCount={maxFilesCount}
-        isMultiple={isMultiple}
+        multiple={multiple}
         fileFormatError={fileFormatError}
         fileCountError={fileCountError}
         getIsFileFormatError={getIsFileFormatError}

--- a/src/components/RemoveButton/RemoveButton.spec.tsx
+++ b/src/components/RemoveButton/RemoveButton.spec.tsx
@@ -1,0 +1,57 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DialRemoveButton } from './RemoveButton';
+import { BASE_ICON_PROPS } from '@/constants/icon';
+
+describe('Dial UI Kit :: DialRemoveButton', () => {
+  it('renders a button element', () => {
+    const { getByRole } = render(<DialRemoveButton onClick={vi.fn()} />);
+    const button = getByRole('button');
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it('applies aria-label if provided', () => {
+    const { getByLabelText } = render(
+      <DialRemoveButton ariaLabel="Delete item" onClick={vi.fn()} />,
+    );
+
+    expect(getByLabelText('Delete item')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(<DialRemoveButton onClick={onClick} />);
+
+    fireEvent.click(getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies custom cssClass when provided', () => {
+    const { getByRole } = render(
+      <DialRemoveButton cssClass="custom-remove" onClick={vi.fn()} />,
+    );
+
+    expect(getByRole('button').className).toMatch(/custom-remove/);
+  });
+
+  it('renders IconTrashX as the leading icon', () => {
+    const { container } = render(<DialRemoveButton onClick={vi.fn()} />);
+    const icon = container.querySelector('svg');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon?.getAttribute('width')).toBe(String(BASE_ICON_PROPS.size));
+    expect(icon?.getAttribute('height')).toBe(String(BASE_ICON_PROPS.size));
+  });
+
+  it('applies custom iconClass to the IconTrashX element', () => {
+    const { container } = render(
+      <DialRemoveButton iconClass="text-error" onClick={vi.fn()} />,
+    );
+
+    const icon = container.querySelector('svg');
+
+    expect(icon?.classList.contains('text-error')).toBe(true);
+  });
+});

--- a/src/components/RemoveButton/RemoveButton.stories.tsx
+++ b/src/components/RemoveButton/RemoveButton.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialRemoveButton, type DialRemoveButtonProps } from './RemoveButton';
+
+const meta: Meta<typeof DialRemoveButton> = {
+  title: 'Utility/RemoveButton',
+  component: DialRemoveButton,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A specialized delete button using a predefined trash icon (`IconTrashX`). It`s intended for destructive or removal actions and wraps the `DialButton` component.',
+      },
+    },
+  },
+  argTypes: {
+    ariaLabel: {
+      control: { type: 'text' },
+      description: 'Accessibility label for the button',
+    },
+    cssClass: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes applied to the button',
+    },
+    iconClass: {
+      control: { type: 'text' },
+      description: 'Optional CSS class applied to the trash icon',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Callback fired when the button is clicked',
+    },
+  },
+} satisfies Meta<DialRemoveButtonProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    ariaLabel: 'Remove item',
+    onClick: () => alert('Item removed!'),
+  },
+};
+
+export const CustomIconClass: Story = {
+  args: {
+    ariaLabel: 'Delete entry',
+    iconClass: 'text-error',
+    onClick: () => alert('Deleted!'),
+  },
+};
+
+export const WithCustomButtonClass: Story = {
+  args: {
+    ariaLabel: 'Remove',
+    cssClass: 'bg-layer-3 hover:bg-error-alpha text-primary',
+    onClick: () => alert('Removed!'),
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="p-8 flex flex-col gap-y-6">
+      <div className="flex flex-row items-center gap-x-4">
+        <div className="text-primary min-w-[160px]">Default</div>
+        <DialRemoveButton
+          ariaLabel="Remove default"
+          onClick={() => alert('Removed!')}
+        />
+      </div>
+
+      <div className="flex flex-row items-center gap-x-4">
+        <div className="text-primary min-w-[160px]">Error Icon</div>
+        <DialRemoveButton
+          ariaLabel="Remove error"
+          iconClass="text-error"
+          onClick={() => alert('Removed!')}
+        />
+      </div>
+
+      <div className="flex flex-row items-center gap-x-4">
+        <div className="text-primary min-w-[160px]">Custom Button Style</div>
+        <DialRemoveButton
+          ariaLabel="Remove custom"
+          cssClass="bg-error text-white hover:bg-error-alpha"
+          onClick={() => alert('Removed!')}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/RemoveButton/RemoveButton.tsx
+++ b/src/components/RemoveButton/RemoveButton.tsx
@@ -3,7 +3,7 @@ import { IconTrashX } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import { DialButton } from '@/components/Button/Button';
 
-interface DialRemoveButtonProps {
+export interface DialRemoveButtonProps {
   iconClass?: string;
   cssClass?: string;
   ariaLabel?: string;

--- a/src/components/RemoveButton/RemoveButton.tsx
+++ b/src/components/RemoveButton/RemoveButton.tsx
@@ -10,6 +10,22 @@ interface DialRemoveButtonProps {
   onClick: (e: MouseEvent) => void;
 }
 
+/**
+ * A specialized button component for removal or delete actions.
+ *
+ * Renders a `DialButton` with a predefined trash icon (`IconTrashX`) as the leading icon.
+ * Additional props are passed directly to the underlying `DialButton`.
+ * @example
+ * <DialRemoveButton
+ *   label="Delete item"
+ *   onClick={handleDelete}
+ *   iconClass="text-error"
+ * />
+ * @component
+ * @param {DialRemoveButtonProps} props - The properties for the remove button component.
+ * @param {string} [props.iconClass] - Optional CSS class applied to the trash icon for styling or sizing.
+ * @returns {JSX.Element} The rendered remove button component.
+ */
 export const DialRemoveButton: FC<DialRemoveButtonProps> = ({
   iconClass,
   ...props

--- a/src/components/RemoveButton/RemoveButton.tsx
+++ b/src/components/RemoveButton/RemoveButton.tsx
@@ -1,0 +1,25 @@
+import { type FC, type MouseEvent } from 'react';
+import { DialButton } from '@epam/ai-dial-ui-kit';
+import { IconTrashX } from '@tabler/icons-react';
+import { BASE_ICON_PROPS } from '@/constants/icon';
+
+interface DialRemoveButtonProps {
+  iconClass?: string;
+  cssClass?: string;
+  ariaLabel?: string;
+  onClick: (e: MouseEvent) => void;
+}
+
+export const DialRemoveButton: FC<DialRemoveButtonProps> = ({
+  iconClass,
+  ...props
+}) => {
+  return (
+    <DialButton
+      iconBefore={
+        <IconTrashX {...BASE_ICON_PROPS} className={iconClass || ''} />
+      }
+      {...props}
+    />
+  );
+};

--- a/src/components/RemoveButton/RemoveButton.tsx
+++ b/src/components/RemoveButton/RemoveButton.tsx
@@ -1,7 +1,7 @@
 import { type FC, type MouseEvent } from 'react';
-import { DialButton } from '@epam/ai-dial-ui-kit';
 import { IconTrashX } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
+import { DialButton } from '@/components/Button/Button';
 
 interface DialRemoveButtonProps {
   iconClass?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { DialBreadcrumbItem } from './components/Breadcrumb/BreadcrumbItem';
 // Buttons
 export { DialButton } from './components/Button/Button';
 export { DialCloseButton } from './components/CloseButton/CloseButton';
+export { DialRemoveButton } from './components/RemoveButton/RemoveButton';
 
 // Textareas
 export { DialTextarea } from './components/Textarea/Textarea';
@@ -59,6 +60,7 @@ export { DialAutocompleteInputValue } from './components/AutocompleteInput/Autoc
 export { DialTagInput } from './components/TagInput/TagInput';
 export { DialSelect } from './components/Select/Select';
 export { DialSelectField } from './components/SelectField/SelectField';
+export { DialLoadFileAreaField } from './components/LoadFileArea/LoadFileAreaField';
 
 // Dropdowns
 export { DialDropdown } from './components/Dropdown/Dropdown';


### PR DESCRIPTION
**Description:**

Add LoadedFileAreaField with its components, tests and stories 

Issues:

- Issue #37 

**UI changes**

storybook:
<img width="772" height="372" alt="image" src="https://github.com/user-attachments/assets/47b31d52-124f-410b-8bd9-16134b5f8020" />
<img width="776" height="383" alt="image" src="https://github.com/user-attachments/assets/4ebad320-64f1-4845-ad6e-d6e917362804" />
<img width="787" height="386" alt="image" src="https://github.com/user-attachments/assets/087c6489-cb51-42e1-9e07-71081b927630" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added