### PR TITLE
feat: improve scroll logic in FolderTree (Issue #114)

### DIFF
--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -166,22 +166,26 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
 
       return (
         <div key={`${path}-children`} className="cursor-pointer text-secondary">
-          <div className="flex flex-col">
-            <div
-              style={{ paddingLeft: `${level * FOLDER_LEVEL_PADDING}px` }}
-              className={mergeClasses(
-                'py-[6px] pr-[6px] gap-[2px] dial-small flex justify-between hover:bg-accent-primary-alpha rounded group w-full mb-[2px]',
-                selectedClass,
-              )}
+          <div className="flex flex-col min-w-fit w-full">
+            <DialDropdown
+              trigger={[DropdownTrigger.ContextMenu]}
+              cssClass="w-full"
+              anchorToMouse
+              menu={{ items: menuItems }}
             >
-              <div onClick={() => handleFolderClick(node)} className="w-full">
-                <DialDropdown
-                  trigger={[DropdownTrigger.ContextMenu]}
-                  cssClass="w-full"
-                  anchorToMouse
-                  menu={{ items: menuItems }}
-                >
-                  <div className="flex-1 flex flex-row truncate items-center">
+              <div
+                style={{ paddingLeft: `${level * FOLDER_LEVEL_PADDING}px` }}
+                className={mergeClasses(
+                  'py-[6px] pr-[6px] gap-[2px] dial-small flex justify-between hover:bg-accent-primary-alpha rounded group w-full mb-[2px] relative',
+                  selectedClass,
+                )}
+              >
+                <div
+                  className="absolute size-full left-0 top-0"
+                  onClick={() => handleFolderClick(node)}
+                />
+                <div>
+                  <div className="flex-1 flex flex-row truncate items-center w-fit">
                     {!isFolder ? (
                       <DialFileName name={name} />
                     ) : (
@@ -198,22 +202,25 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                       </>
                     )}
                   </div>
-                </DialDropdown>
-              </div>
+                </div>
 
-              {menuItems.length > 0 && (
-                <DialDropdown
-                  placement="bottom-start"
-                  allowedPlacements={['top-start', 'top-end']}
-                  menu={{ items: menuItems }}
-                >
-                  <DialIcon
-                    className="invisible group-hover:visible text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary"
-                    icon={<IconDotsVertical {...BASE_ICON_PROPS} />}
-                  />
-                </DialDropdown>
-              )}
-            </div>
+                {menuItems.length > 0 && (
+                  <div className="flex-1 flex justify-end">
+                    <DialDropdown
+                      placement="bottom-start"
+                      allowedPlacements={['top-start', 'top-end']}
+                      menu={{ items: menuItems }}
+                      cssClass="sticky right-0"
+                    >
+                      <DialIcon
+                        className="invisible group-hover:visible text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary"
+                        icon={<IconDotsVertical {...BASE_ICON_PROPS} />}
+                      />
+                    </DialDropdown>
+                  </div>
+                )}
+              </div>
+            </DialDropdown>
 
             {isExpanded && items && renderTree(items, level + 1)}
           </div>

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -184,24 +184,25 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                   className="absolute size-full left-0 top-0"
                   onClick={() => handleFolderClick(node)}
                 />
-                <div>
-                  <div className="flex-1 flex flex-row truncate items-center w-fit">
-                    {!isFolder ? (
-                      <DialFileName name={name} />
-                    ) : (
-                      <>
-                        <IconCaretRightFilled
-                          {...CARET_ICON_PROPS}
-                          className={classNames(
-                            'flex-shrink-0',
-                            isExpanded && 'rotate-90 transition-all',
-                            !hasValidItems && 'text-transparent',
-                          )}
-                        />
-                        <DialFolderName name={name} loading={isLoading} />
-                      </>
-                    )}
-                  </div>
+                <div
+                  className="flex flex-row truncate items-center w-fit"
+                  onClick={() => handleFolderClick(node)}
+                >
+                  {!isFolder ? (
+                    <DialFileName name={name} />
+                  ) : (
+                    <>
+                      <IconCaretRightFilled
+                        {...CARET_ICON_PROPS}
+                        className={classNames(
+                          'flex-shrink-0',
+                          isExpanded && 'rotate-90 transition-all',
+                          !hasValidItems && 'text-transparent',
+                        )}
+                      />
+                      <DialFolderName name={name} loading={isLoading} />
+                    </>
+                  )}
                 </div>
 
                 {menuItems.length > 0 && (


### PR DESCRIPTION
**Description:**

FolderTree scroll logic was improved:
- fixed the problem with item label widths.
- the menu button now becomes sticky to handle cases where the user hovers over the root folder while nested folders are expanded
- folders can now be toggled by clicking anywhere on a row
- the context menu can now be opened from anywhere on a row

Issues:

- Issue #114 

**UI changes**

sticky menu button:
<img width="301" height="454" alt="image" src="https://github.com/user-attachments/assets/3865a399-c06c-4a68-9e41-1e8118cb7792" />

fixed names length:
<img width="302" height="378" alt="image" src="https://github.com/user-attachments/assets/77071402-592e-4e07-8ec3-e9a2f6460c09" />

context menu that was triggered by clicking at the very beginning of a row:
<img width="300" height="360" alt="image" src="https://github.com/user-attachments/assets/2ef0cea8-fb35-4a35-96b0-47fba2cee31b" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added