### PR TITLE
fix: Fix invalid Tab not showing invalid sign

### DIFF
--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -48,7 +48,7 @@ export const DialTab: FC<DialTabProps> = ({
   onClick,
 }) => {
   const baseClasses =
-    'rounded px-3 py-2 flex flex-row gap-2 h-[32px] cursor-pointer dial-small leading-4 hover:text-accent-primary';
+    'rounded px-3 pt-2 pb-[6px] flex flex-row gap-2 h-[32px] cursor-pointer dial-small leading-4 hover:text-accent-primary';
 
   const tabClassNames = mergeClasses(
     baseClasses,
@@ -57,7 +57,7 @@ export const DialTab: FC<DialTabProps> = ({
       'bg-layer-1 text-secondary pointer-events-none': disabled,
       'bg-accent-primary-alpha text-primary': active && !disabled,
       'text-primary': !active && !disabled,
-      'pb-[6px] border-b-2 border-b-accent-primary':
+      'pb-1 border-b-2 border-b-accent-primary':
         active && horizontal && !disabled,
       'border-l-2 border-l-accent-primary': active && !horizontal && !disabled,
     },
@@ -76,7 +76,7 @@ export const DialTab: FC<DialTabProps> = ({
         contentClassName="max-w-[200px]"
         cssClass="max-w-[200px]"
       />
-      {invalid && (
+      {(invalid || tab.invalid) && (
         <div className="text-error">
           <IconExclamationCircle {...BASE_ICON_PROPS} />
         </div>

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -16,6 +16,7 @@ const manySampleTabs: TabModel[] = [
   ...sampleTabs.map((t) => ({
     id: t.id + '_copy',
     name: t.name + ' Copy',
+    invalid: t.id === 'overview',
   })),
 ];
 
@@ -119,6 +120,18 @@ export const ManyVerticalTabs: Story = {
   },
 };
 
+export const WithInvalidTab: Story = {
+  render: InteractiveTabs,
+  args: {
+    tabs: sampleTabs.map((tab) => ({
+      ...tab,
+      invalid: tab.id === 'details',
+    })),
+    activeTab: 'details',
+    orientation: TabOrientation.Horizontal,
+  },
+};
+
 export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-10 text-primary">
@@ -142,7 +155,9 @@ export const AllVariants: Story = {
           />
         </div>
         <div>
-          <h3 className="dial-h3 font-semibold mb-2">Many horizontal tabs</h3>
+          <h3 className="dial-h3 font-semibold mb-2">
+            Many horizontal tabs and one is invalid
+          </h3>
           <InteractiveTabs
             tabs={manySampleTabs}
             activeTab="details"

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -43,7 +43,7 @@ export interface DialTabsProps {
  *   tabs={[
  *     { id: 'overview', label: 'Overview' },
  *     { id: 'details', label: 'Details' },
- *     { id: 'settings', label: 'Settings' },
+ *     { id: 'settings', label: 'Settings', invalid: true },
  *   ]}
  *   activeTab="overview"
  *   onClick={(id) => setActiveTab(id)}

--- a/src/models/tab.ts
+++ b/src/models/tab.ts
@@ -1,4 +1,5 @@
 export interface TabModel {
   id: string;
   name: string;
+  invalid?: boolean;
 }


### PR DESCRIPTION
**Description:**

Two fixes for Tabs component:
1) There was no possibility to mark some tab as invalid
2) Letters like 'y', 'g' were being cut on the bottom

Issues:

- Issue #<TICKET_ID>

**UI changes**
before
<img width="525" height="123" alt="image" src="https://github.com/user-attachments/assets/03c6d823-9e7f-4e6a-8b20-23b0ea663d50" />

after
<img width="555" height="116" alt="image" src="https://github.com/user-attachments/assets/2c8fee45-92b7-4f0a-9354-4ecf260105f3" />



**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added