### PR TITLE
fix: remove regex from changeLastPathSegment in useItemRenaming

### DIFF
--- a/src/components/FileManager/hooks/use-item-renaming.tsx
+++ b/src/components/FileManager/hooks/use-item-renaming.tsx
@@ -14,10 +14,22 @@ const DEFAULT_VALIDATION_MESSAGES: Required<RenameValidationMessages> = {
   duplicateName: 'An item with this name already exists',
 };
 
+function trimTrailingSlashes(path: string): string {
+  let i = path.length;
+  while (i > 0 && path[i - 1] === '/') i--;
+  return path.slice(0, i);
+}
+
 function changeLastPathSegment(path: string, newName: string): string {
-  const parts = path.replace(/\/+$/, '').split('/');
-  parts[parts.length - 1] = newName;
-  return parts.join('/');
+  const trimmed = trimTrailingSlashes(path);
+  const lastSlashIndex = trimmed.lastIndexOf('/');
+
+  if (lastSlashIndex === -1) {
+    return newName;
+  }
+
+  const base = trimmed.slice(0, lastSlashIndex + 1);
+  return base + newName;
 }
 
 function getFileNameWithoutExtension(name: string): string {


### PR DESCRIPTION
**Description:**

remove regex from changeLastPathSegment in useItemRenaming

Issues:

- Issue #114 
- https://github.com/epam/ai-dial-ui-kit/security/code-scanning/21

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added