### PR TITLE
fix: correctly handle renaming triggered from tree and grid (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -81,6 +81,7 @@ import classNames from 'classnames';
 import {
   DestinationFolderMode,
   DialFileManagerActions,
+  FileManagerRenameTriggerView,
 } from '@/types/file-manager';
 import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
 import { DialItemType } from '@/types/item';
@@ -502,7 +503,8 @@ export const DialFileManagerView: FC = () => {
           }
 
           const isBeingRenamed =
-            renameTriggerView === 'grid' && renamedPath === params.data?.path;
+            renameTriggerView === FileManagerRenameTriggerView.Grid &&
+            renamedPath === params.data?.path;
           if (isBeingRenamed && renamedItem && params.data) {
             const displayName = getDisplayName(renamedItem);
             return (
@@ -825,7 +827,9 @@ export const DialFileManagerView: FC = () => {
               areHiddenFilesVisible={areHiddenFilesVisible}
               getContextMenuItems={getTreeContextMenuItems}
               renamedPath={
-                renameTriggerView === 'tree' ? renamedPath : undefined
+                renameTriggerView === FileManagerRenameTriggerView.Tree
+                  ? renamedPath
+                  : undefined
               }
               onRenameSave={onRenameSave}
               onRenameCancel={onRenameCancel}

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -95,6 +95,7 @@ import { DialFileManagerItemSummaryCell } from '@/components/FileManager/compone
 import { useWidthBreakpoint } from '@/hooks/use-width-breakpoint';
 import { useGridActionsColumn } from '@/components/FileManager/hooks/use-grid-actions-column';
 import { FileManagerColumnKey } from '@/types/file-manager';
+import { useTriggerViewRename } from '@/components/FileManager/hooks/use-trigger-view-rename';
 
 type GridRow = FileManagerGridRow;
 
@@ -441,6 +442,9 @@ export const DialFileManagerView: FC = () => {
 
   const [sidebarCurrentWidth, setSidebarCurrentWidth] = useState(width);
 
+  const { renameTriggerView, onGridRename, onTreeRename } =
+    useTriggerViewRename({ onRename });
+
   const sidebarThrottledRef = useRef<number | null>(null);
 
   const sidebarResizingHandler = (width: number) => {
@@ -497,7 +501,8 @@ export const DialFileManagerView: FC = () => {
             );
           }
 
-          const isBeingRenamed = renamedPath === params.data?.path;
+          const isBeingRenamed =
+            renameTriggerView === 'grid' && renamedPath === params.data?.path;
           if (isBeingRenamed && renamedItem && params.data) {
             const displayName = getDisplayName(renamedItem);
             return (
@@ -590,6 +595,7 @@ export const DialFileManagerView: FC = () => {
     validateFolderName,
     renamedPath,
     renamedItem,
+    renameTriggerView,
     onRenameValidate,
     onRenameSave,
     onRenameCancel,
@@ -662,7 +668,7 @@ export const DialFileManagerView: FC = () => {
                 className="text-secondary"
               />
             ),
-            onClick: () => onRename(file.path),
+            onClick: () => onTreeRename(file.path),
           });
         }
         if (treeOptions.actionLabels[DialFileManagerActions.Delete]) {
@@ -685,7 +691,7 @@ export const DialFileManagerView: FC = () => {
       handleOpenDestinationFolderPopup,
       handleSetCopiedFiles,
       handleSetMovedFiles,
-      onRename,
+      onTreeRename,
       openDeleteConfirmation,
       treeOptions,
     ],
@@ -729,7 +735,7 @@ export const DialFileManagerView: FC = () => {
       handleOpenDestinationFolderPopup(DestinationFolderMode.Move);
     },
     onDownload: handleDownloadFiles,
-    onRename,
+    onRename: onGridRename,
     onDelete: openDeleteConfirmation,
     getCurrentFolderPath: () => currentPath ?? '/',
   });
@@ -818,7 +824,9 @@ export const DialFileManagerView: FC = () => {
               onItemClick={handleTreeItemClick}
               areHiddenFilesVisible={areHiddenFilesVisible}
               getContextMenuItems={getTreeContextMenuItems}
-              renamedPath={renamedPath}
+              renamedPath={
+                renameTriggerView === 'tree' ? renamedPath : undefined
+              }
               onRenameSave={onRenameSave}
               onRenameCancel={onRenameCancel}
               onRenameValidate={onRenameValidate}
@@ -842,6 +850,7 @@ export const DialFileManagerView: FC = () => {
     onRenameCancel,
     onRenameSave,
     onRenameValidate,
+    renameTriggerView,
     renamedPath,
     sidebarCurrentWidth,
     title,
@@ -860,7 +869,7 @@ export const DialFileManagerView: FC = () => {
       handleOpenDestinationFolderPopup(DestinationFolderMode.Move);
     },
     onDownload: (file) => handleDownloadFiles([file]),
-    onRename,
+    onRename: onGridRename,
     onDelete: (file, parentFolderPath) =>
       openDeleteConfirmation([file], parentFolderPath),
   });

--- a/src/components/FileManager/hooks/__tests__/use-trigger-view-rename.spec.ts
+++ b/src/components/FileManager/hooks/__tests__/use-trigger-view-rename.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTriggerViewRename } from '@/components/FileManager/hooks/use-trigger-view-rename';
+import { FileManagerRenameTriggerView } from '@/types/file-manager';
+
+describe('Dial UI Kit :: FileManager :: useTriggerViewRename', () => {
+  it('initializes with Grid trigger view by default', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Grid,
+    );
+  });
+
+  it('calls onRename when onGridRename is invoked', () => {
+    const onRename = vi.fn();
+    const testPath = '/test/path';
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onGridRename(testPath);
+    });
+
+    expect(onRename).toHaveBeenCalledWith(testPath);
+    expect(onRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets renameTriggerView to Grid when onGridRename is called', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onGridRename('/test/path');
+    });
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Grid,
+    );
+  });
+
+  it('calls onRename when onTreeRename is invoked', () => {
+    const onRename = vi.fn();
+    const testPath = '/tree/path';
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onTreeRename(testPath);
+    });
+
+    expect(onRename).toHaveBeenCalledWith(testPath);
+    expect(onRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets renameTriggerView to Tree when onTreeRename is called', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onTreeRename('/tree/path');
+    });
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Tree,
+    );
+  });
+
+  it('switches trigger view from Grid to Tree', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Grid,
+    );
+
+    act(() => {
+      result.current.onTreeRename('/tree/path');
+    });
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Tree,
+    );
+  });
+
+  it('switches trigger view from Tree to Grid', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onTreeRename('/tree/path');
+    });
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Tree,
+    );
+
+    act(() => {
+      result.current.onGridRename('/grid/path');
+    });
+
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Grid,
+    );
+  });
+
+  it('maintains stable callback references when onRename does not change', () => {
+    const onRename = vi.fn();
+
+    const { result, rerender } = renderHook(() =>
+      useTriggerViewRename({ onRename }),
+    );
+
+    const firstOnGridRename = result.current.onGridRename;
+    const firstOnTreeRename = result.current.onTreeRename;
+
+    rerender();
+
+    expect(result.current.onGridRename).toBe(firstOnGridRename);
+    expect(result.current.onTreeRename).toBe(firstOnTreeRename);
+  });
+
+  it('updates callback references when onRename changes', () => {
+    const onRenameFromGrid = vi.fn();
+    const onRenameFromTree = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ onRename }) => useTriggerViewRename({ onRename }),
+      { initialProps: { onRename: onRenameFromGrid } },
+    );
+
+    const firstOnGridRename = result.current.onGridRename;
+
+    rerender({ onRename: onRenameFromTree });
+
+    expect(result.current.onGridRename).not.toBe(firstOnGridRename);
+
+    act(() => {
+      result.current.onGridRename('/path');
+    });
+
+    expect(onRenameFromGrid).not.toHaveBeenCalled();
+    expect(onRenameFromTree).toHaveBeenCalledWith('/path');
+  });
+
+  it('handles multiple consecutive calls correctly', () => {
+    const onRename = vi.fn();
+
+    const { result } = renderHook(() => useTriggerViewRename({ onRename }));
+
+    act(() => {
+      result.current.onGridRename('/path1');
+      result.current.onTreeRename('/path2');
+      result.current.onGridRename('/path3');
+    });
+
+    expect(onRename).toHaveBeenCalledTimes(3);
+    expect(onRename).toHaveBeenNthCalledWith(1, '/path1');
+    expect(onRename).toHaveBeenNthCalledWith(2, '/path2');
+    expect(onRename).toHaveBeenNthCalledWith(3, '/path3');
+    expect(result.current.renameTriggerView).toBe(
+      FileManagerRenameTriggerView.Grid,
+    );
+  });
+});

