### PR TITLE
fix: use item's folderId as source when moving items (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -38,7 +38,7 @@ const meta = {
     onPathChange: { action: 'onPathChange' },
   },
   args: {
-    path: 'All files/Folder 4',
+    path: 'All files',
     items: itemsMock,
     treeOptions: {
       expandedPaths: new Set<string>([
@@ -46,7 +46,6 @@ const meta = {
         'All files/Design',
         'All files/Design/Icons',
         'All files/Design/Icons/SVG',
-        'All files/Folder 4',
         'All files/Media',
         'All files/Projects',
       ]),

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1052,8 +1052,7 @@ export const DialFileManagerView: FC = () => {
           if (destinationFolderMode === DestinationFolderMode.Copy) {
             handleCopyTo(destinationPath);
           } else {
-            const sourcePath = currentPath ?? '/';
-            handleMoveTo(destinationPath, sourcePath);
+            handleMoveTo(destinationPath);
           }
           handleCloseDestinationFolderPopup();
         }}

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -68,7 +68,7 @@ export interface FileManagerContextValue {
   gridRows: FileManagerGridRow[];
 
   handleCopyTo: (destinationFolder: string) => void;
-  handleMoveTo: (destinationFolder: string, sourceFolder: string) => void;
+  handleMoveTo: (destinationFolder: string, sourceFolder?: string) => void;
   handleDuplicate: (files: DialFile[]) => void;
   handleOpenDestinationFolderPopup: (mode: DestinationFolderMode) => void;
   handleCloseDestinationFolderPopup: () => void;

--- a/src/components/FileManager/hooks/use-file-clipboard.ts
+++ b/src/components/FileManager/hooks/use-file-clipboard.ts
@@ -110,13 +110,14 @@ export const useFileClipboard = ({
   );
 
   const handleMoveTo = useCallback(
-    (destinationFolder: string, sourceFolder: string) => {
+    (destinationFolder: string, sourceFolder?: string) => {
+      const sourceFolderPath =
+        sourceFolder || (operationMetadata?.sourceFolder ?? '/');
+
       const result = startConflictResolution(destinationFolder, movedFiles, {
         type: DestinationFolderMode.Move,
-        sourceFolder,
+        sourceFolderPath,
       });
-
-      setOperationMetadata({ type: DestinationFolderMode.Move, sourceFolder });
 
       if (!result.hasConflicts) {
         const resolvedItems = resolveConflictsWithStrategy(
@@ -124,7 +125,7 @@ export const useFileClipboard = ({
           movedFiles,
           true,
         );
-        onMoveToFiles?.(resolvedItems, sourceFolder, destinationFolder);
+        onMoveToFiles?.(resolvedItems, sourceFolderPath, destinationFolder);
         onMoveSuccess?.();
         clearState();
       }
@@ -136,6 +137,7 @@ export const useFileClipboard = ({
       onMoveToFiles,
       onMoveSuccess,
       clearState,
+      operationMetadata,
     ],
   );
 
@@ -204,13 +206,18 @@ export const useFileClipboard = ({
   const handleSetMovedFiles = useCallback(
     (files: DialFile[]) => {
       setMovedFiles(files);
+      setOperationMetadata({
+        type: DestinationFolderMode.Move,
+        sourceFolder: files[0]?.folderId,
+      });
+
       if (getMoveHeader && files.length > 0) {
         setDestinationFolderTitle(getMoveHeader(files.length, files[0]?.name));
       } else {
         setDestinationFolderTitle(undefined);
       }
     },
-    [getMoveHeader],
+    [getMoveHeader, setOperationMetadata],
   );
 
   return {


### PR DESCRIPTION
**Description:**

use item's folderId as source when moving items

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added