### PR TITLE
fix: update class names for improved styling consistency in FoldersTree component

### DIFF
--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -195,7 +195,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
               <div
                 style={{ paddingLeft: `${level * FOLDER_LEVEL_PADDING}px` }}
                 className={mergeClasses(
-                  'py-1 gap-[2px] dial-small flex justify-between hover:bg-accent-primary-alpha rounded group w-full mb-[2px] relative',
+                  'py-1 gap-[2px] dial-small flex justify-between hover:bg-accent-primary-alpha rounded group/item w-full mb-[2px] relative',
                   selectedClass,
                 )}
               >
@@ -243,7 +243,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                       className="sticky right-0"
                     >
                       <DialIcon
-                        className="invisible group-hover:visible text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary"
+                        className="invisible group-hover/item:visible text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary"
                         icon={<IconDotsVertical {...BASE_ICON_PROPS} />}
                       />
                     </DialDropdown>


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="924" height="186" alt="image" src="https://github.com/user-attachments/assets/cee4ae93-73f7-45fd-a88c-db20d31a8f63" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added