### PR TITLE
fix: enlarge file manager items icon size 18->20 (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -10,7 +10,7 @@ import {
   sidebarWidth,
   sidebarTitleDefault,
   gridBaseClasses,
-  BASE_FILE_MANAGER_ITEM_ICON_SIZE,
+  BASE_FILE_MANAGER_ICON_SIZE,
 } from './constants';
 import { DialCollapsibleSidebar } from '@/components/CollapsibleSidebar/CollapsibleSidebar';
 import type { DialFile, DialRootFolder } from '@/models/file';
@@ -317,12 +317,12 @@ export const DialFileManagerView: FC = () => {
           params.data?.nodeType === DialFileNodeType.FOLDER ? (
             <DialFolderName
               name={params.data.name}
-              iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
+              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
             />
           ) : (
             <DialFileName
               name={params.data.name}
-              iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
+              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
             />
           ),
       },

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -10,6 +10,7 @@ import {
   sidebarWidth,
   sidebarTitleDefault,
   gridBaseClasses,
+  BASE_FILE_MANAGER_ITEM_ICON_SIZE,
 } from './constants';
 import { DialCollapsibleSidebar } from '@/components/CollapsibleSidebar/CollapsibleSidebar';
 import type { DialFile, DialRootFolder } from '@/models/file';
@@ -314,9 +315,15 @@ export const DialFileManagerView: FC = () => {
         minWidth: 200,
         cellRenderer: (params: { data: GridRow }) =>
           params.data?.nodeType === DialFileNodeType.FOLDER ? (
-            <DialFolderName name={params.data.name} />
+            <DialFolderName
+              name={params.data.name}
+              iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
+            />
           ) : (
-            <DialFileName name={params.data.name} />
+            <DialFileName
+              name={params.data.name}
+              iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
+            />
           ),
       },
       {

--- a/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.tsx
+++ b/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.tsx
@@ -7,6 +7,7 @@ import { useEditableItem } from '@/hooks/use-editable-item';
 import { DialItemType } from '@/types/item';
 import { DialFileName } from '@/components/FileName/FileName';
 import { DialFolderName } from '@/components/FolderName/FolderName';
+import { BASE_ICON_SIZE } from '@/constants/icon';
 
 export interface DialFileManagerItemNameProps
   extends DialFileManagerItemNameInputProps {
@@ -61,6 +62,7 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
   editing = false,
   loading = false,
   shared = false,
+  iconSize = BASE_ICON_SIZE,
   validate,
   onSave,
   onCancel,
@@ -81,12 +83,18 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
           name={name}
           loading={loading}
           shared={shared}
+          iconSize={iconSize}
           cssClass="max-w-[428px] truncate"
         />
       );
     }
     return (
-      <DialFileName name={name} shared={shared} cssClass="max-w-[428px]" />
+      <DialFileName
+        name={name}
+        shared={shared}
+        iconSize={iconSize}
+        cssClass="max-w-[428px]"
+      />
     );
   }
 
@@ -99,6 +107,7 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
       inputInvalidMessage={invalidMessage}
       inputRef={inputRef}
       onChange={onChange}
+      iconSize={iconSize}
     />
   );
 };

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -13,7 +13,7 @@ import { DialNoDataContent } from '@/components/NoDataContent/NoDataContent';
 import { isHiddenDotFile } from '../../utils';
 import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
 import { DialItemType } from '@/types/item';
