### PR TITLE
fix: remove tailwind base layer from ui-kit build

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react-vite';
+import './preview.css';
 import '../src/index.css';
 
 const preview: Preview = {

--- a/src/styles/scroll.scss
+++ b/src/styles/scroll.scss
@@ -1,30 +1,28 @@
-@layer base {
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-track:hover,
-  ::-webkit-scrollbar-corner,
-  :not(:hover)::-webkit-scrollbar-thumb {
-    @apply bg-transparent;
-  }
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-track:hover,
+::-webkit-scrollbar-corner,
+:not(:hover)::-webkit-scrollbar-thumb {
+  @apply bg-transparent;
+}
 
-  ::-webkit-scrollbar-thumb {
-    @apply cursor-pointer rounded bg-layer-4;
-  }
+::-webkit-scrollbar-thumb {
+  @apply cursor-pointer rounded bg-layer-4;
+}
 
-  ::-webkit-scrollbar {
-    @apply h-[4px] w-[4px];
-  }
+::-webkit-scrollbar {
+  @apply h-[4px] w-[4px];
+}
 
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
-  }
+* {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
 
-  :hover {
-    scrollbar-color: var(--bg-layer-4, #333942) transparent;
-  }
+:hover {
+  scrollbar-color: var(--bg-layer-4, #333942) transparent;
+}
 
-  .divide-y > :empty ~ :not([hidden]) {
-    border-top: none;
-    border-bottom: none;
-  }
+.divide-y > :empty ~ :not([hidden]) {
+  border-top: none;
+  border-bottom: none;
 }

--- a/src/styles/tailwind-entry.scss
+++ b/src/styles/tailwind-entry.scss
@@ -7,9 +7,3 @@
 @import './popup.scss';
 @import './ag-grid.scss';
 @import './steps.scss';
-
-@layer ui {
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
-}


### PR DESCRIPTION
**Description:**

Removes Tailwind base/components/utilities from the compiled UI-kit CSS so that only the host application provides Tailwind, preventing duplicated utilities and cascade issues.


_Problem in the chat application:_
A UI element that should become display: inline on larger screens remains display: none.
DevTools shows that Tailwind utilities are duplicated in the final CSS bundle, producing conflicting rules:
<img width="506" height="42" alt="image" src="https://github.com/user-attachments/assets/70cd5637-1531-4343-b269-a4c2b018b3a6" />
<img width="408" height="177" alt="image" src="https://github.com/user-attachments/assets/4dae5923-80e4-446b-9642-7efecc1a7f2f" />
<img width="403" height="56" alt="image" src="https://github.com/user-attachments/assets/f66401af-f0ca-4792-9a37-3127cc0b55b1" />


Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added