### PR TITLE
chore: rename `DialBreadcrumbs` props to standard naming (Issue #249)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,10 +52,16 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
+          args: 'all',
           argsIgnorePattern: '^_',
-          varsIgnorePattern: '^__',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
         },
       ],
+
       '@typescript-eslint/no-explicit-any': 'warn',
       'react-refresh/only-export-components': 'error',
       'prettier/prettier': 'error',

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -10,10 +10,10 @@ const meta = {
   argTypes: {
     separator: { control: { type: 'text' } },
     ariaLabel: { control: { type: 'text' } },
-    cssClass: { control: { type: 'text' } },
+    className: { control: { type: 'text' } },
     pathItems: { control: false },
     children: { control: false },
-    titleCssClass: { control: { type: 'text' } },
+    titleClassName: { control: { type: 'text' } },
   },
   args: {
     ariaLabel: 'Breadcrumb',
@@ -119,7 +119,7 @@ export const LongLabelsTruncate: Story = {
           },
           { title: 'Current Page With A Long Name' },
         ]}
-        titleCssClass="max-w-[80px]"
+        titleClassName="max-w-[80px]"
       />
     </div>
   ),

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,12 +2,12 @@ import type { FC, MouseEvent, ReactNode } from 'react';
 import { Children, isValidElement, useMemo, useCallback } from 'react';
 import { mergeClasses } from '@/utils/merge-classes';
 import {
-  breadcrumbBaseClasses,
-  breadcrumbListClasses,
+  breadcrumbBaseClassName,
+  breadcrumbListClassName,
   defaultSeparator,
-  breadcrumbItemBaseClasses,
-  breadcrumbSeparatorClasses,
-  breadcrumbEllipsisButtonClasses,
+  breadcrumbItemBaseClassName,
+  breadcrumbSeparatorClassName,
+  breadcrumbEllipsisButtonClassName,
 } from './constants';
 import {
   DialBreadcrumbItem,
@@ -22,9 +22,9 @@ export interface DialBreadcrumbProps {
   pathItems?: DialBreadcrumbPathItem[];
   separator?: ReactNode;
   ariaLabel?: string;
-  cssClass?: string;
+  className?: string;
   children?: ReactNode;
-  titleCssClass?: string;
+  titleClassName?: string;
 }
 
 /**
@@ -50,20 +50,20 @@ export interface DialBreadcrumbProps {
  * </DialBreadcrumb>
  * ```
  *
- * @param pathItems - Array of breadcrumb pathItems (see `DialBreadcrumbItem`).
- * @param separator - Custom separator node (default: right chevron icon).
- * @param ariaLabel - Aria label for the `<nav>` element (default: "Breadcrumb").
- * @param cssClass - Additional CSS classes for the `<nav>` container.
- * @param children - Alternatively, compose with `<DialBreadcrumbItem/>` as children.
- * @param titleCssClass - Additional CSS classes applied to each item when using `pathItems` prop.
+ * @param [pathItems] - Array of breadcrumb pathItems (see `DialBreadcrumbItem`).
+ * @param [separator] - Custom separator node (default: right chevron icon).
+ * @param [ariaLabel] - Aria label for the `<nav>` element (default: "Breadcrumb").
+ * @param [className] - Additional CSS classes for the `<nav>` container.
+ * @param [children] - Alternatively, compose with `<DialBreadcrumbItem/>` as children.
+ * @param [titleClassName] - Additional CSS classes applied to each item when using `pathItems` prop.
  */
 export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
   pathItems,
   separator = defaultSeparator,
   ariaLabel = 'Breadcrumb',
-  cssClass,
+  className,
   children,
-  titleCssClass,
+  titleClassName,
 }) => {
   const items = useMemo(() => {
     if (pathItems?.length) {
@@ -72,15 +72,9 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
     return Children.toArray(children)
       .filter(isValidElement)
       .map((child) => {
-        const props = child.props as DialBreadcrumbItemProps;
-        return {
-          title: props.title,
-          href: props.href,
-          onClick: props.onClick,
-          disabled: props.disabled,
-          iconBefore: props.iconBefore,
-          cssClass: props.cssClass,
-        };
+        const childProps = child.props as DialBreadcrumbItemProps;
+        const { titleClassName, isLast, separator, ...props } = childProps;
+        return props;
       });
   }, [pathItems, children]);
 
@@ -107,7 +101,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           key={`item-${index}`}
           isLast={index === items.length - 1}
           separator={separator}
-          titleCssClass={titleCssClass}
+          titleClassName={titleClassName}
         />
       ));
     }