-import { BASE_FILE_MANAGER_ITEM_ICON_SIZE } from '@/components/FileManager/constants';
+import { BASE_FILE_MANAGER_ICON_SIZE } from '@/components/FileManager/constants';
 
 export interface DialFoldersTreeProps {
   items: DialFile[];
@@ -236,7 +236,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                       onSave={onRenameSave}
                       onCancel={onRenameCancel}
                       validate={validateHandler}
-                      iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
+                      iconSize={BASE_FILE_MANAGER_ICON_SIZE}
                     />
                   </>
                 </div>

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -13,6 +13,7 @@ import { DialNoDataContent } from '@/components/NoDataContent/NoDataContent';
 import { isHiddenDotFile } from '../../utils';
 import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
 import { DialItemType } from '@/types/item';
+import { BASE_FILE_MANAGER_ITEM_ICON_SIZE } from '@/components/FileManager/constants';
 
 export interface DialFoldersTreeProps {
   items: DialFile[];
@@ -235,6 +236,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                       onSave={onRenameSave}
                       onCancel={onRenameCancel}
                       validate={validateHandler}
+                      iconSize={BASE_FILE_MANAGER_ITEM_ICON_SIZE}
                     />
                   </>
                 </div>

--- a/src/components/FileManager/constants.tsx
+++ b/src/components/FileManager/constants.tsx
@@ -20,3 +20,5 @@ export const gridBaseClasses =
 
 export const sidebarWidth = 280;
 export const sidebarTitleDefault = 'Files';
+
+export const BASE_FILE_MANAGER_ITEM_ICON_SIZE = 20;

--- a/src/components/FileManager/constants.tsx
+++ b/src/components/FileManager/constants.tsx
@@ -21,4 +21,4 @@ export const gridBaseClasses =
 export const sidebarWidth = 280;
 export const sidebarTitleDefault = 'Files';
 
-export const BASE_FILE_MANAGER_ITEM_ICON_SIZE = 20;
+export const BASE_FILE_MANAGER_ICON_SIZE = 20;

--- a/src/components/FileName/FileName.tsx
+++ b/src/components/FileName/FileName.tsx
@@ -3,11 +3,13 @@ import type { FC } from 'react';
 import { DialFileIcon } from '@/components/FileIcon/FileIcon';
 import { DialSharedEntityIndicator } from '@/components/SharedEntityIndicator/SharedEntityIndicator';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
+import { BASE_ICON_SIZE } from '@/constants/icon';
 
 export interface DialFileNameProps {
   name: string;
   cssClass?: string;
   shared?: boolean;
+  iconSize?: number;
 }
 
 /**
@@ -22,11 +24,13 @@ export interface DialFileNameProps {
  * @param name - Full file name with or without extension
  * @param cssClass - Additional CSS classes for the root container
  * @param shared - Whether the file is shared
+ * @param iconSize - Icon size in px. Default: BASE_ICON_SIZE.
  */
 export const DialFileName: FC<DialFileNameProps> = ({
   name,
   cssClass,
   shared = false,
+  iconSize = BASE_ICON_SIZE,
 }) => {
   const extension = name.includes('.') ? name.split('.').pop() : null;
 
@@ -35,6 +39,7 @@ export const DialFileName: FC<DialFileNameProps> = ({
       {extension && (
         <DialFileIcon
           extension={extension}
+          size={iconSize}
           cssClass="text-secondary"
           indicator={shared ? <DialSharedEntityIndicator /> : null}
           label="File type icon"

--- a/src/components/FolderName/FolderName.tsx
+++ b/src/components/FolderName/FolderName.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 import { DialSharedEntityIndicator } from '@/components/SharedEntityIndicator/SharedEntityIndicator';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import { DialIcon } from '@/components/Icon/Icon';
-import { BASE_ICON_PROPS } from '@/constants/icon';
+import { BASE_ICON_PROPS, BASE_ICON_SIZE } from '@/constants/icon';
 import { IconFolder } from '@tabler/icons-react';
 import { DialLoader } from '@/components/Loader/Loader';
 
@@ -12,6 +12,7 @@ export interface DialFolderNameProps {
   cssClass?: string;
   shared?: boolean;
   loading?: boolean;
+  iconSize?: number;
 }
 
 /**
@@ -25,21 +26,24 @@ export interface DialFolderNameProps {
  *
  * @param name - Folder name
  * @param cssClass - Additional CSS classes for the root container
- * @param shared - Whether the folder is shared
+ * @param shared - If true, shows shared indicator. Default: false.
+ * @param loading - If true, shows loading state. Default: false.
+ * @param iconSize - Icon size in px. Default: BASE_ICON_SIZE.
  */
 export const DialFolderName: FC<DialFolderNameProps> = ({
   name,
   cssClass,
   shared = false,
   loading = false,
+  iconSize = BASE_ICON_SIZE,
 }) => {
   const getIcon = () => {
     if (loading) {
-      return <DialLoader />;
+      return <DialLoader size={iconSize} />;
     }
     return (
       <DialIcon
-        icon={<IconFolder {...BASE_ICON_PROPS} />}
+        icon={<IconFolder {...BASE_ICON_PROPS} size={iconSize} />}
         className="inline-block align-middle"
       />
     );


### PR DESCRIPTION
**Description:**

Enlarge file manager items icon size 18->20

Issues:

- Issue #114 

**UI changes**

<img width="785" height="524" alt="image" src="https://github.com/user-attachments/assets/cd55e3ff-6231-49e5-9dcd-46ddd5a44ee7" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added