### PR TITLE
feat: stop scrolling FoldersTree. adjust styles of ResizableContainer (Issue #114)

### DIFF
--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -189,7 +189,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
 
       return (
         <div key={`${path}-children`} className="cursor-pointer text-secondary">
-          <div className="flex flex-col min-w-fit w-full">
+          <div className="flex flex-col w-full">
             <DialDropdown
               trigger={[DropdownTrigger.ContextMenu]}
               className="w-full"

--- a/src/components/ResizableContainer/ResizableContainer.spec.tsx
+++ b/src/components/ResizableContainer/ResizableContainer.spec.tsx
@@ -28,9 +28,7 @@ describe('Dial UI Kit :: DialResizableContainer', () => {
 
     expect(screen.getByText('Left content')).toBeInTheDocument();
 
-    const handle = document.querySelector(
-      '[style*="left: -3px"]',
-    ) as HTMLElement;
+    const handle = document.querySelector('[style*="left: 0"]') as HTMLElement;
     expect(handle).toBeInTheDocument();
   });
 

--- a/src/components/ResizableContainer/ResizableContainer.tsx
+++ b/src/components/ResizableContainer/ResizableContainer.tsx
@@ -144,8 +144,8 @@ export const DialResizableContainer: FC<DialResizableContainerProps> = ({
         left: 'group',
       },
       handleStyles: {
-        right: { right: '-11px' },
-        left: { left: '-3px' },
+        right: { right: '-8px', zIndex: 10 },
+        left: { left: 0, zIndex: 10 },
       },
       handleComponent: {
         left: isLeft ? handleComponent : undefined,


### PR DESCRIPTION
**Description:**

Stop scrolling FoldersTree. adjust styles of ResizableContainer.

Issues:

- Issue #114

**UI changes**

<img width="1210" height="614" alt="image" src="https://github.com/user-attachments/assets/7373d34f-7d8d-426b-8e61-0815411c52cf" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added