### PR TITLE
feat: [Alert] add icon size and stroke properties

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -37,6 +37,14 @@ const meta = {
       control: { type: 'boolean' },
       description: 'Whether the close button should be shown',
     },
+    iconSize: {
+      control: { type: 'number' },
+      description: 'Size of the icon displayed in the alert',
+    },
+    iconStroke: {
+      control: { type: 'number' },
+      description: 'Stroke width of the icon displayed in the alert',
+    },
     onClose: {
       control: false,
       description: 'Callback fired when the close button is clicked',
@@ -97,8 +105,14 @@ export const LongMessage: Story = {
 export const CustomClass: Story = {
   args: {
     variant: AlertVariant.Info,
-    message: 'Alert with custom CSS class',
-    className: 'border-dashed w-[250px] bg-layer-2',
+    message: (
+      <span>
+        Alert with <span className="italic">custom CSS class</span>
+      </span>
+    ),
+    iconSize: 12,
+    iconStroke: 1,
+    className: 'py-1 px-2 border-dashed dial-tiny-sensory w-[250px] bg-layer-2',
   },
   parameters: {
     docs: {
@@ -117,6 +131,22 @@ export const AllVariants: Story = {
       <DialAlert variant={AlertVariant.Success} message="Success alert" />
       <DialAlert variant={AlertVariant.Warning} message="Warning alert" />
       <DialAlert variant={AlertVariant.Error} message="Error alert" />
+      <div className="dial-caption text-primary">Additional</div>
+      <DialAlert
+        variant={AlertVariant.Info}
+        iconSize={14}
+        className="py-1 px-2 w-fit"
+        message={
+          <span className="dial-tiny">
+            <b>Customized</b> to be smaller Info alert
+          </span>
+        }
+      />
+      <DialAlert
+        closable
+        variant={AlertVariant.Error}
+        message="Closable error alert"
+      />
     </div>
   ),
   parameters: {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 import { IconX } from '@tabler/icons-react';
 import classNames from 'classnames';
-import type { FC, ReactNode, MouseEvent } from 'react';
+import { type FC, type ReactNode, type MouseEvent, useMemo } from 'react';
 
 import { DialIcon } from '@/components/Icon/Icon';
 import { DialButton } from '@/components/Button/Button';
@@ -64,6 +64,10 @@ export const DialAlert: FC<DialAlertProps> = ({
   closable = false,
   onClose,
 }) => {
+  const icon = useMemo(() => {
+    return variantIcons({ size: iconSize, stroke: iconStroke })[variant];
+  }, [variant, iconSize, iconStroke]);
+
   return (
     <div
       role="alert"
@@ -74,9 +78,7 @@ export const DialAlert: FC<DialAlertProps> = ({
       )}
     >
       <div className="flex items-center gap-2">
-        <DialIcon
-          icon={variantIcons({ size: iconSize, stroke: iconStroke })[variant]}
-        />
+        <DialIcon icon={icon} />
         <div className="text-primary dial-small">{message}</div>
       </div>
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -16,6 +16,8 @@ export interface DialAlertProps {
   message: string | ReactNode;
   className?: string;
   closable?: boolean;
+  iconSize?: number;
+  iconStroke?: number;
   onClose?: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -49,12 +51,16 @@ export interface DialAlertProps {
  * @param message - Message text to display inside the alert
  * @param [className] - Additional CSS classes applied to the alert container
  * @param [closable=false] - Whether the alert has a close button
+ * @param [iconSize=24] - Size of the icon displayed in the alert
+ * @param [iconStroke=2] - Stroke width of the icon displayed in the alert
  * @param [onClose] - Callback fired when the close button is clicked
  */
 export const DialAlert: FC<DialAlertProps> = ({
   variant = AlertVariant.Info,
   message,
   className,
+  iconSize = 24,
+  iconStroke = 2,
   closable = false,
   onClose,
 }) => {
@@ -68,8 +74,10 @@ export const DialAlert: FC<DialAlertProps> = ({
       )}
     >
       <div className="flex items-center gap-2">
-        <DialIcon icon={variantIcons[variant]} />
-        <div className="text-primary">{message}</div>
+        <DialIcon
+          icon={variantIcons({ size: iconSize, stroke: iconStroke })[variant]}
+        />
+        <div className="text-primary dial-small">{message}</div>
       </div>
 
       {closable && (

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,10 +1,10 @@
 import { IconX } from '@tabler/icons-react';
-import classNames from 'classnames';
-import { type FC, type ReactNode, type MouseEvent, useMemo } from 'react';
+import { type FC, type MouseEvent, type ReactNode, useMemo } from 'react';
 
-import { DialIcon } from '@/components/Icon/Icon';
 import { DialButton } from '@/components/Button/Button';
+import { DialIcon } from '@/components/Icon/Icon';
 import { AlertVariant } from '@/types/alert';
+import { mergeClasses } from '@/utils/merge-classes';
 import {
   alertBaseClassName,
   alertVariantClassNameMap,
@@ -71,7 +71,7 @@ export const DialAlert: FC<DialAlertProps> = ({
   return (
     <div
       role="alert"
-      className={classNames(
+      className={mergeClasses(
         alertBaseClassName,
         alertVariantClassNameMap[variant],
         className,
@@ -79,7 +79,7 @@ export const DialAlert: FC<DialAlertProps> = ({
     >
       <div className="flex items-center gap-2">
         <DialIcon icon={icon} />
-        <div className="text-primary dial-small">{message}</div>
+        <div className="text-primary">{message}</div>
       </div>
 
       {closable && (

--- a/src/components/Alert/constants.tsx
+++ b/src/components/Alert/constants.tsx
@@ -1,18 +1,21 @@
 import { AlertVariant } from '@/types/alert';
-import type { ReactNode } from 'react';
 import {
   IconAlertCircle,
   IconAlertTriangle,
   IconCircleCheck,
   IconInfoCircle,
+  type ReactNode,
 } from '@tabler/icons-react';
 
-export const variantIcons: Record<AlertVariant, ReactNode> = {
-  info: <IconInfoCircle size={24} stroke={2} />,
-  error: <IconAlertCircle size={24} stroke={2} />,
-  warning: <IconAlertTriangle size={24} stroke={2} />,
-  success: <IconCircleCheck size={24} stroke={2} />,
-};
+export const variantIcons = (props: {
+  size: number;
+  stroke: number;
+}): Record<AlertVariant, ReactNode> => ({
+  info: <IconInfoCircle {...props} />,
+  error: <IconAlertCircle {...props} />,
+  warning: <IconAlertTriangle {...props} />,
+  success: <IconCircleCheck {...props} />,
+});
 
 export const alertVariantClassNameMap: Record<AlertVariant, string> = {
   [AlertVariant.Info]: 'bg-info border-info text-info',


### PR DESCRIPTION
**Description:**

Add possibility to customize Alert icon size and stroke

Issues:

- Issue #<TICKET_ID>

**UI changes**
<img width="1521" height="521" alt="image" src="https://github.com/user-attachments/assets/7e772d99-0811-43dd-8887-4423982151ef" />
**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added