--- a/src/components/FileManager/hooks/use-trigger-view-rename.ts
+++ b/src/components/FileManager/hooks/use-trigger-view-rename.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+type RenameView = 'tree' | 'grid';
+
+interface UseTriggerViewRenameOptions {
+  onRename: (path: string) => void;
+}
+
+/**
+ * Manages which view ("tree" or "grid") triggered a rename action.
+ *
+ * Useful when both TreeView and GridView can initiate renaming,
+ * and the parent needs to know which source triggered it
+ * to apply view-specific logic or UI updates.
+ *
+ * Returns the last rename trigger source and two handlers
+ * (`onGridRename`, `onTreeRename`) that wrap the provided `onRename` callback.
+ */
+export const useTriggerViewRename = ({
+  onRename,
+}: UseTriggerViewRenameOptions) => {
+  const [renameTriggerView, setRenameTriggerView] =
+    useState<RenameView>('grid');
+
+  const onGridRename = useCallback(
+    (path: string) => {
+      onRename(path);
+      setRenameTriggerView('grid');
+    },
+    [onRename],
+  );
+
+  const onTreeRename = useCallback(
+    (path: string) => {
+      onRename(path);
+      setRenameTriggerView('tree');
+    },
+    [onRename],
+  );
+
+  return {
+    renameTriggerView,
+    onGridRename,
+    onTreeRename,
+  };
+};

