### PR TITLE
feat: Add more styles for radiobutton group

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -1,8 +1,8 @@
-import classNames from 'classnames';
-import type { FC, ReactNode } from 'react';
-import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { DialIcon } from '@/components/Icon/Icon';
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
+import { mergeClasses } from '@/utils/merge-classes';
 import { IconInfoCircle } from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
 
 export interface DialFieldLabelProps {
   fieldTitle?: string | ReactNode;
@@ -39,7 +39,7 @@ export const DialFieldLabel: FC<DialFieldLabelProps> = ({
 }) => {
   return fieldTitle ? (
     <label
-      className={classNames(
+      className={mergeClasses(
         'dial-tiny text-secondary flex gap-1',
         cssClass,
         !cssClass?.includes('mb') && 'mb-2',

--- a/src/components/FormItem/FormItem.stories.tsx
+++ b/src/components/FormItem/FormItem.stories.tsx
@@ -28,6 +28,7 @@ const meta = {
     error: { control: 'text' },
     labelVisuallyHidden: { control: 'boolean' },
     cssClass: { control: 'text' },
+    childrenCssClass: { control: 'text' },
     labelCssClass: { control: 'text' },
     errorCssClass: { control: 'text' },
     captionDescription: { control: 'text' },

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -17,6 +17,7 @@ export interface DialFormItemProps {
   orientation?: FormItemOrientation;
   labelVisuallyHidden?: boolean;
   cssClass?: string;
+  childrenCssClass?: string;
   labelCssClass?: string;
   errorCssClass?: string;
   children: ReactNode;
@@ -72,6 +73,7 @@ export interface DialFormItemProps {
  * @param [orientation='vertical'] - Layout orientation, either 'vertical' (label above control) or 'horizontal' (label to the left)
  * @param [labelVisuallyHidden=false] - Whether to visually hide the label (still accessible to screen readers)
  * @param [cssClass] - Additional CSS classes to apply to the container div
+ * @param [childrenCssClass] - Additional CSS classes to apply to the children container div
  * @param [labelCssClass] - Additional CSS classes to apply to the label element
  * @param [errorCssClass] - Additional CSS classes to apply to the error message element
  * @param [captionDescription] - Additional caption description text, displayed below the form control.
@@ -92,6 +94,7 @@ export const DialFormItem: FC<DialFormItemProps> = ({
   cssClass,
   labelCssClass,
   errorCssClass,
+  childrenCssClass,
   captionDescription,
   readonly,
   value,
@@ -178,7 +181,7 @@ export const DialFormItem: FC<DialFormItemProps> = ({
         </div>
       )}
 
-      <div className="min-w-0 w-full">
+      <div className={mergeClasses('min-w-0 w-full', childrenCssClass)}>
         {readonly ? (
           <div className="dial-input px-3 py-2">{renderReadonlyValue()}</div>
         ) : (

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -49,6 +49,15 @@ const meta = {
         defaultValue: { summary: 'undefined' },
       },
     },
+    groupLabelCssClass: {
+      control: { type: 'text' },
+      description:
+        'Optional classes applied to the group label. If not provided, labelCssClass will be used.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
     containerCssClass: {
       control: { type: 'text' },
       description: 'Additional classes applied to the outer container',
@@ -344,24 +353,27 @@ const AllCssClassesExample = (
   );
 
   return (
-    <DialRadioGroup
-      {...args}
-      activeRadioButton={activeRadioButton}
-      selectedLabelCssClass={
-        activeRadioButton === 'premium'
-          ? 'dial-h1 text-warning'
-          : 'dial-h1 text-accent-tertiary'
-      }
-      selectedItemCssClass={
-        activeRadioButton === 'premium'
-          ? 'mt-2 p-3 bg-layer-1 border border-accent-primary rounded-md text-warning'
-          : undefined
-      }
-      onChange={(id) => {
-        setActiveRadioButton(id);
-        args.onChange?.(id);
-      }}
-    />
+    <div className="h-[500px] w-[400px]">
+      <DialRadioGroup
+        {...args}
+        activeRadioButton={activeRadioButton}
+        selectedLabelCssClass={
+          activeRadioButton === 'premium'
+            ? 'dial-h1 text-warning'
+            : 'dial-h1 text-accent-tertiary'
+        }
+        selectedInputContainerCssClass={
+          activeRadioButton === 'premium' ? 'flex-1' : undefined
+        }
+        selectedItemCssClass={
+          activeRadioButton === 'premium' ? 'flex-1' : undefined
+        }
+        onChange={(id) => {
+          setActiveRadioButton(id);
+          args.onChange?.(id);
+        }}
+      />
+    </div>
   );
 };
 export const AllCssClasses: Story = {
@@ -369,7 +381,7 @@ export const AllCssClasses: Story = {
     docs: {
       description: {
         story:
-          'Demonstration of all available CSS customization options. Shows containerCssClass, labelCssClass, radioGroupCssClass, inputContainerCssClass, radioCssClass, selectedLabelCssClass and selectedItemCssClass in action.',
+          'Demonstration of all available CSS customization options. Shows containerCssClass, labelCssClass, radioGroupCssClass, inputContainerCssClass, radioCssClass, selectedLabelCssClass and selectedItemCssClass in action. Height is fixed to 500px to show how it can fill available space.',
       },
     },
   },
@@ -380,10 +392,12 @@ export const AllCssClasses: Story = {
     orientation: RadioGroupOrientation.Column,
     activeRadioButton: 'premium',
     containerCssClass:
-      'p-6 bg-layer-2 border-2 border-dashed border-accent-primary rounded-lg',
-    labelCssClass: 'dial-h1 text-accent-tertiary',
+      'p-2 bg-layer-2 border-2 border-dashed border-accent-primary rounded-lg h-full',
+    labelCssClass: 'dial-small text-accent-tertiary',
+    groupLabelCssClass: 'dial-h1 text-accent-secondary',
+    formItemChildrenCssClass: 'h-full',
     radioGroupCssClass:
-      'bg-layer-1 p-4 rounded-md shadow border border-primary',
+      'flex flex-col h-full bg-layer-1 p-4 rounded-md shadow border border-primary',
     inputContainerCssClass:
       'mb-3 p-3 bg-layer-0 rounded-md border-l-4 border-accent-primary',
     radioCssClass:
@@ -415,24 +429,6 @@ export const AllCssClasses: Story = {
               <li>• Unlimited projects</li>
               <li>• Priority support</li>
               <li>• Advanced features</li>
-            </ul>
-          </div>
-        ),
-      },
-      {
-        id: 'enterprise',
-        name: 'Enterprise Plan',
-        content: (
-          <div className="dial-small">
-            <div className="dial-small-semi text-accent-tertiary">
-              Custom pricing
-            </div>
-            <div className="text-secondary">For large organizations</div>
-            <ul className="mt-1 dial-tiny text-secondary">
-              <li>• Everything in Premium</li>
-              <li>• Dedicated support</li>
-              <li>• Custom integrations</li>
-              <li>• SLA guarantee</li>
             </ul>
           </div>
         ),

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -14,18 +14,22 @@ import {
 export interface DialRadioGroupProps {
   fieldTitle?: string;
   elementId: string;
-  radioCssClass?: string;
-  labelCssClass?: string;
-  containerCssClass?: string;
-  selectedItemCssClass?: string;
-  selectedLabelCssClass?: string;
-  radioGroupCssClass?: string;
-  inputContainerCssClass?: string;
   disabled?: boolean;
   radioButtons: RadioButtonWithContent[];
   activeRadioButton: string;
   orientation: RadioGroupOrientation;
   onChange: (radioId: string) => void;
+  // Optional CSS class names
+  radioCssClass?: string;
+  groupLabelCssClass?: string;
+  labelCssClass?: string;
+  containerCssClass?: string;
+  formItemChildrenCssClass?: string;
+  selectedItemCssClass?: string;
+  selectedLabelCssClass?: string;
+  radioGroupCssClass?: string;
+  inputContainerCssClass?: string;
+  selectedInputContainerCssClass?: string;
 }
 
 /**
@@ -53,6 +57,9 @@ export interface DialRadioGroupProps {
  * @param elementId - Name for the underlying radio group; also used for input `name`
  * @param [radioCssClass] - Additional classes applied to each radio input
  * @param [inputContainerCssClass] - Additional classes applied to each radio input's container
+ * @param [selectedInputContainerCssClass] - Additional classes applied to the selected radio input's container
+ * @param [groupLabelCssClass] - Optional classes applied to the group label. If not provided, `labelCssClass` will be used.
+ * @param [formItemChildrenCssClass] - Additional classes applied to the DialFormItem's children container
  * @param [labelCssClass] - Additional classes applied to each radio label
  * @param [containerCssClass] - Additional classes applied to the outer container
  * @param [selectedItemCssClass] - Additional classes applied to the selected option's content container
@@ -72,6 +79,9 @@ export const DialRadioGroup: FC<DialRadioGroupProps> = ({
   selectedLabelCssClass,
   radioGroupCssClass,
   inputContainerCssClass,
+  selectedInputContainerCssClass,
+  groupLabelCssClass,
+  formItemChildrenCssClass,
   labelCssClass,
   disabled,
   elementId,
@@ -84,8 +94,9 @@ export const DialRadioGroup: FC<DialRadioGroupProps> = ({
     <DialFormItem
       elementId={elementId}
       label={fieldTitle}
-      labelCssClass={labelCssClass}
+      labelCssClass={groupLabelCssClass ? groupLabelCssClass : labelCssClass}
       cssClass={containerCssClass}
+      childrenCssClass={formItemChildrenCssClass}
     >
       <div
         role="radiogroup"
@@ -100,7 +111,11 @@ export const DialRadioGroup: FC<DialRadioGroupProps> = ({
         {radioButtons.map((radio) => (
           <div
             key={radio.id}
-            className={mergeClasses('flex flex-col', inputContainerCssClass)}
+            className={mergeClasses(
+              'flex flex-col',
+              inputContainerCssClass,
+              radio.id === activeRadioButton && selectedInputContainerCssClass,
+            )}
           >
             <DialRadioButton
               name={elementId}


### PR DESCRIPTION
**Description:**

Add style for missing internal elements of RadioButtonGroup. Make it possible to style like on screenshot

Issues:

- Issue #<TICKET_ID>

**UI changes**
<img width="1918" height="972" alt="image" src="https://github.com/user-attachments/assets/1b5a3541-b712-4950-806f-2d8489893f03" />
one option grows full height
<img width="1919" height="1035" alt="image" src="https://github.com/user-attachments/assets/d6b99610-64f3-4bde-a82c-703adf50cee8" />
another option stays fixed height

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added