### PR TITLE
chore: rename `Alert` and `DraggableItem` props to standard naming (Issue #249)

### DIFF
--- a/src/components/Alert/Alert.spec.tsx
+++ b/src/components/Alert/Alert.spec.tsx
@@ -24,8 +24,8 @@ describe('Dial UI Kit :: DialAlert', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('Should apply custom cssClass', () => {
-    render(<DialAlert message="Styled" cssClass="custom-alert-class" />);
+  test('Should apply custom className', () => {
+    render(<DialAlert message="Styled" className="custom-alert-class" />);
     const alert = screen.getByRole('alert');
     expect(alert).toHaveClass('custom-alert-class');
   });

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
       control: { type: 'text' },
       description: 'Message text displayed inside the alert',
     },
-    cssClass: {
+    className: {
       control: { type: 'text' },
       description: 'Additional CSS classes applied to the alert container',
     },
@@ -98,7 +98,7 @@ export const CustomClass: Story = {
   args: {
     variant: AlertVariant.Info,
     message: 'Alert with custom CSS class',
-    cssClass: 'border-dashed w-[250px] bg-layer-2',
+    className: 'border-dashed w-[250px] bg-layer-2',
   },
   parameters: {
     docs: {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -6,15 +6,15 @@ import { DialIcon } from '@/components/Icon/Icon';
 import { DialButton } from '@/components/Button/Button';
 import { AlertVariant } from '@/types/alert';
 import {
-  alertBaseClasses,
-  alertVariantClassMap,
+  alertBaseClassName,
+  alertVariantClassNameMap,
   variantIcons,
 } from './constants';
 
 export interface DialAlertProps {
   variant?: AlertVariant;
   message: string | ReactNode;
-  cssClass?: string;
+  className?: string;
   closable?: boolean;
   onClose?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
@@ -47,14 +47,14 @@ export interface DialAlertProps {
  *
  * @param [variant=AlertVariant.Info] - Defines the visual style and icon of the alert
  * @param message - Message text to display inside the alert
- * @param [cssClass] - Additional CSS classes applied to the alert container
+ * @param [className] - Additional CSS classes applied to the alert container
  * @param [closable=false] - Whether the alert has a close button
  * @param [onClose] - Callback fired when the close button is clicked
  */
 export const DialAlert: FC<DialAlertProps> = ({
   variant = AlertVariant.Info,
   message,
-  cssClass,
+  className,
   closable = false,
   onClose,
 }) => {
@@ -62,9 +62,9 @@ export const DialAlert: FC<DialAlertProps> = ({
     <div
       role="alert"
       className={classNames(
-        alertBaseClasses,
-        alertVariantClassMap[variant],
-        cssClass,
+        alertBaseClassName,
+        alertVariantClassNameMap[variant],
+        className,
       )}
     >
       <div className="flex items-center gap-2">
@@ -77,7 +77,7 @@ export const DialAlert: FC<DialAlertProps> = ({
           cssClass="ml-2 text-secondary hover:text-primary"
           ariaLabel="Close alert"
           iconBefore={<IconX size={16} />}
-          onClick={(e) => onClose?.(e)}
+          onClick={onClose}
         />
       )}
     </div>

--- a/src/components/Alert/constants.tsx
+++ b/src/components/Alert/constants.tsx
@@ -14,12 +14,12 @@ export const variantIcons: Record<AlertVariant, ReactNode> = {
   success: <IconCircleCheck size={24} stroke={2} />,
 };
 
-export const alertVariantClassMap: Record<AlertVariant, string> = {
+export const alertVariantClassNameMap: Record<AlertVariant, string> = {
   [AlertVariant.Info]: 'bg-info border-info text-info',
   [AlertVariant.Success]: 'bg-success border-success text-success',
   [AlertVariant.Warning]: 'bg-warning border-warning text-warning',
   [AlertVariant.Error]: 'bg-error border-error text-error',
 };
 
-export const alertBaseClasses =
+export const alertBaseClassName =
   'items-center justify-between gap-2 p-3 border border-solid dial-small-150 rounded flex';

--- a/src/components/DraggableItem/DraggableItem.spec.tsx
+++ b/src/components/DraggableItem/DraggableItem.spec.tsx
@@ -127,9 +127,9 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     expect(handle).toBeInTheDocument();
   });
 
-  test('applies custom cssClass to container', () => {
+  test('applies custom className to container', () => {
     render(
-      <DialDraggableItem id="id-3" cssClass="bg-red-500">
+      <DialDraggableItem id="id-3" className="bg-red-500">
         <span>Row</span>
       </DialDraggableItem>,
     );
@@ -155,7 +155,7 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     const moveItem = vi.fn();
 
     render(
-      <DialDraggableItem id="x-1" findItem={findItem} moveItem={moveItem}>
+      <DialDraggableItem id="x-1" onFind={findItem} onMove={moveItem}>
         <span>Row</span>
       </DialDraggableItem>,
     );
@@ -172,7 +172,7 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     const moveItem = vi.fn();
 
     render(
-      <DialDraggableItem id="x-2" findItem={findItem} moveItem={moveItem}>
+      <DialDraggableItem id="x-2" onFind={findItem} onMove={moveItem}>
         <span>Row</span>
       </DialDraggableItem>,
     );
@@ -189,7 +189,7 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     const moveItem = vi.fn();
 
     render(
-      <DialDraggableItem id="host" findItem={findItem} moveItem={moveItem}>
+      <DialDraggableItem id="host" onFind={findItem} onMove={moveItem}>
         <span>Host</span>
       </DialDraggableItem>,
     );
@@ -205,7 +205,7 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     const moveItem = vi.fn();
 
     render(
-      <DialDraggableItem id="same" findItem={findItem} moveItem={moveItem}>
+      <DialDraggableItem id="same" onFind={findItem} onMove={moveItem}>
         <span>Same</span>
       </DialDraggableItem>,
     );
@@ -221,7 +221,7 @@ describe('Dial UI Kit :: DialDraggableItem', () => {
     const moveItem = vi.fn();
 
     render(
-      <DialDraggableItem id="null-case" findItem={findItem} moveItem={moveItem}>
+      <DialDraggableItem id="null-case" onFind={findItem} onMove={moveItem}>
         <span>Row</span>
       </DialDraggableItem>,
     );

--- a/src/components/DraggableItem/DraggableItem.stories.tsx
+++ b/src/components/DraggableItem/DraggableItem.stories.tsx
@@ -23,16 +23,16 @@ const meta = {
   ],
   argTypes: {
     id: { control: { type: 'text' } },
-    cssClass: { control: { type: 'text' } },
-    handleAriaLabel: { control: { type: 'text' } },
-    findItem: { control: false },
-    moveItem: { control: false },
+    className: { control: { type: 'text' } },
+    ariaLabel: { control: { type: 'text' } },
+    onFind: { control: false },
+    onMove: { control: false },
     children: { control: { type: 'text' } },
   },
   args: {
     id: 'item-1',
     children: 'Draggable row',
-    handleAriaLabel: 'Drag item',
+    ariaLabel: 'Drag item',
   },
 } satisfies Meta<DialDraggableItemProps>;
 
@@ -85,8 +85,8 @@ const SortableListDemoExample: FC = () => {
           <div key={row.id} role="listitem" className="rounded border p-2">
             <DialDraggableItem
               id={row.id}
-              findItem={findItem}
-              moveItem={moveItem}
+              onFind={findItem}
+              onMove={moveItem}
             >
               <span className="text-sm">{row.label}</span>
             </DialDraggableItem>
@@ -103,6 +103,6 @@ export const SortableListDemo: Story = {
 
 export const WithCustomClass: Story = {
   args: {
-    cssClass: 'bg-accent-primary-alpha',
+    className: 'bg-accent-primary-alpha',
   },
 };

--- a/src/components/DraggableItem/DraggableItem.stories.tsx
+++ b/src/components/DraggableItem/DraggableItem.stories.tsx
@@ -83,11 +83,7 @@ const SortableListDemoExample: FC = () => {
       <div role="list" className="flex flex-col gap-2">
         {rows.map((row) => (
           <div key={row.id} role="listitem" className="rounded border p-2">
-            <DialDraggableItem
-              id={row.id}
-              onFind={findItem}
-              onMove={moveItem}
-            >
+            <DialDraggableItem id={row.id} onFind={findItem} onMove={moveItem}>
               <span className="text-sm">{row.label}</span>
             </DialDraggableItem>
           </div>

--- a/src/components/DraggableItem/DraggableItem.tsx
+++ b/src/components/DraggableItem/DraggableItem.tsx
@@ -3,9 +3,9 @@ import type { FC, ReactNode } from 'react';
 import { useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import {
-  containerBaseClasses,
+  containerBaseClassName,
   DRAG_TYPE,
-  handleBaseClasses,
+  handleBaseClassName,
 } from './constants';
 import { mergeClasses } from '@/utils/merge-classes';
 import { BASE_ICON_PROPS } from '@/constants/icon';
@@ -13,10 +13,10 @@ import { BASE_ICON_PROPS } from '@/constants/icon';
 export interface DialDraggableItemProps {
   id: string;
   children: ReactNode;
-  cssClass?: string;
-  findItem?: (field: string) => number;
-  moveItem?: (field: string, atIndex: number) => void;
-  handleAriaLabel?: string;
+  className?: string;
+  ariaLabel?: string;
+  onFind?: (field: string) => number;
+  onMove?: (field: string, atIndex: number) => void;
 }
 
 /**
@@ -35,23 +35,23 @@ export interface DialDraggableItemProps {
  *
  * @param id - Unique identifier of the draggable item
  * @param children - Content rendered within the draggable row
- * @param [cssClass] - Additional CSS classes applied to the root container
- * @param [findItem] - Function to resolve an item's current index by id
- * @param [moveItem] - Function to move an item (by id) to a target index
- * @param [handleAriaLabel='Drag item'] - Accessible label for the handle
+ * @param [className] - Additional CSS classes applied to the root container
+ * @param [onFind] - Function to resolve an item's current index by id
+ * @param [onMove] - Function to move an item (by id) to a target index
+ * @param [ariaLabel='Drag item'] - Accessible label for the handle
  */
 export const DialDraggableItem: FC<DialDraggableItemProps> = ({
   id,
   children,
-  cssClass,
-  findItem,
-  moveItem,
-  handleAriaLabel = 'Drag item',
+  className,
+  onFind,
+  onMove,
+  ariaLabel = 'Drag item',
 }) => {
   const dragRef = useRef<HTMLDivElement | null>(null);
   const dropRef = useRef<HTMLDivElement | null>(null);
 
-  const originalIndex = typeof findItem === 'function' ? findItem(id) : -1;
+  const originalIndex = typeof onFind === 'function' ? onFind(id) : -1;
 
   const [{ isDragging }, drag, preview] = useDrag(
     () => ({
@@ -68,14 +68,14 @@ export const DialDraggableItem: FC<DialDraggableItemProps> = ({
         const didDrop = monitor.didDrop();
         if (
           !didDrop &&
-          typeof moveItem === 'function' &&
+          typeof onMove === 'function' &&
           item.originalIndex > -1
         ) {
-          moveItem(item.id, item.originalIndex);
+          onMove(item.id, item.originalIndex);
         }
       },
     }),
-    [id, originalIndex, moveItem],
+    [id, originalIndex, onMove],
   );
 
   const [, drop] = useDrop(
@@ -83,13 +83,13 @@ export const DialDraggableItem: FC<DialDraggableItemProps> = ({
       accept: DRAG_TYPE,
       hover: (item: { id: string }) => {
         if (!item || item.id === id) return;
-        if (typeof findItem === 'function' && typeof moveItem === 'function') {
-          const index = findItem(id);
-          moveItem(item.id, index);
+        if (typeof onFind === 'function' && typeof onMove === 'function') {
+          const index = onFind(id);
+          onMove(item.id, index);
         }
       },
     }),
-    [findItem, moveItem, id],
+    [onFind, onMove, id],
   );
 
   preview(drop(dropRef));
@@ -98,15 +98,11 @@ export const DialDraggableItem: FC<DialDraggableItemProps> = ({
   return (
     <div
       ref={dropRef}
-      className={mergeClasses(containerBaseClasses, cssClass)}
+      className={mergeClasses(containerBaseClassName, className)}
       style={{ opacity: isDragging ? 0 : 1 }}
       aria-roledescription="Draggable item"
     >
-      <div
-        ref={dragRef}
-        className={handleBaseClasses}
-        aria-label={handleAriaLabel}
-      >
+      <div ref={dragRef} className={handleBaseClassName} aria-label={ariaLabel}>
         <IconGripVertical {...BASE_ICON_PROPS} />
       </div>
       {children}

--- a/src/components/DraggableItem/constants.tsx
+++ b/src/components/DraggableItem/constants.tsx
@@ -1,5 +1,5 @@
 export const DRAG_TYPE = 'column';
 
-export const containerBaseClasses = 'flex items-center';
+export const containerBaseClassName = 'flex items-center';
 
-export const handleBaseClasses = 'mr-3 cursor-move text-secondary';
+export const handleBaseClassName = 'mr-3 cursor-move text-secondary';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 export interface DialIconProps {
   icon?: ReactNode;
   className?: string;
-  label?: string;
 }
 
 /**

--- a/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
+++ b/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
@@ -38,7 +38,6 @@ export const DialSharedEntityIndicator: FC<DialSharedEntityIndicatorProps> = ({
   return (
     <DialIcon
       className={mergeClasses('text-accent-primary', cssClass)}
-      label="Shared entity indicator"
       icon={
         <IconArrowUpRight
           size={size}


### PR DESCRIPTION
**Description:**

**Alert**

1. rename `cssName` to `className`

**DraggableItem**
1. rename `cssName` to `className`
2. rename `findItem` to `onFind`
3. rename `moveItem` to `onMove`
4. rename  `handleAriaLabel` to `ariaLabel`


Issues:

- Issue #249

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added