### PR TITLE
feat: add anchorToMouse and matchReferenceWidth props to DialDropdown component

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -527,4 +527,63 @@ describe('Dial UI Kit :: Dropdown', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  test('anchorToMouse + ContextMenu opens on right click', () => {
+    render(
+      <DialDropdown
+        anchorToMouse
+        trigger={[DropdownTrigger.ContextMenu]}
+        menu={{ items }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('anchorToMouse + Click opens on left click', () => {
+    render(
+      <DialDropdown
+        anchorToMouse
+        trigger={[DropdownTrigger.Click]}
+        menu={{ items }}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('calls onOpenChange on open and close', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <DialDropdown onOpenChange={onOpenChange} menu={{ items }}>
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test('matchReferenceWidth=false -> menu has w-max and no inline min-width', () => {
+    render(
+      <DialDropdown matchReferenceWidth={false} menu={{ items }}>
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    openByClick();
+    const menuEl = screen.getByRole('menu');
+    expect(menuEl).toHaveClass('w-max');
+    expect(menuEl.getAttribute('style') || '').not.toMatch(/min-width:/i);
+    expect(menuEl.style.minWidth).toBe('');
+  });
 });

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -97,6 +97,8 @@ const meta = {
     placement: { control: { type: 'select' }, options: PLACEMENTS },
     disabled: { control: { type: 'boolean' } },
     closable: { control: { type: 'boolean' } },
+    anchorToMouse: { control: { type: 'boolean' } },
+    matchReferenceWidth: { control: { type: 'boolean' } },
     cssClass: { control: { type: 'text' } },
     listClassName: { control: { type: 'text' } },
     open: { control: false },
@@ -111,6 +113,8 @@ const meta = {
     trigger: [DropdownTrigger.Click],
     disabled: false,
     closable: false,
+    anchorToMouse: false,
+    matchReferenceWidth: true,
     children: <TriggerBtn />,
     menu: { items },
   },
@@ -133,6 +137,7 @@ export const SpecWidthHugContent: Story = {
   name: 'Width hugs content (spec-like)',
   args: {
     placement: 'bottom-start',
+    matchReferenceWidth: false,
     menu: { items: specItems },
   },
 };
@@ -328,4 +333,69 @@ const FooterActionsExample = (args: DialDropdownProps) => {
 
 export const WithFooterActionsControlled: Story = {
   render: (args) => <FooterActionsExample {...args} />,
+};
+
+export const ContextMenuAtCursor: Story = {
+  name: 'Context menu anchored to cursor',
+  args: {
+    trigger: [DropdownTrigger.ContextMenu],
+    anchorToMouse: true,
+    matchReferenceWidth: false,
+    menu: { items: specItems },
+  },
+  render: (args) => (
+    <DialDropdown {...args}>
+      <div className="h-48 w-[520px] p-4 text-primary border border-secondary flex items-center justify-center">
+        Right-click anywhere in this area
+      </div>
+    </DialDropdown>
+  ),
+};
+
+export const ClickNearCursor: Story = {
+  name: 'Click anchored to cursor',
+  args: {
+    trigger: [DropdownTrigger.Click],
+    anchorToMouse: true,
+    matchReferenceWidth: false,
+    menu: { items: specItems },
+  },
+  render: (args) => (
+    <DialDropdown {...args}>
+      <DialButton
+        variant={ButtonVariant.Primary}
+        title="Click me (opens near cursor)"
+      />
+    </DialDropdown>
+  ),
+};
+
+export const CompareWidthModes: Story = {
+  name: 'Compare: matchReferenceWidth=true vs false',
+  args: {},
+  render: (args) => (
+    <div className="flex gap-6">
+      <DialDropdown {...args} matchReferenceWidth>
+        <DialButton
+          variant={ButtonVariant.Secondary}
+          title="Match trigger width"
+        />
+      </DialDropdown>
+      <DialDropdown
+        {...args}
+        matchReferenceWidth={false}
+        renderOverlay={() => (
+          <div className="p-3 whitespace-nowrap">
+            Very long, unwrapped overlay content that should define its own
+            width
+          </div>
+        )}
+      >
+        <DialButton
+          variant={ButtonVariant.Secondary}
+          title="Hug content width"
+        />
+      </DialDropdown>
+    </div>
+  ),
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -113,8 +113,8 @@ export interface DialDropdownProps {
  * @param [listClassName] - Additional CSS classes applied to the floating overlay
  * @param [outsidePressIgnoreRef] - Ref to an element that should not trigger outside press behavior
  * @param [outsideClosable=true] - Whether clicks outside the overlay should close it
- * @param [anchorToMouse=false] - Whether to anchor the dropdown to the mouse position (not implemented)
- * @param [matchReferenceWidth=false] - Whether to match the reference element's width (not implemented)
+ * @param [anchorToMouse=false] - Whether to anchor the dropdown to the mouse position
+ * @param [matchReferenceWidth=false] - Whether to match the reference element's width
  */
 export const DialDropdown: FC<DialDropdownProps> = ({
   children,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,6 +20,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useState,
   type FC,
   type MouseEvent,
@@ -67,6 +68,8 @@ export interface DialDropdownProps {
   listClassName?: string;
   outsidePressIgnoreRef?: RefObject<HTMLElement | null>;
   outsideClosable?: boolean;
+  anchorToMouse?: boolean;
+  matchReferenceWidth?: boolean;
 }
 
 /**
@@ -110,6 +113,8 @@ export interface DialDropdownProps {
  * @param [listClassName] - Additional CSS classes applied to the floating overlay
  * @param [outsidePressIgnoreRef] - Ref to an element that should not trigger outside press behavior
  * @param [outsideClosable=true] - Whether clicks outside the overlay should close it
+ * @param [anchorToMouse=false] - Whether to anchor the dropdown to the mouse position (not implemented)
+ * @param [matchReferenceWidth=false] - Whether to match the reference element's width (not implemented)
  */
 export const DialDropdown: FC<DialDropdownProps> = ({
   children,
@@ -128,6 +133,8 @@ export const DialDropdown: FC<DialDropdownProps> = ({
   outsidePressIgnoreRef,
   outsideClosable = true,
   allowedPlacements,
+  anchorToMouse = false,
+  matchReferenceWidth = true,
 }) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
   const isControlled = open !== undefined;
@@ -142,6 +149,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
   );
 
   const listId = useId();
+  const useAuto = placement === undefined;
 
   const getRefWidth = (el: ReferenceElement | null): number => {
     if (!el) return 0;
@@ -151,8 +159,6 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     ).getBoundingClientRect?.();
     return rect?.width ?? 0;
   };
-
-  const useAuto = placement === undefined;
 
   const { refs, floatingStyles, context } = useFloating({
     placement,
@@ -177,15 +183,20 @@ export const DialDropdown: FC<DialDropdownProps> = ({
           const refWidth = getRefWidth(elements.reference);
 
           floating.style.setProperty(
-            '--reference-width',
-            `${Math.round(refWidth)}px`,
-          );
-          floating.style.setProperty(
             '--fui-available-height',
             `${Math.floor(availableHeight)}px`,
           );
+          floating.style.setProperty(
+            '--reference-width',
+            matchReferenceWidth ? `${Math.round(refWidth)}px` : '0px',
+          );
 
-          floating.style.minWidth = `${Math.round(refWidth)}px`;
+          if (matchReferenceWidth) {
+            floating.style.minWidth = `${Math.round(refWidth)}px`;
+          } else {
+            floating.style.removeProperty('min-width');
+          }
+
           floating.style.maxWidth = `${Math.floor(availableWidth)}px`;
           floating.style.maxHeight = `${Math.floor(availableHeight)}px`;
         },
@@ -229,89 +240,129 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     role,
   ]);
 
-  const onContextMenu = (e: MouseEvent) => {
-    if (!trigger.includes(DropdownTrigger.ContextMenu) || disabled) return;
-    e.preventDefault();
-    setOpen(true);
-  };
+  const setPositionFromPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      refs.setPositionReference({
+        getBoundingClientRect: () =>
+          ({
+            width: 0,
+            height: 0,
+            x: clientX,
+            y: clientY,
+            top: clientY,
+            left: clientX,
+            right: clientX,
+            bottom: clientY,
+          }) as DOMRect,
+      });
+    },
+    [refs],
+  );
+
+  const onContextMenu = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (!trigger.includes(DropdownTrigger.ContextMenu) || disabled) return;
+      e.preventDefault();
+      if (anchorToMouse) {
+        setPositionFromPointer(e.clientX, e.clientY);
+      }
+      setOpen(true);
+    },
+    [anchorToMouse, disabled, setOpen, setPositionFromPointer, trigger],
+  );
+
+  const onPointerDown = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (!anchorToMouse || disabled) return;
+      setPositionFromPointer(e.clientX, e.clientY);
+    },
+    [anchorToMouse, disabled, setPositionFromPointer],
+  );
 
   useEffect(() => {
     if (disabled && isOpen) setOpen(false);
   }, [disabled, isOpen, setOpen]);
 
-  const handleItemClick = (item: DropdownItem) => (e: MouseEvent) => {
-    if (item.disabled) return;
-    item.onClick?.({ key: item.key, domEvent: e });
-    menu?.onClick?.({ key: item.key, domEvent: e });
-    setOpen(false);
-  };
+  const handleItemClick = useCallback(
+    (item: DropdownItem) => (e: MouseEvent<HTMLButtonElement>) => {
+      if (item.disabled) return;
+      item.onClick?.({ key: item.key, domEvent: e });
+      menu?.onClick?.({ key: item.key, domEvent: e });
+      setOpen(false);
+    },
+    [menu, setOpen],
+  );
 
-  const overlayContent: ReactNode = renderOverlay
-    ? renderOverlay()
-    : menu && (
-        <>
-          {menu.header && (
-            <>
-              {typeof menu.header === 'function' ? menu.header() : menu.header}
-            </>
-          )}
+  const overlayContent: ReactNode = useMemo(() => {
+    if (renderOverlay) return renderOverlay();
+    if (!menu) return null;
 
-          <div role="none" className="py-1">
-            {menu.items.map((it) => {
-              if (it.type === DropdownItemType.Divider) {
-                return (
-                  <div
-                    key={it.key}
-                    role="separator"
-                    className={dropdownDividerClasses}
-                  />
-                );
-              }
+    return (
+      <>
+        {menu.header && (
+          <>{typeof menu.header === 'function' ? menu.header() : menu.header}</>
+        )}
+
+        <div role="none" className="py-1">
+          {menu.items.map((it) => {
+            if (it.type === DropdownItemType.Divider) {
               return (
-                <button
+                <div
                   key={it.key}
-                  role="menuitem"
-                  type="button"
-                  aria-disabled={!!it.disabled}
-                  className={classNames(
-                    dropdownItemBaseClasses,
-                    it.disabled && dropdownItemDisabledClasses,
-                    it.danger && dropdownItemDangerClasses,
-                  )}
-                  disabled={it.disabled}
-                  onClick={handleItemClick(it)}
-                >
-                  {it.icon && (
-                    <span
-                      className={classNames(
-                        it.danger && 'text-error',
-                        it.disabled && 'text-secondary',
-                      )}
-                    >
-                      <DialIcon icon={it.icon} />
-                    </span>
-                  )}
+                  role="separator"
+                  className={dropdownDividerClasses}
+                />
+              );
+            }
+            return (
+              <button
+                key={it.key}
+                role="menuitem"
+                type="button"
+                aria-disabled={!!it.disabled}
+                className={classNames(
+                  dropdownItemBaseClasses,
+                  it.disabled && dropdownItemDisabledClasses,
+                  it.danger && dropdownItemDangerClasses,
+                )}
+                disabled={it.disabled}
+                onClick={handleItemClick(it)}
+              >
+                {it.icon && (
                   <span
                     className={classNames(
-                      'flex-1 truncate text-left',
                       it.danger && 'text-error',
                       it.disabled && 'text-secondary',
                     )}
                   >
-                    {it.label}
+                    <DialIcon icon={it.icon} />
                   </span>
-                </button>
-              );
-            })}
-          </div>
+                )}
+                <span
+                  className={classNames(
+                    'flex-1 truncate text-left',
+                    it.danger && 'text-error',
+                    it.disabled && 'text-secondary',
+                  )}
+                >
+                  {it.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
 
-          {menu.footer && (
-            <>
-              {typeof menu.footer === 'function' ? menu.footer() : menu.footer}
-            </>
-          )}
-        </>
-      );
+        {menu.footer && (
+          <>{typeof menu.footer === 'function' ? menu.footer() : menu.footer}</>
+        )}
+      </>
+    );
+  }, [handleItemClick, menu, renderOverlay]);
+
+  const referenceProps = getReferenceProps({
+    onContextMenu,
+    onMouseDown: onPointerDown,
+  });
 
   return (
     <>
@@ -325,8 +376,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-controls={listId}
-        onContextMenu={onContextMenu}
-        {...getReferenceProps()}
+        {...referenceProps}
       >
         {children}
       </span>
@@ -343,7 +393,11 @@ export const DialDropdown: FC<DialDropdownProps> = ({
               id={listId}
               ref={refs.setFloating}
               style={floatingStyles}
-              className={classNames(dropdownListBaseClasses, listClassName)}
+              className={classNames(
+                dropdownListBaseClasses,
+                !matchReferenceWidth && 'w-max',
+                listClassName,
+              )}
               {...getFloatingProps()}
             >
               {closable && (
@@ -357,7 +411,6 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                   />
                 </div>
               )}
-
               {overlayContent}
             </div>
           </FloatingFocusManager>


### PR DESCRIPTION
… 

**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="567" height="365" alt="image" src="https://github.com/user-attachments/assets/19f2d716-9ce0-41cc-b8ca-834f39da20bc" />
<img width="660" height="238" alt="image" src="https://github.com/user-attachments/assets/5c8b57fc-fabc-4b93-94da-f30f9abe9444" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added