### PR TITLE
fix: PasswordInput - Don't show tooltip when password is hidden

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -65,6 +65,18 @@ const meta = {
       control: false,
       description: 'Callback function called when the input blurs',
     },
+    tooltipText: {
+      control: { type: 'text' },
+      description: 'The text to display inside the tooltip',
+    },
+    tooltipTriggerClassName: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes to apply to the tooltip trigger',
+    },
+    hideTooltip: {
+      control: { type: 'boolean' },
+      description: 'Whether to hide the tooltip',
+    },
   },
   args: {
     elementId: 'story-input',
@@ -205,6 +217,13 @@ export const WithTooltipText: Story = {
   args: {
     value: 'example value',
     tooltipText: 'Tooltip text',
+  },
+};
+
+export const HiddenTooltip: Story = {
+  args: {
+    value: 'example value',
+    hideTooltip: true,
   },
 };
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -24,6 +24,7 @@ export interface DialInputProps
   hideBorder?: boolean;
   tooltipText?: string;
   tooltipTriggerClassName?: string;
+  hideTooltip?: boolean;
   onChange?: (value?: string) => void;
   onBlur?: (event: FocusEvent<HTMLInputElement, Element>) => void;
 }
@@ -52,6 +53,7 @@ export interface DialInputProps
  * @param hideBorder - Whether to hide the input border styling
  * @param tooltipText - The text to display inside the tooltip. If empty, the tooltip will display the value prop.
  * @param tooltipTriggerClassName - Additional CSS classes to apply to the tooltip
+ * @param hideTooltip - Whether to hide the tooltip
  * @param onChange - Callback function called when the input value changes
  * @param onBlur - Callback function called when the input blurs
  */
@@ -79,6 +81,7 @@ export const DialInput: FC<DialInputProps> = ({
   onBlur,
   defaultValue,
   tooltipText,
+  hideTooltip = false,
 }) => {
   const handleWheel = (e: WheelEvent<HTMLInputElement>) =>
     (e.target as HTMLInputElement).blur();
@@ -147,7 +150,7 @@ export const DialInput: FC<DialInputProps> = ({
       />
 
       <DialTooltip
-        tooltip={tooltipText || value}
+        tooltip={hideTooltip ? undefined : tooltipText || value}
         triggerClassName={classNames(tooltipTriggerClassName, 'flex-1')}
       >
         <input

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -36,6 +36,7 @@ export const DialPasswordInput: FC<DialInputProps> = ({ ...props }) => {
     <DialInput
       type={showValue ? 'text' : 'password'}
       {...props}
+      hideTooltip={!showValue}
       iconAfter={
         showValue ? (
           <DialHideIcon onClick={() => onChangeShowValue(false)} />


### PR DESCRIPTION
**Description:**

Removed tooltip from PasswordInput when value is hidden

Issues:

- Issue #<TICKET_ID>

**UI changes**
before
<img width="986" height="131" alt="image" src="https://github.com/user-attachments/assets/2ef2d1b2-9298-4a3e-8799-437a3ba2a409" />

after
<img width="347" height="137" alt="image" src="https://github.com/user-attachments/assets/c68e331e-f5a3-4d45-8999-a09d7361b27b" />

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added