### PR TITLE
fix(tabs): allow to disable tab using Tabs component (Issue #191)

### DIFF
--- a/src/components/Tab/Tab.spec.tsx
+++ b/src/components/Tab/Tab.spec.tsx
@@ -19,7 +19,13 @@ describe('Dial UI Kit :: DialTab', () => {
 
   test('applies disabled styles and disables click', () => {
     const onClick = vi.fn();
-    render(<DialTab tab={baseTab} active={false} disabled onClick={onClick} />);
+    render(
+      <DialTab
+        tab={{ ...baseTab, disabled: true }}
+        active={false}
+        onClick={onClick}
+      />,
+    );
     const btn = screen.getByRole('tab');
     expect(btn.className).toMatch(/pointer-events-none/);
     fireEvent.click(btn);
@@ -29,7 +35,11 @@ describe('Dial UI Kit :: DialTab', () => {
 
   test('shows exclamation icon if invalid', () => {
     const { container } = render(
-      <DialTab tab={baseTab} active={false} invalid onClick={vi.fn()} />,
+      <DialTab
+        tab={{ ...baseTab, invalid: true }}
+        active={false}
+        onClick={vi.fn()}
+      />,
     );
     expect(
       container.querySelector('.tabler-icon-exclamation-circle'),
@@ -117,7 +127,9 @@ describe('Dial UI Kit :: DialTab', () => {
   });
 
   test('disabled applies text-secondary and bg-layer-1 and removes active styles', () => {
-    render(<DialTab tab={baseTab} active disabled onClick={vi.fn()} />);
+    render(
+      <DialTab tab={{ ...baseTab, disabled: true }} active onClick={vi.fn()} />,
+    );
     const btn = screen.getByRole('tab');
     expect(btn.className).toMatch(/text-secondary/);
     expect(btn.className).toMatch(/bg-layer-1/);
@@ -128,7 +140,11 @@ describe('Dial UI Kit :: DialTab', () => {
 
   test('invalid state wraps icon with text-error class (via prop)', () => {
     const { container } = render(
-      <DialTab tab={baseTab} active={false} invalid onClick={vi.fn()} />,
+      <DialTab
+        tab={{ ...baseTab, invalid: true }}
+        active={false}
+        onClick={vi.fn()}
+      />,
     );
     expect(container.querySelector('.text-error')).toBeInTheDocument();
   });

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -61,7 +61,7 @@ export const Inactive: Story = {
 
 export const Disabled: Story = {
   args: {
-    tab: { id: 'settings', name: 'Settings', disabled: true},
+    tab: { id: 'settings', name: 'Settings', disabled: true },
     active: false,
     horizontal: true,
     onClick: () => null,

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -27,14 +27,6 @@ const meta: Meta<typeof DialTab> = {
       control: 'boolean',
       description: 'Marks the tab as active.',
     },
-    disabled: {
-      control: 'boolean',
-      description: 'Disables the tab so it is non-interactive.',
-    },
-    invalid: {
-      control: 'boolean',
-      description: 'Marks the tab as invalid, showing an error icon.',
-    },
     horizontal: {
       control: 'boolean',
       description: 'Determines horizontal vs vertical orientation.',
@@ -69,9 +61,8 @@ export const Inactive: Story = {
 
 export const Disabled: Story = {
   args: {
-    tab: { id: 'settings', name: 'Settings' },
+    tab: { id: 'settings', name: 'Settings', disabled: true},
     active: false,
-    disabled: true,
     horizontal: true,
     onClick: () => null,
   },
@@ -79,9 +70,8 @@ export const Disabled: Story = {
 
 export const Invalid: Story = {
   args: {
-    tab: { id: 'analytics', name: 'Analytics' },
+    tab: { id: 'analytics', name: 'Analytics', invalid: true },
     active: false,
-    invalid: true,
     horizontal: true,
     onClick: () => null,
   },

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -8,7 +8,6 @@ import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisToolti
 export interface DialTabProps {
   tab: TabModel;
   active: boolean;
-  disabled?: boolean;
   invalid?: boolean;
   horizontal?: boolean;
   cssClass?: string;
@@ -30,10 +29,8 @@ export interface DialTabProps {
  * />
  * ```
  *
- * @param tab - The tab model containing its `id` and `name`.
+ * @param tab - The tab model containing its `id`, `name`, [`disabled`], [`invalid`].
  * @param active - Whether the tab is currently active.
- * @param [disabled=false] - Whether the tab is disabled and non-interactive.
- * @param [invalid=false] - Whether the tab is marked as invalid, displaying an error icon.
  * @param [horizontal=false] - Whether the tab is displayed in horizontal orientation.
  * @param [cssClass] - Additional CSS classes applied to the tab element.
  * @param onClick - Callback fired when the tab is clicked. Receives the tab’s `id`.
@@ -41,7 +38,6 @@ export interface DialTabProps {
 export const DialTab: FC<DialTabProps> = ({
   tab,
   active,
-  disabled,
   invalid,
   cssClass,
   horizontal,
@@ -55,11 +51,11 @@ export const DialTab: FC<DialTabProps> = ({
     baseClasses,
     {
       'bg-layer-4': horizontal,
-      'bg-layer-1 text-secondary pointer-events-none': disabled,
-      'bg-accent-primary-alpha text-primary': active && !disabled,
-      'text-primary': !active && !disabled,
-      'border-b-accent-primary': active && horizontal && !disabled,
-      'border-l-accent-primary': active && !horizontal && !disabled,
+      'bg-layer-1 text-secondary pointer-events-none': tab.disabled,
+      'bg-accent-primary-alpha text-primary': active && !tab.disabled,
+      'text-primary': !active && !tab.disabled,
+      'border-b-accent-primary': active && horizontal && !tab.disabled,
+      'border-l-accent-primary': active && !horizontal && !tab.disabled,
     },
     cssClass,
   );
@@ -69,7 +65,7 @@ export const DialTab: FC<DialTabProps> = ({
       role="tab"
       className={tabClassNames}
       onClick={() => onClick(tab.id)}
-      disabled={disabled}
+      disabled={tab.disabled}
     >
       <DialEllipsisTooltip
         text={tab.name}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ export { DialDateCellRenderer } from './components/Grid/renderers/DateCellRender
 
 // Navigation
 export { DialTabs } from './components/Tabs/Tabs';
-export { DialTab } from './components/Tab/Tab';
 export { DialBreadcrumb } from './components/Breadcrumb/Breadcrumb';
 export { DialBreadcrumbItem } from './components/Breadcrumb/BreadcrumbItem';
 

--- a/src/models/tab.ts
+++ b/src/models/tab.ts
@@ -2,4 +2,5 @@ export interface TabModel {
   id: string;
   name: string;
   invalid?: boolean;
+  disabled?: boolean;
 }


### PR DESCRIPTION
**Description:**

Allow to set disabled tab in TabModel

Issues:

- Issue #191

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added