### PR TITLE
feat: pass root item label to the folders-tree and forbid context menu for this element (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -240,16 +240,16 @@ const PopupComponent = (args: DialFileManagerProps) => {
   const rootFolder = rootItem;
   switch (activeTab) {
     case 'my_files':
-      rootFolder.breadcrumbLabel = 'My Files';
+      rootFolder.label = 'My Files';
       break;
     case 'shared':
-      rootFolder.breadcrumbLabel = 'Shared with Me';
+      rootFolder.label = 'Shared with Me';
       break;
     case 'organization':
-      rootFolder.breadcrumbLabel = 'Organization';
+      rootFolder.label = 'Organization';
       break;
     default:
-      rootFolder.breadcrumbLabel = 'Files';
+      rootFolder.label = 'Files';
       break;
   }
 
@@ -447,7 +447,7 @@ const rootItem: DialRootFolder = {
   folderId: 'root',
   path: 'All files',
   name: 'All files',
-  breadcrumbLabel: 'My Workspace',
+  label: 'My Workspace',
   nodeType: DialFileNodeType.FOLDER,
   items: itemsMock,
 };

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -237,6 +237,22 @@ const PopupComponent = (args: DialFileManagerProps) => {
     return null;
   }, []);
 
+  const rootFolder = rootItem;
+  switch (activeTab) {
+    case 'my_files':
+      rootFolder.breadcrumbLabel = 'My Files';
+      break;
+    case 'shared':
+      rootFolder.breadcrumbLabel = 'Shared with Me';
+      break;
+    case 'organization':
+      rootFolder.breadcrumbLabel = 'Organization';
+      break;
+    default:
+      rootFolder.breadcrumbLabel = 'Files';
+      break;
+  }
+
   return (
     <div className="h-[640px] w-full flex items-center justify-center">
       <DialButton
@@ -314,7 +330,7 @@ const PopupComponent = (args: DialFileManagerProps) => {
           treeOptions={{
             ...(args.treeOptions ?? {}),
             collapsed: false,
-            expandedPaths: new Set<string>([rootItem.path]),
+            expandedPaths: new Set<string>([rootFolder.path]),
             loadedPaths,
             actionLabels: {
               ...(args.treeOptions?.actionLabels ?? {}),
@@ -363,7 +379,7 @@ const PopupComponent = (args: DialFileManagerProps) => {
               'A folder with this name already exists in this location',
           }}
           maxFileSize={10 * 1024 * 1024} // 10MB
-          rootItem={rootItem}
+          rootItem={rootFolder}
         />
       </DialPopup>
     </div>

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -791,7 +791,7 @@ export const DialFileManagerView: FC = () => {
               {...forwardedTreeProps}
               items={items}
               rootItemPath={rootItem?.path}
-              rootItemLabel={rootItem?.breadcrumbLabel}
+              rootItemLabel={rootItem?.label}
               selectedPath={currentPath}
               onItemClick={handleTreeItemClick}
               areHiddenFilesVisible={areHiddenFilesVisible}
@@ -904,7 +904,7 @@ export const DialFileManagerView: FC = () => {
             path={currentPath}
             onItemClick={handleBreadcrumbItemClick}
             rootItemPath={rootItem?.path}
-            rootItemLabel={rootItem?.breadcrumbLabel}
+            rootItemLabel={rootItem?.label}
             value={effectiveSearchValue}
             onSearchChange={handleSearchChange}
             isCompactView={isCompactView}

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -790,6 +790,8 @@ export const DialFileManagerView: FC = () => {
             <DialFoldersTree
               {...forwardedTreeProps}
               items={items}
+              rootItemPath={rootItem?.path}
+              rootItemLabel={rootItem?.breadcrumbLabel}
               selectedPath={currentPath}
               onItemClick={handleTreeItemClick}
               areHiddenFilesVisible={areHiddenFilesVisible}
@@ -814,6 +816,7 @@ export const DialFileManagerView: FC = () => {
     isCompactView,
     isTreeCollapsed,
     items,
+    rootItem,
     onRenameCancel,
     onRenameSave,
     onRenameValidate,

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
@@ -36,7 +36,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -56,7 +56,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -77,7 +77,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -98,7 +98,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -120,7 +120,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -144,7 +144,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -167,7 +167,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -191,7 +191,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -212,7 +212,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -234,7 +234,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -255,7 +255,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -275,7 +275,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -303,7 +303,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -324,7 +324,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -352,7 +352,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -374,7 +374,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -396,7 +396,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -417,7 +417,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -438,7 +438,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );
@@ -458,7 +458,7 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
           path: '/',
           folderId: 'root-folder',
           nodeType: DialFileNodeType.FOLDER,
-          breadcrumbLabel: 'Root',
+          label: 'Root',
         }}
       />,
     );

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
@@ -79,7 +79,7 @@ const meta: Meta<DestinationFolderPopupProps> = {
       path: '/',
       folderId: 'root-folder',
       nodeType: DialFileNodeType.FOLDER,
-      breadcrumbLabel: 'Root',
+      label: 'Root',
     },
     path: '/',
   },

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.spec.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.spec.tsx
@@ -29,7 +29,7 @@ const mockItems = [
 ];
 
 const getMenu = vi.fn(() => [
-  { key: 'copy', label: 'Copy', icon: <span data-testid="icon-copy" /> },
+  { key: 'copy', label: 'Copy', icon: <span>copy-icon</span> },
 ]);
 
 describe('Dial UI Kit :: DialFoldersTree', () => {
@@ -108,5 +108,20 @@ describe('Dial UI Kit :: DialFoldersTree', () => {
     expect(getMenu).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Subfolder' }),
     );
+  });
+
+  test('renders root item with custom label when rootItemLabel is provided', () => {
+    render(
+      <DialFoldersTree
+        items={mockItems}
+        rootItemPath="/root"
+        rootItemLabel="Custom Root Label"
+        expandedPaths={new Set(['/root'])}
+      />,
+    );
+
+    expect(screen.getByText('Custom Root Label')).toBeInTheDocument();
+
+    expect(screen.queryByText('Root')).not.toBeInTheDocument();
   });
 });

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.stories.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.stories.tsx
@@ -176,6 +176,8 @@ export const Default: Story = {
     items: mockFolders,
     expandedPaths: new Set(),
     showFiles: false,
+    rootItemLabel: 'My workspace',
+    rootItemPath: '/root',
   },
   render: (args) => {
     const Wrapper = () => {

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -24,6 +24,8 @@ export interface DialFoldersTreeProps {
   selectedPath?: string;
   renamedPath?: string;
   showFiles?: boolean;
+  rootItemPath?: string;
+  rootItemLabel?: string;
   emptyStateTitle?: string;
   emptyStateDescription?: string;
   emptyStateIcon?: ReactNode;
@@ -120,7 +122,8 @@ export interface DialFoldersTreeProps {
  * @param [onRenameValidate] - Function to validate the new name during editing. Should return an error string or `null` if valid.
  * @param [getContextMenuItems] - Function returning context menu items for a given node.
  * @param [areHiddenFilesVisible=false] - Whether hidden files (dotfiles) should be visible in the tree.
- *
+ * @param [rootItemPath] - Path of the folder to treat as the custom root node (no context menu, special label).
+ * @param [rootItemLabel] - Label to display for the root node instead of its actual name.
  * @remarks
  * - Folder and file data must follow the `DialFile` model.
  * - The `expandedPaths`, `loadingPaths`, `selectedPath`, and `renamedPath` props are externally controlled.
@@ -140,6 +143,8 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
   emptyStateIcon,
   areHiddenFilesVisible = false,
   renamedPath,
+  rootItemLabel,
+  rootItemPath,
   onItemClick,
   getContextMenuItems,
   onRenameSave,
@@ -177,6 +182,8 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
       const isLoading = loadingPaths.has(path);
       const isRenaming = renamedPath === path;
       const isLoaded = loadedPaths.has(path);
+      const isRootFolder =
+        rootItemPath && rootItemLabel && path === rootItemPath && isFolder;
 
       const validateHandler =
         onRenameValidate && ((value: string) => onRenameValidate(value, node));
@@ -185,7 +192,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
         ? 'bg-accent-primary-alpha border-l-2 border-l-accent-primary rounded'
         : 'border-l-2 border-l-transparent';
 
-      const menuItems = getContextMenuItems?.(node) ?? [];
+      const menuItems = isRootFolder ? [] : (getContextMenuItems?.(node) ?? []);
 
       return (
         <div key={`${path}-children`} className="cursor-pointer text-secondary">
@@ -226,19 +233,21 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                     )}
                     <DialFileManagerItemName
                       elementId={`${path}-tree-item`}
-                      name={name}
+                      name={isRootFolder ? rootItemLabel : name}
                       type={isFolder ? DialItemType.Folder : DialItemType.File}
                       loading={isLoading}
-                      editing={isRenaming}
-                      onSave={onRenameSave}
-                      onCancel={onRenameCancel}
-                      validate={validateHandler}
                       iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+                      {...(!isRootFolder && {
+                        editing: isRenaming,
+                        onSave: onRenameSave,
+                        onCancel: onRenameCancel,
+                        validate: validateHandler,
+                      })}
                     />
                   </>
                 </div>
 
-                {menuItems.length > 0 && !isRenaming && (
+                {menuItems.length > 0 && !isRenaming && !isRootFolder && (
                   <div className="flex-1 flex justify-end">
                     <DialDropdown
                       placement="bottom-start"

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -39,5 +39,5 @@ export enum DialFilePermission {
 }
 
 export interface DialRootFolder extends DialFile {
-  breadcrumbLabel: string;
+  label: string;
 }


### PR DESCRIPTION
**Description:**

pass root item label to the folders-tree and forbid context menu for this element

Issues:

- Issue #114

**UI changes**

<img width="504" height="241" alt="image" src="https://github.com/user-attachments/assets/f9a5d2b8-56dd-48bd-b4a5-c124c1d69693" />
<img width="522" height="239" alt="image" src="https://github.com/user-attachments/assets/175a2c51-1fbf-47b5-a439-2e5af11187dd" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added