### PR TITLE
feat: set fixed height for DestinationFolderPopup (Issue #114)

### DIFF
--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -103,6 +103,7 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
         onClose();
       }}
       size={PopupSize.Lg}
+      className={'md:!h-[800px]'}
       footer={
         <div className="flex justify-between space-x-2 py-4 px-6">
           <div className="flex space-x-4">


### PR DESCRIPTION
**Description:**

set fixed height for DestinationFolderPopup

Issues:

- Issue #114 

**UI changes**

<img width="1224" height="888" alt="image" src="https://github.com/user-attachments/assets/15aeba1e-ae66-4480-a60c-dd2e6c5aa3f0" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added