--- a/src/components/FileManager/hooks/use-trigger-view-rename.ts
+++ b/src/components/FileManager/hooks/use-trigger-view-rename.ts
@@ -1,6 +1,5 @@
+import { FileManagerRenameTriggerView } from '@/types/file-manager';
 import { useCallback, useState } from 'react';
-
-type RenameView = 'tree' | 'grid';
 
 interface UseTriggerViewRenameOptions {
   onRename: (path: string) => void;
@@ -20,12 +19,12 @@ export const useTriggerViewRename = ({
   onRename,
 }: UseTriggerViewRenameOptions) => {
   const [renameTriggerView, setRenameTriggerView] =
-    useState<RenameView>('grid');
+    useState<FileManagerRenameTriggerView>(FileManagerRenameTriggerView.Grid);
 
   const onGridRename = useCallback(
     (path: string) => {
       onRename(path);
-      setRenameTriggerView('grid');
+      setRenameTriggerView(FileManagerRenameTriggerView.Grid);
     },
     [onRename],
   );
@@ -33,7 +32,7 @@ export const useTriggerViewRename = ({
   const onTreeRename = useCallback(
     (path: string) => {
       onRename(path);
-      setRenameTriggerView('tree');
+      setRenameTriggerView(FileManagerRenameTriggerView.Tree);
     },
     [onRename],
   );

--- a/src/types/file-manager.ts
+++ b/src/types/file-manager.ts
@@ -30,6 +30,11 @@ export enum DestinationFolderMode {
   Move = 'move',
 }
 
+export enum FileManagerRenameTriggerView {
+  Tree = 'tree',
+  Grid = 'grid',
+}
+
 export enum FileManagerColumnKey {
   Name = 'name',
   UpdatedAt = 'updatedAt',


### PR DESCRIPTION
**Description:**

correctly handle renaming triggered from tree and grid

Issues:

- Issue #114 

**UI changes**

<img width="1037" height="584" alt="image" src="https://github.com/user-attachments/assets/dd05c76f-0a43-4c16-ba5e-070d9d2553be" />
<img width="1051" height="579" alt="image" src="https://github.com/user-attachments/assets/b2dafd27-3ee3-4956-8f3b-ef02e13dc52f" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added