### PR TITLE
feat: close Dropdown when it scrolled out (Issue #114)

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import React from 'react';
 
 // Mock Monaco Editor
@@ -31,4 +31,53 @@ vi.mock('@monaco-editor/react', () => ({
 
 afterEach(() => {
   cleanup();
+});
+
+let originalIntersectionObserver: typeof IntersectionObserver;
+let originalResizeObserver: typeof ResizeObserver;
+
+beforeAll(() => {
+  if (!document.elementFromPoint) {
+    document.elementFromPoint = vi.fn(() => document.createElement('div'));
+  }
+
+  originalIntersectionObserver = globalThis.IntersectionObserver;
+  originalResizeObserver = globalThis.ResizeObserver;
+
+  class IntersectionObserverMock implements IntersectionObserver {
+    readonly root: Element | Document | null = null;
+    readonly rootMargin: string = '';
+    readonly thresholds: number[] = [];
+    callback: IntersectionObserverCallback;
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback;
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn();
+  }
+
+  class ResizeObserverMock implements ResizeObserver {
+    callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  }
+
+  globalThis.IntersectionObserver =
+    IntersectionObserverMock as unknown as typeof IntersectionObserver;
+
+  globalThis.ResizeObserver =
+    ResizeObserverMock as unknown as typeof ResizeObserver;
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+  globalThis.IntersectionObserver = originalIntersectionObserver;
+  globalThis.ResizeObserver = originalResizeObserver;
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -377,12 +377,13 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     if (!isOpen) return;
 
     const refEl = refs.reference.current;
-    const targetEl =
-      refEl instanceof Element
-        ? refEl
-        : pointedElementRef.current instanceof Element
-          ? pointedElementRef.current
-          : null;
+    let targetEl: Element | null = null;
+
+    if (refEl instanceof Element) {
+      targetEl = refEl;
+    } else if (pointedElementRef.current instanceof Element) {
+      targetEl = pointedElementRef.current;
+    }
 
     if (!targetEl) return;
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -21,6 +21,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
   type FC,
   type MouseEvent,
@@ -139,6 +140,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
   const isControlled = open !== undefined;
   const isOpen = isControlled ? !!open : uncontrolledOpen;
+  const pointedElementRef = useRef<Element | null>(null);
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -264,6 +266,10 @@ export const DialDropdown: FC<DialDropdownProps> = ({
       e.preventDefault();
       if (anchorToMouse) {
         setPositionFromPointer(e.clientX, e.clientY);
+        pointedElementRef.current = document.elementFromPoint(
+          e.clientX,
+          e.clientY,
+        );
       }
       setOpen(true);
     },
@@ -274,6 +280,10 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     (e: MouseEvent<HTMLDivElement>) => {
       if (!anchorToMouse || disabled) return;
       setPositionFromPointer(e.clientX, e.clientY);
+      pointedElementRef.current = document.elementFromPoint(
+        e.clientX,
+        e.clientY,
+      );
     },
     [anchorToMouse, disabled, setPositionFromPointer],
   );
@@ -362,6 +372,31 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     onContextMenu,
     onMouseDown: onPointerDown,
   });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const refEl = refs.reference.current;
+    const targetEl =
+      refEl instanceof Element
+        ? refEl
+        : pointedElementRef.current instanceof Element
+          ? pointedElementRef.current
+          : null;
+
+    if (!targetEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) setOpen(false);
+      },
+      { root: null, threshold: 0 },
+    );
+
+    observer.observe(targetEl);
+
+    return () => observer.disconnect();
+  }, [isOpen, refs.reference, setOpen]);
 
   return (
     <>

--- a/src/components/FileManager/components/FileManagerBulkActionsToolbar/FileManagerBulkActionsToolbar.spec.tsx
+++ b/src/components/FileManager/components/FileManagerBulkActionsToolbar/FileManagerBulkActionsToolbar.spec.tsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, screen } from '@testing-library/react';
-import { describe, it, expect, vi, afterAll, beforeAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { DialFileManagerBulkActionsToolbar } from './FileManagerBulkActionsToolbar';
 import type { DialButtonProps } from '@/components/Button/Button';
 import type { DialDropdownProps } from '@/components/Dropdown/Dropdown';
@@ -30,30 +30,6 @@ vi.mock('@/hooks/use-is-tablet-screen', () => ({
 }));
 
 describe('Dial UI Kit :: DialFileManagerBulkActionsToolbar', () => {
-  let originalResizeObserver: typeof ResizeObserver;
-
-  beforeAll(() => {
-    originalResizeObserver = globalThis.ResizeObserver;
-
-    class ResizeObserverMock implements ResizeObserver {
-      callback: ResizeObserverCallback;
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-      }
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    }
-
-    globalThis.ResizeObserver =
-      ResizeObserverMock as unknown as typeof ResizeObserver;
-  });
-
-  afterAll(() => {
-    vi.restoreAllMocks();
-    globalThis.ResizeObserver = originalResizeObserver;
-  });
-
   const actions = [
     { key: 'download', title: 'Download', onClick: vi.fn() },
     { key: 'delete', title: 'Delete', onClick: vi.fn() },

--- a/src/components/Tabs/Tabs.spec.tsx
+++ b/src/components/Tabs/Tabs.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { DialTabs } from './Tabs';
 import { TabOrientation } from '@/types/tab';
 import * as useIsTabletScreenHook from '@/hooks/use-is-tablet-screen';
@@ -10,30 +10,6 @@ const tabsMock = [
 ];
 
 describe('Dial UI Kit :: DialTabs', () => {
-  let originalResizeObserver: typeof ResizeObserver;
-
-  beforeAll(() => {
-    originalResizeObserver = globalThis.ResizeObserver;
-
-    class ResizeObserverMock implements ResizeObserver {
-      callback: ResizeObserverCallback;
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-      }
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    }
-
-    globalThis.ResizeObserver =
-      ResizeObserverMock as unknown as typeof ResizeObserver;
-  });
-
-  afterAll(() => {
-    vi.restoreAllMocks();
-    globalThis.ResizeObserver = originalResizeObserver;
-  });
-
   test('renders horizontal tabs and handles click', () => {
     const onClick = vi.fn();
     render(<DialTabs tabs={tabsMock} activeTab="tab1" onClick={onClick} />);

--- a/src/components/TagInput/TagInput.spec.tsx
+++ b/src/components/TagInput/TagInput.spec.tsx
@@ -1,31 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { DialTagInput } from './TagInput';
 
 describe('Dial UI Kit :: DialTagInput', () => {
-  let originalResizeObserver: typeof ResizeObserver;
-
-  beforeAll(() => {
-    originalResizeObserver = globalThis.ResizeObserver;
-
-    class ResizeObserverMock implements ResizeObserver {
-      callback: ResizeObserverCallback;
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-      }
-      observe = vi.fn();
-      unobserve = vi.fn();
-      disconnect = vi.fn();
-    }
-
-    globalThis.ResizeObserver =
-      ResizeObserverMock as unknown as typeof ResizeObserver;
-  });
-
-  afterAll(() => {
-    globalThis.ResizeObserver = originalResizeObserver;
-  });
-
   test('Should render correctly', () => {
     render(<DialTagInput elementId="test-tag" />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();


### PR DESCRIPTION
**Description:**

Close Dropdown when it scrolled out. Set up common mocks for ResizeObserver and IntersectionObserver.

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added