### PR TITLE
feat(FileManager): add long folder name mock and improve text wrapping in delete confirmation popup

### DIFF
--- a/src/components/FileManager/__mocks__/files.ts
+++ b/src/components/FileManager/__mocks__/files.ts
@@ -357,6 +357,16 @@ export const itemsMock: DialFile[] = [
               },
             ],
           },
+          {
+            id: 'long-name-without-spaces-design-folder-to-test-ui-behavior',
+            name: 'ThisIsAVeryLongFolderNameWithoutSpacesToTestTheUIBehaviorInDifferentComponents.png',
+            path: '/All files/Design/ThisIsAVeryLongFolderNameWithoutSpacesToTestTheUIBehaviorInDifferentComponents',
+            parentPath: '/All files/Design',
+            nodeType: DialFileNodeType.ITEM,
+            folderId: 'design',
+            updatedAt: '2025-01-11',
+            items: [],
+          },
         ],
       },
 

--- a/src/components/FileManager/components/FileManagerDeleteConfirmationPopup/FileManagerDeleteConfirmationPopup.tsx
+++ b/src/components/FileManager/components/FileManagerDeleteConfirmationPopup/FileManagerDeleteConfirmationPopup.tsx
@@ -50,7 +50,10 @@ export const FileManagerDeleteConfirmationPopup: FC<
         {itemsToDelete.length === 1 ? (
           <>
             Do you want to delete file or folder{' '}
-            <span className="text-primary">"{itemsToDelete[0].name}"</span>?
+            <span className="text-primary break-all">
+              "{itemsToDelete[0].name}"
+            </span>
+            ?
           </>
         ) : (
           <>


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="885" height="643" alt="image" src="https://github.com/user-attachments/assets/89139bfa-af26-42e4-90f9-0cf83b057fd9" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added