### PR TITLE
fix: remove onRefresh prop and related functionality from DialFileManagerToolbar

### DIFF
--- a/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.spec.tsx
+++ b/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.spec.tsx
@@ -70,7 +70,6 @@ describe('Dial UI Kit :: DialFileManagerToolbar', () => {
         areHiddenFilesVisible={false}
         onTabChange={vi.fn()}
         onToggleHiddenFiles={vi.fn()}
-        onRefresh={vi.fn()}
       />,
     );
 
@@ -87,7 +86,6 @@ describe('Dial UI Kit :: DialFileManagerToolbar', () => {
         areHiddenFilesVisible={true}
         onTabChange={vi.fn()}
         onToggleHiddenFiles={onToggleHiddenFiles}
-        onRefresh={vi.fn()}
       />,
     );
 
@@ -106,7 +104,6 @@ describe('Dial UI Kit :: DialFileManagerToolbar', () => {
         areHiddenFilesVisible={false}
         onTabChange={vi.fn()}
         onToggleHiddenFiles={vi.fn()}
-        onRefresh={vi.fn()}
         isCreateButtonVisible={false}
       />,
     );
@@ -120,29 +117,11 @@ describe('Dial UI Kit :: DialFileManagerToolbar', () => {
         areHiddenFilesVisible={false}
         onTabChange={vi.fn()}
         onToggleHiddenFiles={vi.fn()}
-        onRefresh={vi.fn()}
         isCreateButtonVisible={true}
         createButtonDropdownItems={[{ key: '1', label: 'New File' }]}
       />,
     );
 
     expect(queryByTestId('create-button')).toBeInTheDocument();
-  });
-
-  it('calls onRefresh when clicking refresh button', () => {
-    const onRefresh = vi.fn();
-    render(
-      <DialFileManagerToolbar
-        tabs={mockTabs}
-        activeTab="tab1"
-        areHiddenFilesVisible={false}
-        onTabChange={vi.fn()}
-        onToggleHiddenFiles={vi.fn()}
-        onRefresh={onRefresh}
-      />,
-    );
-
-    fireEvent.click(screen.getByText('Refresh'));
-    expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.stories.tsx
+++ b/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.stories.tsx
@@ -23,7 +23,6 @@ const meta: Meta<typeof DialFileManagerToolbar> = {
   argTypes: {
     onTabChange: { action: 'onTabChange' },
     onToggleHiddenFiles: { action: 'onToggleHiddenFiles' },
-    onRefresh: { action: 'onRefresh' },
   },
 };
 export default meta;
@@ -71,7 +70,6 @@ export const Default: Story = {
             onTabChange={setActiveTab}
             areHiddenFilesVisible={areHiddenFilesVisible}
             onToggleHiddenFiles={setAreHiddenFilesVisible}
-            onRefresh={() => alert('Refresh')}
             isCreateButtonVisible
             createButtonVariant={ButtonVariant.Primary}
             createButtonDropdownItems={mockCreateItems}
@@ -98,7 +96,6 @@ export const WithSecondaryCreateButton: Story = {
             onTabChange={setActiveTab}
             areHiddenFilesVisible={areHiddenFilesVisible}
             onToggleHiddenFiles={setAreHiddenFilesVisible}
-            onRefresh={() => alert('Refresh')}
             isCreateButtonVisible
             createButtonVariant={ButtonVariant.Secondary}
             createButtonDropdownItems={mockCreateItems}
@@ -125,7 +122,6 @@ export const WithoutCreateButton: Story = {
             onTabChange={setActiveTab}
             areHiddenFilesVisible={areHiddenFilesVisible}
             onToggleHiddenFiles={setAreHiddenFilesVisible}
-            onRefresh={() => alert('Refresh')}
           />
         </div>
       );

--- a/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
+++ b/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
@@ -2,12 +2,7 @@ import { type FC, useMemo } from 'react';
 import { DialTabs } from '@/components/Tabs/Tabs';
 import { DialSwitch } from '@/components/Switch/Switch';
 import { DialButton } from '@/components/Button/Button';
-import {
-  IconDotsVertical,
-  IconEye,
-  IconEyeOff,
-  IconRefresh,
-} from '@tabler/icons-react';
+import { IconDotsVertical, IconEye, IconEyeOff } from '@tabler/icons-react';
 import type { TabModel } from '@/models/tab';
 import { ButtonVariant } from '@/types/button';
 import { DialButtonDropdown } from '@/components/ButtonDropdown/ButtonDropdown';
@@ -29,10 +24,8 @@ export interface DialFileManagerToolbarProps {
   createButtonVariant?: ButtonVariant;
   createButtonDropdownItems?: DropdownItem[];
   createButtonLabel?: string;
-  refreshButtonLabel?: string;
   onTabChange?: (id: DialFileManagerTabs) => void;
   onToggleHiddenFiles?: (value: boolean) => void;
-  onRefresh?: () => void;
 }
 
 /**
@@ -74,8 +67,6 @@ export interface DialFileManagerToolbarProps {
  * @param [hideHiddenFilesLabel='Hide hidden'] - Label shown when hidden files are visible.
  * @param [onTabChange] - Callback fired when the user switches between tabs. Receives the selected tab ID.
  * @param [onToggleHiddenFiles] - Callback fired when the hidden files visibility is toggled. Receives the new visibility state.
- * @param [onRefresh] - Callback fired when the refresh button is clicked.
- * @param [refreshButtonLabel='Refresh'] - Text label for the refresh button.
  * @param [isCreateButtonVisible] - Whether the "Create" button or dropdown should be displayed.
  * @param [createButtonVariant=ButtonVariant.Secondary] - Visual style variant for the create button.
  * @param [createButtonDropdownItems=[]] - Dropdown items available under the create button. If empty, a single create button is shown instead.
@@ -94,7 +85,6 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
   onTabChange,
   areHiddenFilesVisible,
   onToggleHiddenFiles,
-  onRefresh,
   isCreateButtonVisible,
   createButtonVariant = ButtonVariant.Secondary,
   createButtonDropdownItems = [],
@@ -102,7 +92,6 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
   hiddenFilesSwitcherLabel = 'Hidden files',
   showHiddenFilesLabel = 'Show hidden files',
   hideHiddenFilesLabel = 'Hide hidden files',
-  refreshButtonLabel = 'Refresh',
 }) => {
   const isMobile = useIsMobileScreen();
 
@@ -122,24 +111,12 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
       },
     ];
 
-    if (isCreateButtonVisible) {
-      items.push({
-        key: 'refresh-button',
-        label: refreshButtonLabel,
-        icon: <IconRefresh {...BASE_ICON_PROPS} className="text-secondary" />,
-        onClick: () => onRefresh?.(),
-      });
-    }
-
     return items;
   }, [
     areHiddenFilesVisible,
     hideHiddenFilesLabel,
     showHiddenFilesLabel,
-    refreshButtonLabel,
-    onRefresh,
     onToggleHiddenFiles,
-    isCreateButtonVisible,
   ]);
 
   const renderTabs = () =>
@@ -163,21 +140,15 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
         onChange={onToggleHiddenFiles}
       />
 
-      <div className="h-6 border-l border-primary" />
-
-      <DialButton
-        title={refreshButtonLabel}
-        onClick={onRefresh}
-        variant={ButtonVariant.Secondary}
-        iconBefore={<IconRefresh {...BASE_ICON_PROPS} />}
-      />
-
       {isCreateButtonVisible && (
-        <DialButtonDropdown
-          title={createButtonLabel}
-          variant={createButtonVariant}
-          items={createButtonDropdownItems}
-        />
+        <>
+          <div className="h-6 border-l border-primary" />
+          <DialButtonDropdown
+            title={createButtonLabel}
+            variant={createButtonVariant}
+            items={createButtonDropdownItems}
+          />
+        </>
       )}
     </>
   );
@@ -205,14 +176,7 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
           variant={createButtonVariant}
           items={createButtonDropdownItems}
         />
-      ) : (
-        <DialButton
-          title={refreshButtonLabel}
-          onClick={onRefresh}
-          variant={ButtonVariant.Secondary}
-          iconBefore={<IconRefresh {...BASE_ICON_PROPS} />}
-        />
-      )}
+      ) : null}
     </>
   );
 


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added