### PR TITLE
fix: close menu opened by context-menu trigger on click

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -651,4 +651,25 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     expect(pos1).toBe(pos2);
   });
+
+  test('closes menu opened by context-menu trigger on side click', () => {
+    const { container } = render(
+      <DialDropdown
+        trigger={[DropdownTrigger.ContextMenu]}
+        menu={{ items }}
+        anchorToMouse
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+
+    const wrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    const button = screen.getByRole('button', { name: /open/i });
+
+    fireEvent.contextMenu(button);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(wrapper);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -279,13 +279,18 @@ export const DialDropdown: FC<DialDropdownProps> = ({
   const onPointerDown = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
       if (!anchorToMouse || disabled) return;
+
+      if (trigger.includes(DropdownTrigger.ContextMenu) && isOpen) {
+        setOpen(false);
+      }
+
       setPositionFromPointer(e.clientX, e.clientY);
       pointedElementRef.current = document.elementFromPoint(
         e.clientX,
         e.clientY,
       );
     },
-    [anchorToMouse, disabled, setPositionFromPointer],
+    [anchorToMouse, disabled, setPositionFromPointer, isOpen, trigger, setOpen],
   );
 
   useEffect(() => {


### PR DESCRIPTION
**Description:**

Fixes dropdown behavior where menus opened via the context-menu trigger were not closing on click.

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added