### PR TITLE
fix: skip grid cell click if cell in edit or create folder mode (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   useRef,
 } from 'react';
-import type { ColDef } from 'ag-grid-community';
+import type { CellClickedEvent, ColDef } from 'ag-grid-community';
 import {
   containerBaseClassName,
   mainGridClassName,
@@ -483,6 +483,10 @@ export const DialFileManagerView: FC = () => {
                 validate={validateFolderName}
                 onSave={saveFolderCreation}
                 onCancel={cancelFolderCreation}
+                inputContainerClassName={mergeClasses([
+                  '!h-9',
+                  isCompactView && type === DialFileNodeType.ITEM && '!h-10',
+                ])}
               />
             );
           }
@@ -876,6 +880,23 @@ export const DialFileManagerView: FC = () => {
     }));
   }, [baseColumns, filterable, isCompactView, actionsColumnDef]);
 
+  const cellClickHandler = useCallback(
+    (event: CellClickedEvent<FileManagerGridRow>) => {
+      if (
+        event.colDef.colId === '__select' ||
+        event.colDef.colId === '__actions' ||
+        (renamedPath && event.data?.path === renamedPath) ||
+        event.data?.isTemporary
+      ) {
+        return;
+      }
+      if (event.data) {
+        handleTableRowClick(event.data);
+      }
+    },
+    [renamedPath, handleTableRowClick],
+  );
+
   return (
     <section
       ref={containerRef}
@@ -936,17 +957,7 @@ export const DialFileManagerView: FC = () => {
               {...forwardedGridOptions}
               additionalGridOptions={{
                 ...forwardedGridOptions.additionalGridOptions,
-                onCellClicked: (event) => {
-                  if (
-                    event.colDef.colId === '__select' ||
-                    event.colDef.colId === '__actions'
-                  ) {
-                    return;
-                  }
-                  if (event.data) {
-                    handleTableRowClick(event.data);
-                  }
-                },
+                onCellClicked: cellClickHandler,
                 headerHeight: COMPACT_VIEW_HEADER_HEIGHT,
                 rowHeight: COMPACT_VIEW_HEADER_HEIGHT,
                 ...(isCompactView

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -923,7 +923,7 @@ export const DialFileManagerView: FC = () => {
     (event: CellClickedEvent<FileManagerGridRow>) => {
       if (
         event.colDef.colId === '__select' ||
-        event.colDef.colId === '__actions' ||
+        event.colDef.colId === FileManagerColumnKey.Actions ||
         (renamedPath && event.data?.path === renamedPath) ||
         event.data?.isTemporary
       ) {


### PR DESCRIPTION
**Description:**

Skip grid cell click if cell in edit or create folder mode. Fix height of input when cell in create folder mode.

Issues:

- Issue #114 

**UI changes**

<img width="962" height="312" alt="image" src="https://github.com/user-attachments/assets/b064799b-7341-4158-8f8e-a640cf9b20e8" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added