@@ -131,10 +125,10 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           {...first}
           key="item-0"
           separator={separator}
-          titleCssClass={titleCssClass}
+          titleClassName={titleClassName}
         />
 
-        <li className={mergeClasses(breadcrumbItemBaseClasses)}>
+        <li className={mergeClasses(breadcrumbItemBaseClassName)}>
           <DialDropdown
             menu={{
               items: dropdownItems,
@@ -146,19 +140,19 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
             <button
               type="button"
               aria-label="More breadcrumbs"
-              className={breadcrumbEllipsisButtonClasses}
+              className={breadcrumbEllipsisButtonClassName}
             >
               <IconDots size={16} />
             </button>
           </DialDropdown>
-          <span className={breadcrumbSeparatorClasses}>{separator}</span>
+          <span className={breadcrumbSeparatorClassName}>{separator}</span>
         </li>
 
         <DialBreadcrumbItem
           {...preLast}
           key={`item-${items.length - 2}`}
           separator={separator}
-          titleCssClass={titleCssClass}
+          titleClassName={titleClassName}
         />
 
         <DialBreadcrumbItem
@@ -166,18 +160,18 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           key={`item-${items.length - 1}`}
           isLast
           separator={separator}
-          titleCssClass={titleCssClass}
+          titleClassName={titleClassName}
         />
       </>
     );
-  }, [items, separator, titleCssClass, handleDropdownItemClick]);
+  }, [items, separator, titleClassName, handleDropdownItemClick]);
 
   return (
     <nav
       aria-label={ariaLabel}
-      className={mergeClasses(breadcrumbBaseClasses, cssClass)}
+      className={mergeClasses(breadcrumbBaseClassName, className)}
     >
-      <ol className={breadcrumbListClasses}>{content}</ol>
+      <ol className={breadcrumbListClassName}>{content}</ol>
     </nav>
   );
 };

