### PR TITLE
feat: more css and dismiss customization for popup component (Issue #114)

### DIFF
--- a/src/components/Popup/Popup.spec.tsx
+++ b/src/components/Popup/Popup.spec.tsx
@@ -73,4 +73,41 @@ describe('Dial UI Kit :: DialPopup', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveClass(popupSizeClassMap[PopupSize.Lg]);
   });
+
+  test('applies headerClassName to the popup header', () => {
+    render(
+      <DialPopup
+        open
+        title="Header class test"
+        headerClassName="custom-header-class"
+      >
+        <div>Body</div>
+      </DialPopup>,
+    );
+
+    const header = screen
+      .getByRole('button', { name: 'Close dialog' })
+      .closest('div');
+
+    expect(header).toHaveClass('custom-header-class');
+  });
+
+  test('does not close on outside click when closeOnOutsideClick is false', () => {
+    const onClose = vi.fn();
+
+    render(
+      <DialPopup
+        open
+        title="Outside click disabled"
+        closeOnOutsideClick={false}
+        onClose={onClose}
+      >
+        <div>Body</div>
+      </DialPopup>,
+    );
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
     title: { control: { type: 'text' } },
     className: { control: { type: 'text' } },
     overlayClassName: { control: { type: 'text' } },
-    headingClassName: { control: { type: 'text' } },
+    titleClassName: { control: { type: 'text' } },
     dividers: { control: { type: 'boolean' } },
     footer: { control: { type: 'text' } },
     onClose: { action: 'onClose', control: false },
@@ -93,7 +93,7 @@ export const CustomClasses: Story = {
   render: StatefulRender,
   args: {
     className: 'ring-2 ring-offset-2 ring-sky-400 !bg-accent-secondary',
-    headingClassName: 'font-medium bg-red-400',
+    titleClassName: 'font-medium bg-red-400',
   },
 };
 

--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DialPopup, type DialPopupProps } from './Popup';
 import { PopupSize } from '@/types/popup';
+import { DialLoader } from '@/components/Loader/Loader';
+import { DialButton } from '@/components/Button/Button';
+import { ButtonVariant } from '@/types/button';
 
 const meta = {
   title: 'Overlay/Popup',
@@ -121,4 +124,30 @@ export const DifferentSizes: Story = {
     </div>
   ),
   args: {},
+};
+
+export const WithoutHeaderAndDismiss: Story = {
+  render: StatefulRender,
+  args: {
+    className: '!w-[280px]',
+    title: undefined,
+    footer: undefined,
+    dividers: false,
+    headerClassName: 'hidden',
+    closeOnOutsideClick: false,
+    children: (
+      <div className="flex items-center flex-col gap-6 p-9">
+        <DialLoader size={120} />
+        <div className="flex flex-col gap-2 text-center text-primary">
+          <div className="text-lg font-semibold">Moving items</div>
+          <div className="text-sm">8 of 24 items moved...</div>
+        </div>
+        <DialButton
+          className="w-fit"
+          variant={ButtonVariant.Tertiary}
+          label="Cancel"
+        />
+      </div>
+    ),
+  },
 };

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -27,7 +27,7 @@ export interface DialPopupProps {
   portalId?: string;
   className?: string;
   overlayClassName?: string;
-  headingClassName?: string;
+  titleClassName?: string;
   headerClassName?: string;
   dividers?: boolean;
   children?: ReactNode;
@@ -66,7 +66,7 @@ export interface DialPopupProps {
  * @param [portalId] - Optional portal container id
  * @param [className] - Additional CSS classes applied to the popup container
  * @param [overlayClassName] - Additional CSS classes applied to the overlay
- * @param [headingClassName] - Additional CSS classes applied to the title element
+ * @param [titleClassName] - Additional CSS classes applied to the title element
  * @param [headerClassName] - Additional CSS classes applied to the popup header container
  * @param [dividers=true] - Whether to render separators between sections
  * @param [children] - Body content
@@ -81,7 +81,7 @@ export const DialPopup: FC<DialPopupProps> = ({
   portalId,
   className,
   overlayClassName,
-  headingClassName,
+  titleClassName,
   headerClassName,
   dividers = true,
   children,
@@ -114,7 +114,7 @@ export const DialPopup: FC<DialPopupProps> = ({
         id={headingId}
         className={classNames(
           'flex-1 min-w-0 mr-3 truncate dial-h3 text-primary',
-          headingClassName,
+          titleClassName,
         )}
       >
         <DialTooltip tooltip={title}>{title}</DialTooltip>

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -19,6 +19,7 @@ import {
   popupHeaderClassName,
   popupSizeClassMap,
 } from './constants';
+import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DialPopupProps {
   open?: boolean;
@@ -27,11 +28,13 @@ export interface DialPopupProps {
   className?: string;
   overlayClassName?: string;
   headingClassName?: string;
+  headerClassName?: string;
   dividers?: boolean;
   children?: ReactNode;
   footer?: ReactNode;
   onClose?: (e?: MouseEvent<HTMLButtonElement> | null) => void;
   size?: PopupSize;
+  closeOnOutsideClick?: boolean;
 }
 
 /**
@@ -64,11 +67,13 @@ export interface DialPopupProps {
  * @param [className] - Additional CSS classes applied to the popup container
  * @param [overlayClassName] - Additional CSS classes applied to the overlay
  * @param [headingClassName] - Additional CSS classes applied to the title element
+ * @param [headerClassName] - Additional CSS classes applied to the popup header container
  * @param [dividers=true] - Whether to render separators between sections
  * @param [children] - Body content
  * @param [footer] - Footer area for actions
  * @param [onClose] - Callback fired when the popup requests to close
  * @param [size=PopupSize.Md] - Sets the max-width of the popup
+ * @param [closeOnOutsideClick=true] - Whether the popup closes when clicking outside
  */
 export const DialPopup: FC<DialPopupProps> = ({
   open = false,
@@ -77,11 +82,13 @@ export const DialPopup: FC<DialPopupProps> = ({
   className,
   overlayClassName,
   headingClassName,
+  headerClassName,
   dividers = true,
   children,
   footer,
   onClose,
   size = PopupSize.Md,
+  closeOnOutsideClick = true,
 }) => {
   const { refs, context } = useFloating({
     open,
@@ -91,7 +98,7 @@ export const DialPopup: FC<DialPopupProps> = ({
   });
 
   const role = useRole(context, { role: 'dialog' });
-  const dismiss = useDismiss(context, { outsidePress: true });
+  const dismiss = useDismiss(context, { outsidePress: closeOnOutsideClick });
   const { getFloatingProps } = useInteractions([role, dismiss]);
 
   if (!open) return null;
@@ -136,7 +143,9 @@ export const DialPopup: FC<DialPopupProps> = ({
               className,
             )}
           >
-            <div className={popupHeaderClassName}>
+            <div
+              className={mergeClasses(popupHeaderClassName, headerClassName)}
+            >
               {renderTitle(title)}
               <DialCloseButton
                 ariaLabel="Close dialog"


### PR DESCRIPTION
**Description:**

more css and dismiss customization for popup component.
breaking change prop renaming: headingClassName -> titleClassName

Issues:

- Issue #114 

**UI changes**

<img width="423" height="429" alt="image" src="https://github.com/user-attachments/assets/d06aea41-7c21-4895-9d80-777112fd4e21" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added