### PR TITLE
chore: rename `DialField` and `DialLoader` props to standard naming (Issue #249)

### DIFF
--- a/src/components/Field/Field.spec.tsx
+++ b/src/components/Field/Field.spec.tsx
@@ -64,7 +64,7 @@ describe('Dial UI Kit :: DialFieldLabel', () => {
       <DialFieldLabel
         fieldTitle="Styled Field"
         htmlFor="styled-input"
-        cssClass="custom-label-class"
+        className="custom-label-class"
       />,
     );
     const label = screen.getByText('Styled Field').closest('label');
@@ -79,24 +79,24 @@ describe('Dial UI Kit :: DialFieldLabel', () => {
     expect(label).toHaveClass('dial-tiny', 'text-secondary');
   });
 
-  test('Should apply default mb-2 class when cssClass does not include mb', () => {
+  test('Should apply default mb-2 class when className does not include mb', () => {
     render(
       <DialFieldLabel
         fieldTitle="Default Margin"
         htmlFor="margin-input"
-        cssClass="custom-class"
+        className="custom-class"
       />,
     );
     const label = screen.getByText('Default Margin').closest('label');
     expect(label).toHaveClass('mb-2');
   });
 
-  test('Should not apply mb-2 when cssClass includes mb', () => {
+  test('Should not apply mb-2 when className includes mb', () => {
     render(
       <DialFieldLabel
         fieldTitle="Custom Margin"
         htmlFor="custom-margin-input"
-        cssClass="mb-4 custom-class"
+        className="mb-4 custom-class"
       />,
     );
     const label = screen.getByText('Custom Margin').closest('label');
@@ -118,7 +118,7 @@ describe('Dial UI Kit :: DialFieldLabel', () => {
         htmlFor="full-input"
         optional
         optionalText="(Choose if needed)"
-        cssClass="special-label"
+        className="special-label"
       />,
     );
 

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -2,15 +2,15 @@ import { DialIcon } from '@/components/Icon/Icon';
 import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
 import { IconInfoCircle } from '@tabler/icons-react';
-import type { FC, ReactNode } from 'react';
+import type { FC, LabelHTMLAttributes, ReactNode } from 'react';
 
-export interface DialFieldLabelProps {
-  fieldTitle?: string | ReactNode;
-  htmlFor: string;
+type NativeLabelProps = Omit<LabelHTMLAttributes<HTMLLabelElement>, 'children'>;
+
+export interface DialFieldLabelProps extends NativeLabelProps {
+  fieldTitle?: ReactNode;
   optional?: boolean;
   optionalText?: string;
-  className?: string;
-  description?: string;
+  description?: ReactNode;
 }
 
 /**
@@ -22,35 +22,31 @@ export interface DialFieldLabelProps {
  * <DialFieldLabel htmlFor="email-input" fieldTitle="Email Address" />
  * ```
  *
- * @param htmlFor - The ID of the form element this label is associated with
  * @param [fieldTitle] - The title/label text to display for the field
  * @param [optional=false] - Whether the field is optional (displays "(Optional)" text if optionalText is not provided)
  * @param [optionalText="(Optional)"] - Custom text for optional indicator
- * @param [className] - Additional CSS classes to apply to the label element
  * @param [description] - Additional description text, displayed below the label.
  */
 export const DialFieldLabel: FC<DialFieldLabelProps> = ({
   fieldTitle,
-  htmlFor,
   optional,
   optionalText,
   className,
   description,
+  ...props
 }) => {
-  return fieldTitle ? (
+  if (!fieldTitle) return null;
+
+  return (
     <label
+      {...props}
       className={mergeClasses(
         'dial-tiny text-secondary flex gap-1',
         className,
         !className?.includes('mb') && 'mb-2',
       )}
-      htmlFor={htmlFor}
     >
-      {typeof fieldTitle === 'string' ? (
-        <span className="min-h-4">{fieldTitle}</span>
-      ) : (
-        fieldTitle
-      )}
+      <span className="min-h-4">{fieldTitle}</span>
       {optional && <span>{optionalText ?? '(Optional)'}</span>}
       {description && (
         <DialTooltip tooltip={description}>
@@ -60,5 +56,5 @@ export const DialFieldLabel: FC<DialFieldLabelProps> = ({
         </DialTooltip>
       )}
     </label>
-  ) : null;
+  );
 };

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -9,7 +9,7 @@ export interface DialFieldLabelProps {
   htmlFor: string;
   optional?: boolean;
   optionalText?: string;
-  cssClass?: string;
+  className?: string;
   description?: string;
 }
 
@@ -26,7 +26,7 @@ export interface DialFieldLabelProps {
  * @param [fieldTitle] - The title/label text to display for the field
  * @param [optional=false] - Whether the field is optional (displays "(Optional)" text if optionalText is not provided)
  * @param [optionalText="(Optional)"] - Custom text for optional indicator
- * @param [cssClass] - Additional CSS classes to apply to the label element
+ * @param [className] - Additional CSS classes to apply to the label element
  * @param [description] - Additional description text, displayed below the label.
  */
 export const DialFieldLabel: FC<DialFieldLabelProps> = ({
@@ -34,15 +34,15 @@ export const DialFieldLabel: FC<DialFieldLabelProps> = ({
   htmlFor,
   optional,
   optionalText,
-  cssClass,
+  className,
   description,
 }) => {
   return fieldTitle ? (
     <label
       className={mergeClasses(
         'dial-tiny text-secondary flex gap-1',
-        cssClass,
-        !cssClass?.includes('mb') && 'mb-2',
+        className,
+        !className?.includes('mb') && 'mb-2',
       )}
       htmlFor={htmlFor}
     >

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -7,7 +7,7 @@ import type { FC, LabelHTMLAttributes, ReactNode } from 'react';
 type NativeLabelProps = Omit<LabelHTMLAttributes<HTMLLabelElement>, 'children'>;
 
 export interface DialFieldLabelProps extends NativeLabelProps {
-  fieldTitle?: ReactNode;
+  fieldTitle?: string | ReactNode;
   optional?: boolean;
   optionalText?: string;
   description?: ReactNode;
@@ -46,7 +46,11 @@ export const DialFieldLabel: FC<DialFieldLabelProps> = ({
         !className?.includes('mb') && 'mb-2',
       )}
     >
-      <span className="min-h-4">{fieldTitle}</span>
+      {typeof fieldTitle === 'string' ? (
+        <span className="min-h-4">{fieldTitle}</span>
+      ) : (
+        fieldTitle
+      )}
       {optional && <span>{optionalText ?? '(Optional)'}</span>}
       {description && (
         <DialTooltip tooltip={description}>

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -166,7 +166,7 @@ export const DialFormItem: FC<DialFormItemProps> = ({
             fieldTitle={label}
             optional={optional}
             optionalText={optionalText}
-            cssClass={mergeClasses(
+            className={mergeClasses(
               labelVisuallyHidden && 'sr-only',
               labelCssClass,
             )}

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -34,13 +34,15 @@ describe('Dial UI Kit :: DialLoader', () => {
   });
 
   test('applies custom CSS class', () => {
-    render(<DialLoader cssClass="custom-class" />);
+    render(<DialLoader className="custom-class" />);
     const el = screen.getByRole('status');
     expect(el).toHaveClass('custom-class');
   });
 
   test('applies custom icon class', () => {
-    const { container } = render(<DialLoader iconClass="custom-icon-class" />);
+    const { container } = render(
+      <DialLoader iconClassName="custom-icon-class" />,
+    );
     const svg = container.querySelector('svg');
     expect(svg).toHaveClass('custom-icon-class');
   });

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -12,8 +12,11 @@ const meta = {
   },
   argTypes: {
     size: { control: { type: 'number' }, description: 'Icon size in px' },
-    cssClass: { control: { type: 'text' }, description: 'Container classes' },
-    iconClass: { control: { type: 'text' }, description: 'SVG icon classes' },
+    className: { control: { type: 'text' }, description: 'Container classes' },
+    iconClassName: {
+      control: { type: 'text' },
+      description: 'SVG icon classes',
+    },
     fullWidth: {
       control: { type: 'boolean' },
       description: 'Stretch to full width/height of container',
@@ -45,8 +48,8 @@ export const CustomSize: Story = {
 
 export const WithCustomClasses: Story = {
   args: {
-    iconClass: 'text-accent-primary',
-    cssClass: 'bg-layer-3',
+    iconClassName: 'text-accent-primary',
+    className: 'bg-layer-3',
     size: 28,
     fullWidth: false,
   },

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -2,13 +2,13 @@ import classNames from 'classnames';
 import type { FC } from 'react';
 
 import { DialIcon } from '@/components/Icon/Icon';
-import { loaderBaseClasses, loaderIconBaseClasses } from './constants';
+import { loaderBaseClassName, loaderIconBaseClassName } from './constants';
 import LoaderIcon from '@/assets/icons/loader.svg?react';
 
 export interface DialLoaderProps {
   size?: number;
-  cssClass?: string;
-  iconClass?: string;
+  className?: string;
+  iconClassName?: string;
   fullWidth?: boolean;
   ariaLabel?: string;
 }
@@ -27,19 +27,19 @@ export interface DialLoaderProps {
  * <DialLoader fullWidth={false} />
  *
  * // Custom size and classes
- * <DialLoader size={24} iconClass="text-accent-primary" />
+ * <DialLoader size={24} iconClassName="text-accent-primary" />
  * ```
  *
  * @param [size=18] - Icon size in px
- * @param [cssClass] - Additional classes for the container
- * @param [iconClass] - Additional classes for the SVG icon
+ * @param [className] - Additional classes for the container
+ * @param [iconClassName] - Additional classes for the SVG icon
  * @param [fullWidth=true] - Stretch to full width/height of container
  * @param [ariaLabel='Loading'] - Accessible label for screen readers
  */
 export const DialLoader: FC<DialLoaderProps> = ({
   size = 18,
-  cssClass,
-  iconClass,
+  className,
+  iconClassName,
   fullWidth = true,
   ariaLabel = 'Loading',
 }) => {
@@ -47,9 +47,9 @@ export const DialLoader: FC<DialLoaderProps> = ({
     <div
       role="status"
       className={classNames({
-        [loaderBaseClasses]: true,
+        [loaderBaseClassName]: true,
         ['w-full h-full']: fullWidth,
-        [cssClass || '']: !!cssClass,
+        [className || '']: !!className,
       })}
     >
       <DialIcon
@@ -57,7 +57,7 @@ export const DialLoader: FC<DialLoaderProps> = ({
           <LoaderIcon
             width={size}
             height={size}
-            className={classNames(loaderIconBaseClasses, iconClass)}
+            className={classNames(loaderIconBaseClassName, iconClassName)}
             role="img"
             aria-label={ariaLabel}
           />

--- a/src/components/Loader/constants.ts
+++ b/src/components/Loader/constants.ts
@@ -1,5 +1,5 @@
-export const loaderBaseClasses =
+export const loaderBaseClassName =
   'flex items-center justify-center text-secondary';
 
-export const loaderIconBaseClasses =
+export const loaderIconBaseClassName =
   'shrink-0 grow-0 basis-auto animate-spin-steps';


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #249

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added