### PR TITLE
feat: disable collapse-all button whe there is no any expanded-path (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -31,10 +31,9 @@ import {
 import type { DialFileManagerProps } from './FileManager';
 import { useItemRenaming } from './hooks/use-item-renaming';
 import { useExpandedPaths } from './components/FoldersTree/hooks/use-expanded-paths';
-import { IconCopyMinus } from '@tabler/icons-react';
-import { DialButton } from '@/components/Button/Button';
 import { useNewActions } from './hooks/use-new-actions';
 import { useFolderCreation } from './hooks/use-folder-creation';
+import { useTreeAdditionalButtons } from '@/components/FileManager/hooks/use-tree-additional-buttons';
 
 /**
  * Formats bytes into a short, human-readable string.
@@ -406,6 +405,12 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     onExpandedPathsChange: treeOptions?.onExpandedPathsChange,
   });
 
+  const { additionalButtons } = useTreeAdditionalButtons({
+    collapseAll,
+    expandedPathsLength: expandedPaths.size,
+    additionalButtons: treeOptions?.additionalButtons,
+  });
+
   const value: FileManagerContextValue = {
     className,
     items,
@@ -415,16 +420,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       ...treeOptions,
       expandedPaths,
       onExpandedPathsChange: setExpandedPaths,
-      additionalButtons: (
-        <>
-          {treeOptions?.additionalButtons}
-          <DialButton
-            className="hover:text-accent-primary p-1"
-            onClick={collapseAll}
-            iconBefore={<IconCopyMinus size={24} stroke={1.5} />}
-          />
-        </>
-      ),
+      additionalButtons,
     },
     navigationPanelOptions,
     gridOptions,

--- a/src/components/FileManager/hooks/__tests__/use-tree-additional-buttons.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-tree-additional-buttons.spec.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { useTreeAdditionalButtons } from '../use-tree-additional-buttons';
+import React from 'react';
+
+describe('Dial UI Kit :: FileManager :: useTreeAdditionalButtons', () => {
+  it('renders additionalButtons when provided', () => {
+    const Custom = () => <div>CustomButton</div>;
+
+    const { result } = renderHook(() =>
+      useTreeAdditionalButtons({
+        additionalButtons: <Custom />,
+        expandedPathsLength: 1,
+        collapseAll: vi.fn(),
+      }),
+    );
+
+    const { getByText } = render(result.current.additionalButtons);
+
+    expect(getByText('CustomButton')).toBeInTheDocument();
+  });
+
+  it('renders the collapse button', () => {
+    const { result } = renderHook(() =>
+      useTreeAdditionalButtons({
+        expandedPathsLength: 1,
+        collapseAll: vi.fn(),
+      }),
+    );
+
+    const { container } = render(result.current.additionalButtons);
+
+    const button = container.querySelector('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('disables the collapse button when expandedPathsLength is 0', () => {
+    const { result } = renderHook(() =>
+      useTreeAdditionalButtons({
+        expandedPathsLength: 0,
+        collapseAll: vi.fn(),
+      }),
+    );
+
+    const { container } = render(result.current.additionalButtons);
+
+    const button = container.querySelector('button')!;
+    expect(button).toBeDisabled();
+  });
+
+  it('enables the collapse button when expandedPathsLength > 0', () => {
+    const { result } = renderHook(() =>
+      useTreeAdditionalButtons({
+        expandedPathsLength: 3,
+        collapseAll: vi.fn(),
+      }),
+    );
+
+    const { container } = render(result.current.additionalButtons);
+
+    const button = container.querySelector('button')!;
+    expect(button).not.toBeDisabled();
+  });
+
+  it('calls collapseAll when clicking the collapse button', () => {
+    const collapseAll = vi.fn();
+
+    const { result } = renderHook(() =>
+      useTreeAdditionalButtons({
+        expandedPathsLength: 2,
+        collapseAll,
+      }),
+    );
+
+    const { container } = render(result.current.additionalButtons);
+
+    const button = container.querySelector('button')!;
+    fireEvent.click(button);
+
+    expect(collapseAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FileManager/hooks/use-tree-additional-buttons.tsx
+++ b/src/components/FileManager/hooks/use-tree-additional-buttons.tsx
@@ -9,6 +9,18 @@ interface useTreeAdditionalButtonsOptions {
   collapseAll: () => void;
 }
 
+/**
+ * Provides additional action buttons for the tree component, including a
+ * built-in "Collapse All" button. The hook memoizes the returned JSX to avoid
+ * unnecessary re-renders and applies disabled state automatically based on
+ * the number of expanded paths.
+ *
+ * @param {ReactNode} [additionalButtons] - Optional custom buttons rendered before the Collapse All button.
+ * @param {number} expandedPathsLength - Number of currently expanded paths in the tree.
+ * @param {() => void} collapseAll - Callback fired when the Collapse All button is clicked.
+ *
+ * @returns {{ additionalButtons: ReactNode }} - The rendered buttons fragment.
+ */
 export const useTreeAdditionalButtons = ({
   additionalButtons,
   expandedPathsLength,

--- a/src/components/FileManager/hooks/use-tree-additional-buttons.tsx
+++ b/src/components/FileManager/hooks/use-tree-additional-buttons.tsx
@@ -1,0 +1,42 @@
+import { DialButton } from '@/components/Button/Button';
+import { mergeClasses } from '@/utils/merge-classes';
+import { IconCopyMinus } from '@tabler/icons-react';
+import { useMemo, type ReactNode } from 'react';
+
+interface useTreeAdditionalButtonsOptions {
+  additionalButtons?: ReactNode;
+  expandedPathsLength: number;
+  collapseAll: () => void;
+}
+
+export const useTreeAdditionalButtons = ({
+  additionalButtons,
+  expandedPathsLength,
+  collapseAll,
+}: useTreeAdditionalButtonsOptions) => {
+  const isCollapseAllDisabled = expandedPathsLength === 0;
+
+  const buttons = useMemo(() => {
+    const buttonClass = mergeClasses([
+      'hover:text-accent-primary p-1',
+      isCollapseAllDisabled &&
+        'text-controls-disable hover:text-controls-disable disabled:hover:cursor-default',
+    ]);
+
+    return (
+      <>
+        {additionalButtons}
+        <DialButton
+          disabled={isCollapseAllDisabled}
+          className={buttonClass}
+          onClick={collapseAll}
+          iconBefore={<IconCopyMinus size={24} stroke={1.5} />}
+        />
+      </>
+    );
+  }, [additionalButtons, isCollapseAllDisabled, collapseAll]);
+
+  return {
+    additionalButtons: buttons,
+  };
+};


### PR DESCRIPTION
**Description:**

disable collapse-all button whe there is no any expanded-path

Issues:

- Issue #114 

**UI changes**

<img width="966" height="589" alt="image" src="https://github.com/user-attachments/assets/48a6633c-087a-4bbc-a9ea-b0e12e821e55" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added