### PR TITLE
feat(dropdown): add header item and custom button class support in Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -136,6 +136,54 @@ describe('Dial UI Kit :: Dropdown', () => {
     expect(menuEl).toHaveClass('w-max');
   });
 
+  test('renders header item type correctly', () => {
+    const itemsWithHeader: DropdownItem[] = [
+      { key: 'item1', label: 'Item 1' },
+      { key: 'd1', type: DropdownItemType.Divider },
+      {
+        key: 'h1',
+        type: DropdownItemType.Header,
+        label: <span>Section Title</span>,
+      },
+      { key: 'item2', label: 'Item 2' },
+    ];
+    render(
+      <DialDropdown menu={{ items: itemsWithHeader }}>
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+    openByClick();
+    expect(screen.getByText('Section Title')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Item 1' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Item 2' }),
+    ).toBeInTheDocument();
+  });
+
+  test('header item does not act as clickable menuitem', () => {
+    const onMenu = vi.fn();
+    const itemsWithHeader: DropdownItem[] = [
+      { key: 'item1', label: 'Item 1' },
+      {
+        key: 'h1',
+        type: DropdownItemType.Header,
+        label: <span>Section Header</span>,
+      },
+    ];
+    render(
+      <DialDropdown menu={{ items: itemsWithHeader, onClick: onMenu }}>
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+    openByClick();
+    const headerElement = screen.getByText('Section Header');
+    fireEvent.click(headerElement);
+    expect(onMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
   test('outsideClosable=false keeps menu open on outside press', () => {
     render(
       <DialDropdown outsideClosable={false} menu={{ items }}>

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -142,7 +142,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       { key: 'd1', type: DropdownItemType.Divider },
       {
         key: 'h1',
-        type: DropdownItemType.Header,
+        type: DropdownItemType.PlainText,
         label: <span>Section Title</span>,
       },
       { key: 'item2', label: 'Item 2' },
@@ -168,7 +168,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       { key: 'item1', label: 'Item 1' },
       {
         key: 'h1',
-        type: DropdownItemType.Header,
+        type: DropdownItemType.PlainText,
         label: <span>Section Header</span>,
       },
     ];

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -417,14 +417,13 @@ export const DropdownDynamicButtons: Story = {
     const baseItems: DropdownItem[] = [
       {
         key: 'header1',
-        type: DropdownItemType.Header,
+        type: DropdownItemType.PlainText,
         label: 'First Section',
       },
       {
         key: 'normal',
         label: 'Normal Item',
-        buttonClassName:
-          selectedFirstSection === 'normal' ? borderCss : undefined,
+        className: selectedFirstSection === 'normal' ? borderCss : undefined,
         onClick: () => {
           setSelectedFirstSection('normal');
         },
@@ -432,8 +431,7 @@ export const DropdownDynamicButtons: Story = {
       {
         key: 'custom',
         label: 'Custom Styled Item',
-        buttonClassName:
-          selectedFirstSection === 'custom' ? borderCss : undefined,
+        className: selectedFirstSection === 'custom' ? borderCss : undefined,
         onClick: () => {
           setSelectedFirstSection('custom');
         },
@@ -441,7 +439,7 @@ export const DropdownDynamicButtons: Story = {
       {
         key: 'withSubsection',
         label: 'Item with Subsection',
-        buttonClassName:
+        className:
           selectedFirstSection === 'withSubsection' ? borderCss : undefined,
         onClick: (info) => {
           info.domEvent.preventDefault();
@@ -458,13 +456,13 @@ export const DropdownDynamicButtons: Story = {
             { key: 'd1', type: DropdownItemType.Divider },
             {
               key: 'header2',
-              type: DropdownItemType.Header,
+              type: DropdownItemType.PlainText,
               label: 'Subsection',
             },
             {
               key: 'subsection1',
               label: 'Subsection Item 1',
-              buttonClassName:
+              className:
                 selectedSecondSection === 'subsection1' ? borderCss : undefined,
               onClick: () => {
                 setSelectedSecondSection('subsection1');
@@ -473,7 +471,7 @@ export const DropdownDynamicButtons: Story = {
             {
               key: 'subsection2',
               label: 'Subsection Item 2',
-              buttonClassName:
+              className:
                 selectedSecondSection === 'subsection2' ? borderCss : undefined,
               onClick: () => {
                 setSelectedSecondSection('subsection2');

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 import type { Placement } from '@floating-ui/react';
@@ -398,4 +399,102 @@ export const CompareWidthModes: Story = {
       </DialDropdown>
     </div>
   ),
+};
+
+export const DropdownDynamicButtons: Story = {
+  name: 'With dynamic button items and styles',
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    const [selectedFirstSection, setSelectedFirstSection] = useState<
+      string | null
+    >('custom');
+    const [selectedSecondSection, setSelectedSecondSection] = useState<
+      string | null
+    >('subsection1');
+    const [showSubsection, setShowSubsection] = useState(false);
+    const borderCss = 'border-l-2 border-accent-primary pl-2 rounded-l-none';
+
+    const baseItems: DropdownItem[] = [
+      {
+        key: 'header1',
+        type: DropdownItemType.Header,
+        label: 'First Section',
+      },
+      {
+        key: 'normal',
+        label: 'Normal Item',
+        buttonClassName:
+          selectedFirstSection === 'normal' ? borderCss : undefined,
+        onClick: () => {
+          setSelectedFirstSection('normal');
+        },
+      },
+      {
+        key: 'custom',
+        label: 'Custom Styled Item',
+        buttonClassName:
+          selectedFirstSection === 'custom' ? borderCss : undefined,
+        onClick: () => {
+          setSelectedFirstSection('custom');
+        },
+      },
+      {
+        key: 'withSubsection',
+        label: 'Item with Subsection',
+        buttonClassName:
+          selectedFirstSection === 'withSubsection' ? borderCss : undefined,
+        onClick: (info) => {
+          info.domEvent.preventDefault();
+          setSelectedFirstSection('withSubsection');
+          setShowSubsection(true);
+          setTimeout(() => setOpen(true), 0);
+        },
+      },
+    ];
+
+    const subsectionItems: DropdownItem[] =
+      showSubsection && selectedFirstSection === 'withSubsection'
+        ? [
+            { key: 'd1', type: DropdownItemType.Divider },
+            {
+              key: 'header2',
+              type: DropdownItemType.Header,
+              label: 'Subsection',
+            },
+            {
+              key: 'subsection1',
+              label: 'Subsection Item 1',
+              buttonClassName:
+                selectedSecondSection === 'subsection1' ? borderCss : undefined,
+              onClick: () => {
+                setSelectedSecondSection('subsection1');
+              },
+            },
+            {
+              key: 'subsection2',
+              label: 'Subsection Item 2',
+              buttonClassName:
+                selectedSecondSection === 'subsection2' ? borderCss : undefined,
+              onClick: () => {
+                setSelectedSecondSection('subsection2');
+              },
+            },
+          ]
+        : [];
+
+    const items = [...baseItems, ...subsectionItems];
+
+    return (
+      <DialDropdown
+        {...args}
+        open={open}
+        onOpenChange={setOpen}
+        onClose={() => setOpen(false)}
+        placement="bottom"
+        menu={{ items }}
+      >
+        <TriggerBtn label="Dynamic items" />
+      </DialDropdown>
+    );
+  },
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -332,6 +332,16 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                 />
               );
             }
+            if (it.type === DropdownItemType.Header) {
+              return (
+                <div
+                  key={it.key}
+                  className="px-3 py-2 text-secondary dial-caption"
+                >
+                  {it.label}
+                </div>
+              );
+            }
             return (
               <button
                 key={it.key}
@@ -342,6 +352,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                   dropdownItemBaseClassName,
                   it.disabled && dropdownItemDisabledClassName,
                   it.danger && dropdownItemDangerClassName,
+                  it.buttonClassName,
                 )}
                 disabled={it.disabled}
                 onClick={handleItemClick(it)}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -44,6 +44,7 @@ import {
 import { type DropdownItem } from '@/models/dropdown';
 import { DialCloseButton } from '@/components/CloseButton/CloseButton';
 import { DropdownItemType } from '@/types/dropdown';
+import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DropdownMenuProps {
   items: DropdownItem[];
@@ -332,11 +333,14 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                 />
               );
             }
-            if (it.type === DropdownItemType.Header) {
+            if (it.type === DropdownItemType.PlainText) {
               return (
                 <div
                   key={it.key}
-                  className="px-3 py-2 text-secondary dial-caption"
+                  className={mergeClasses(
+                    'px-3 py-2 text-secondary dial-caption',
+                    it.className,
+                  )}
                 >
                   {it.label}
                 </div>
@@ -352,7 +356,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                   dropdownItemBaseClassName,
                   it.disabled && dropdownItemDisabledClassName,
                   it.danger && dropdownItemDangerClassName,
-                  it.buttonClassName,
+                  it.className,
                 )}
                 disabled={it.disabled}
                 onClick={handleItemClick(it)}

--- a/src/models/dropdown.ts
+++ b/src/models/dropdown.ts
@@ -8,5 +8,6 @@ export interface DropdownItem {
   disabled?: boolean;
   danger?: boolean;
   type?: DropdownItemType;
+  buttonClassName?: string;
   onClick?: (info: { key: string; domEvent: MouseEvent }) => void;
 }

--- a/src/models/dropdown.ts
+++ b/src/models/dropdown.ts
@@ -8,6 +8,6 @@ export interface DropdownItem {
   disabled?: boolean;
   danger?: boolean;
   type?: DropdownItemType;
-  buttonClassName?: string;
+  className?: string;
   onClick?: (info: { key: string; domEvent: MouseEvent }) => void;
 }

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -12,5 +12,5 @@ export enum DropdownTrigger {
 export enum DropdownItemType {
   Item = 'item',
   Divider = 'divider',
-  Header = 'header',
+  PlainText = 'plainText',
 }

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -12,4 +12,5 @@ export enum DropdownTrigger {
 export enum DropdownItemType {
   Item = 'item',
   Divider = 'divider',
+  Header = 'header',
 }


### PR DESCRIPTION
**Description:**

- Implemented rendering for plain text items in the Dropdown component
- Updated DropdownItem interface to include className

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="355" height="307" alt="image" src="https://github.com/user-attachments/assets/bec00f0b-876c-47ba-b705-905d6a5a7144" />
<img width="321" height="404" alt="image" src="https://github.com/user-attachments/assets/ecdce35c-d674-4f1d-b918-3fbdd29b60e4" />


**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added