--- a/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
@@ -51,7 +51,7 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
   test('adds custom classes to container and title element', () => {
     render(
       <ul>
-        <DialBreadcrumbItem title="Styled" href="#s" cssClass="dial-small" />
+        <DialBreadcrumbItem title="Styled" href="#s" className="dial-small" />
       </ul>,
     );
     const link = screen.getByRole('link', { name: 'Styled' });

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -1,14 +1,14 @@
 import type { FC, MouseEventHandler, ReactNode } from 'react';
 import { mergeClasses } from '@/utils/merge-classes';
 import {
-  breadcrumbItemBaseClasses,
-  breadcrumbLinkBaseClasses,
-  breadcrumbLinkInteractiveClasses,
-  breadcrumbCurrentClasses,
-  breadcrumbSeparatorClasses,
+  breadcrumbItemBaseClassName,
+  breadcrumbLinkBaseClassName,
+  breadcrumbLinkInteractiveClassName,
+  breadcrumbCurrentClassName,
+  breadcrumbSeparatorClassName,
   defaultSeparator,
-  breadcrumbItemVisibleClasses,
-  breadcrumbItemLastClasses,
+  breadcrumbItemVisibleClassName,
+  breadcrumbItemLastClassName,
 } from './constants';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 
@@ -18,8 +18,8 @@ export interface DialBreadcrumbItemProps {
   onClick?: MouseEventHandler<HTMLAnchorElement>;
   disabled?: boolean;
   iconBefore?: ReactNode;
-  cssClass?: string;
-  titleCssClass?: string;
+  className?: string;
+  titleClassName?: string;
   isLast?: boolean;
   separator?: ReactNode;
 }
@@ -31,33 +31,36 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
   disabled,
   isLast,
   separator = defaultSeparator,
-  cssClass,
+  className,
   iconBefore,
-  titleCssClass,
+  titleClassName,
 }) => {
-  const containerClasses = mergeClasses(
-    breadcrumbItemBaseClasses,
-    isLast ? breadcrumbItemLastClasses : breadcrumbItemVisibleClasses,
-    cssClass,
+  const containerClassName = mergeClasses(
+    breadcrumbItemBaseClassName,
+    isLast ? breadcrumbItemLastClassName : breadcrumbItemVisibleClassName,
+    className,
   );
   const interactive = (!!href || !!onClick) && !isLast && !disabled;
 
   const contentClassNames = interactive
-    ? mergeClasses(breadcrumbLinkBaseClasses, breadcrumbLinkInteractiveClasses)
+    ? mergeClasses(
+        breadcrumbLinkBaseClassName,
+        breadcrumbLinkInteractiveClassName,
+      )
     : mergeClasses(
-        breadcrumbLinkBaseClasses,
-        breadcrumbCurrentClasses,
+        breadcrumbLinkBaseClassName,
+        breadcrumbCurrentClassName,
         disabled ? 'pointer-events-none opacity-75' : '',
       );
 
   const Content =
     typeof title === 'string' ? (
-      <DialEllipsisTooltip cssClass={titleCssClass} text={title} />
+      <DialEllipsisTooltip cssClass={titleClassName} text={title} />
     ) : (
       <span
         className={mergeClasses(
           'flex-1 min-w-0 max-w-full truncate',
-          titleCssClass,
+          titleClassName,
         )}
       >
         {title}
@@ -65,7 +68,7 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
     );
 
   return (
-    <li className={containerClasses}>
+    <li className={containerClassName}>
       {interactive ? (
         <a href={href} onClick={onClick} className={contentClassNames}>
           {iconBefore}
@@ -83,7 +86,7 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
       )}
 
       {!isLast && (
-        <span className={breadcrumbSeparatorClasses}>{separator}</span>
+        <span className={breadcrumbSeparatorClassName}>{separator}</span>
       )}
     </li>
   );

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -1,28 +1,29 @@
 import type { ReactNode } from 'react';
 import { IconChevronRight } from '@tabler/icons-react';
 
-export const breadcrumbBaseClasses = 'w-full overflow-hidden';
-export const breadcrumbListClasses =
+export const breadcrumbBaseClassName = 'w-full overflow-hidden';
+export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
-export const breadcrumbItemBaseClasses =
+export const breadcrumbItemBaseClassName =
   'flex items-center gap-2 min-w-0 shrink-0 dial-small';
 
-export const breadcrumbItemVisibleClasses = 'max-w-[20%] basis-[20%] flex-none';
-export const breadcrumbItemLastClasses = 'flex-1 min-w-0';
+export const breadcrumbItemVisibleClassName =
+  'max-w-[20%] basis-[20%] flex-none';
+export const breadcrumbItemLastClassName = 'flex-1 min-w-0';
 
-export const breadcrumbLinkBaseClasses =
+export const breadcrumbLinkBaseClassName =
   'inline-flex items-center gap-1 min-w-0 transition-colors';
 
-export const breadcrumbLinkInteractiveClasses =
+export const breadcrumbLinkInteractiveClassName =
   'text-secondary hover:text-accent-primary';
 
-export const breadcrumbCurrentClasses = 'text-primary cursor-default';
+export const breadcrumbCurrentClassName = 'text-primary cursor-default';
 
-export const breadcrumbSeparatorClasses =
+export const breadcrumbSeparatorClassName =
   'flex-none inline-flex items-center leading-none text-icon-secondary';
 
-export const breadcrumbEllipsisButtonClasses =
+export const breadcrumbEllipsisButtonClassName =
   'items-center gap-1 min-w-0 transition-colors text-secondary hover:text-accent-primary';
 
 export const defaultSeparator: ReactNode = (

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.stories.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   parameters: { layout: 'fullscreen' },
   argTypes: {
     ariaLabel: { control: { type: 'text' } },
-    titleCssClass: { control: { type: 'text' } },
+    titleClassName: { control: { type: 'text' } },
     breadcrumbCssClass: { control: { type: 'text' } },
 
     path: { control: 'text' },

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
@@ -90,7 +90,7 @@ export const DialFileManagerNavigationPanel: FC<
   DialFileManagerNavigationPanelProps
 > = ({
   ariaLabel = 'Breadcrumb',
-  titleCssClass,
+  titleClassName,
   onItemClick,
 
   path,
@@ -173,8 +173,8 @@ export const DialFileManagerNavigationPanel: FC<
         <DialBreadcrumb
           pathItems={breadcrumbPathItems}
           ariaLabel={ariaLabel}
-          titleCssClass={titleCssClass}
-          cssClass={breadcrumbCssClass}
+          titleClassName={titleClassName}
+          className={breadcrumbCssClass}
         />
       </div>
 

--- a/src/models/breadcrumb.ts
+++ b/src/models/breadcrumb.ts
@@ -5,6 +5,6 @@ export interface DialBreadcrumbPathItem {
   href?: string;
   onClick?: (e: MouseEvent<HTMLAnchorElement>) => void;
   disabled?: boolean;
-  cssClass?: string;
+  className?: string;
   iconBefore?: ReactNode;
 }


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #249

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added