### PR TITLE
feat: add accept prop to FileManager and support disabled rows in Grid (Issue #114)

### DIFF
--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -268,6 +268,7 @@ const PopupComponent = (args: DialFileManagerProps) => {
       >
         <DialFileManager
           {...args}
+          accept={['.svg']}
           onPathChange={(path) => {
             if (path) {
               setLoadedPaths((prev) => new Set(prev).add(path));

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -276,7 +276,7 @@ const PopupComponent = (args: DialFileManagerProps) => {
       >
         <DialFileManager
           {...args}
-          accept={['.svg']}
+          accept={['.svg', 'text/plain', 'application/pdf']}
           onPathChange={(path) => {
             if (path) {
               setLoadedPaths((prev) => new Set(prev).add(path));

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -276,7 +276,7 @@ const PopupComponent = (args: DialFileManagerProps) => {
       >
         <DialFileManager
           {...args}
-          accept={['.svg', 'text/plain', 'application/pdf']}
+          allowedFileTypes={['.svg', 'text/plain', 'application/pdf']}
           onPathChange={(path) => {
             if (path) {
               setLoadedPaths((prev) => new Set(prev).add(path));

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -26,7 +26,7 @@ import {
   COMPACT_VIEW_FILE_ROW_HEIGHT,
   DEFAULT_COMPACT_VIEW_WIDTH_BREAKPOINT,
 } from './constants';
-import { findNodeByPath } from './utils';
+import { findNodeByPath, isFileAccepted } from './utils';
 import { DialCollapsibleSidebar } from '@/components/CollapsibleSidebar/CollapsibleSidebar';
 import type { DialFile, DialRootFolder } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
@@ -55,6 +55,7 @@ import {
   type DialDeletedItem,
   type DialUploadFileItem,
   type DialFileManagerActionsRef,
+  type DialFileAcceptType,
 } from '@/models/file-manager';
 import {
   IconCopy,
@@ -244,6 +245,7 @@ export interface DialFileManagerProps {
   path?: string;
   className?: string;
 
+  accept?: DialFileAcceptType[];
   items?: DialFile[];
   rootItem?: DialRootFolder;
   filesLoading?: boolean;
@@ -387,6 +389,8 @@ export interface DialFileManagerProps {
  * @param [sharedByMePaths] - Set of items paths that the user has shared with others. Enables UI indicators (icons/badges) in the tree and grid.
  *
  * @param [actionsRef] - Ref exposing a limited set of imperative File Manager actions (e.g., creating a folder). Allows parent components to trigger internal behaviors programmatically. This ref is not a DOM ref and should be used only for invoking the component’s public actions API.
+ *
+ * @param [accept] - Accepted file types (same format as HTML `<input accept>`); controls upload filtering and disabled items in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), extensions (e.g. `.svg`), and *\/\*.
  */
 export const DialFileManager: FC<DialFileManagerProps> = (props) => {
   return (
@@ -417,6 +421,7 @@ export const DialFileManagerView: FC = () => {
     conflictResolutionPopupOptions,
     compactViewWidthBreakpoint = DEFAULT_COMPACT_VIEW_WIDTH_BREAKPOINT,
     sharedByMePaths,
+    accept,
 
     areHiddenFilesVisible,
     toggleHiddenFilesVisibility,
@@ -547,6 +552,18 @@ export const DialFileManagerView: FC = () => {
     compactViewWidthBreakpoint,
   );
 
+  const isRowDisabled = useCallback(
+    (row: FileManagerGridRow, accept?: DialFileAcceptType[]) => {
+      const isFileTypeAccepted =
+        row.nodeType === DialFileNodeType.FOLDER ||
+        !row.contentType ||
+        isFileAccepted(accept, row.contentType, row.name);
+
+      return !isFileTypeAccepted;
+    },
+    [],
+  );
+
   const defaultColumns = useMemo<ColDef<GridRow>[]>(() => {
     return [
       {
@@ -603,6 +620,7 @@ export const DialFileManagerView: FC = () => {
           const isBeingRenamed =
             renameTriggerView === FileManagerRenameTriggerView.Grid &&
             renamedPath === params.data?.path;
+
           if (isBeingRenamed && renamedItem && params.data) {
             const displayName = getDisplayName(renamedItem);
             return (
@@ -821,6 +839,14 @@ export const DialFileManagerView: FC = () => {
     return map;
   }, [selectedFiles, gridRows]);
 
+  const disabledGridRowIds = useMemo(() => {
+    const ids = new Set<string>();
+    gridRows
+      .filter((row) => isRowDisabled(row, accept))
+      .forEach((row) => ids.add(row.path));
+    return ids;
+  }, [accept, gridRows, isRowDisabled]);
+
   const handleSelectionChange = useCallback(
     (newSelectedGridRows: Map<string, GridRow>) => {
       const newSelectedFiles = new Map<string, DialFile>();
@@ -1012,6 +1038,8 @@ export const DialFileManagerView: FC = () => {
 
   const { actionsColumnDef } = useGridActionsColumn({
     getContextMenuItems: getGridContextMenuItems,
+    isRowDisabled,
+    accept,
   });
 
   const baseColumns = userColumnDefs ?? defaultColumns;
@@ -1157,6 +1185,7 @@ export const DialFileManagerView: FC = () => {
               selectedRows={selectedGridRows}
               onSelectionChangeWithMap={handleSelectionChange}
               wrapperBorder={!isDragging && !isDraggingOverWindow}
+              disabledRowIds={disabledGridRowIds}
             />
           </section>
         </div>

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -246,7 +246,7 @@ export interface DialFileManagerProps {
   path?: string;
   className?: string;
 
-  accept?: DialFileAcceptType[];
+  allowedFileTypes?: DialFileAcceptType[];
   items?: DialFile[];
   rootItem?: DialRootFolder;
   filesLoading?: boolean;
@@ -396,7 +396,7 @@ export interface DialFileManagerProps {
  *
  * @param [actionsRef] - Ref exposing a limited set of imperative File Manager actions (e.g., creating a folder). Allows parent components to trigger internal behaviors programmatically. This ref is not a DOM ref and should be used only for invoking the component’s public actions API.
  *
- * @param [accept] - Accepted file types (same format as HTML `<input accept>`); controls upload filtering and disabled items in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), extensions (e.g. `.svg`), and *\/\*.
+ * @param allowedFileTypes - Allowed file types (same format as the HTML `<input accept>` attribute). Controls upload filtering and which items are disabled in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), and extensions (e.g. `.svg`).
  */
 export const DialFileManager: FC<DialFileManagerProps> = (props) => {
   return (
@@ -427,7 +427,7 @@ export const DialFileManagerView: FC = () => {
     conflictResolutionPopupOptions,
     compactViewWidthBreakpoint = DEFAULT_COMPACT_VIEW_WIDTH_BREAKPOINT,
     sharedByMePaths,
-    accept,
+    allowedFileTypes,
 
     areHiddenFilesVisible,
     toggleHiddenFilesVisibility,
@@ -571,11 +571,11 @@ export const DialFileManagerView: FC = () => {
   }, [isSearchMode, visibleColumns]);
 
   const isRowDisabled = useCallback(
-    (row: FileManagerGridRow, accept?: DialFileAcceptType[]) => {
+    (row: FileManagerGridRow, allowedFileTypes?: DialFileAcceptType[]) => {
       const isFileTypeAccepted =
         row.nodeType === DialFileNodeType.FOLDER ||
         !row.contentType ||
-        isFileAccepted(accept, row.contentType, row.name);
+        isFileAccepted(allowedFileTypes, row.contentType, row.name);
 
       return !isFileTypeAccepted;
     },
@@ -870,10 +870,10 @@ export const DialFileManagerView: FC = () => {
   const disabledGridRowIds = useMemo(() => {
     const ids = new Set<string>();
     gridRows
-      .filter((row) => isRowDisabled(row, accept))
+      .filter((row) => isRowDisabled(row, allowedFileTypes))
       .forEach((row) => ids.add(row.path));
     return ids;
-  }, [accept, gridRows, isRowDisabled]);
+  }, [allowedFileTypes, gridRows, isRowDisabled]);
 
   const handleSelectionChange = useCallback(
     (newSelectedGridRows: Map<string, GridRow>) => {
@@ -1067,7 +1067,7 @@ export const DialFileManagerView: FC = () => {
   const { actionsColumnDef } = useGridActionsColumn({
     getContextMenuItems: getGridContextMenuItems,
     isRowDisabled,
-    accept,
+    allowedFileTypes: allowedFileTypes,
   });
 
   const baseColumns = userColumnDefs ?? defaultColumns;

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -17,7 +17,10 @@ import type { FileUploadValidationMessages } from './hooks/use-file-upload';
 import type { DropdownItem } from '@/models/dropdown';
 import type { FileConflictDecision } from './components/ConflictResolutionPopup/ConflictResolutionPopup';
 import type { DestinationFolderMode } from '@/types/file-manager';
-import type { DialFileManagerActionsRef } from '@/models/file-manager';
+import type {
+  DialFileAcceptType,
+  DialFileManagerActionsRef,
+} from '@/models/file-manager';
 
 export interface FileManagerGridRow {
   id: string;
@@ -30,12 +33,14 @@ export interface FileManagerGridRow {
   extension?: string;
   isTemporary?: boolean;
   owner?: string;
+  contentType?: string;
 }
 
 export interface FileManagerContextValue {
   className?: string;
   items: DialFile[];
   rootItem?: DialRootFolder;
+  accept?: DialFileAcceptType[];
   filesLoading?: boolean;
   treeOptions?: FileTreeOptions;
   navigationPanelOptions?: NavigationPanelOptions;

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -40,7 +40,7 @@ export interface FileManagerContextValue {
   className?: string;
   items: DialFile[];
   rootItem?: DialRootFolder;
-  accept?: DialFileAcceptType[];
+  allowedFileTypes?: DialFileAcceptType[];
   filesLoading?: boolean;
   treeOptions?: FileTreeOptions;
   navigationPanelOptions?: NavigationPanelOptions;

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -92,6 +92,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   onUnshareFile,
   actionsRef,
   sharedByMePaths,
+  accept,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<Map<string, DialFile>>(
     new Map(),
@@ -317,7 +318,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       source = source.filter((node) => !isHiddenDotFile(node));
     }
 
-    const mapped = source.map((node) => ({
+    const mapped: FileManagerGridRow[] = source.map((node) => ({
       id: node.id ?? node.path,
       name: node.name ?? node.path.split('/').pop() ?? '',
       updatedAt: node.updatedAt,
@@ -331,6 +332,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       extension: node.extension,
       isTemporary: false,
       owner: node.owner,
+      contentType: node.contentType,
     }));
 
     if (isCreatingFolder && newFolderTempId && !query) {
@@ -432,6 +434,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   const value: FileManagerContextValue = {
     className,
     items,
+    accept,
     rootItem,
     filesLoading,
     treeOptions: {

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -82,6 +82,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   renameValidationMessages,
   onUploadFiles,
   onValidateUpload,
+  uploadValidationMessages,
   maxFileSize,
   onUploadArchive,
   onCreateFolder,
@@ -262,6 +263,8 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     onValidateUpload,
     maxFileSize,
     onUploadArchive,
+    accept,
+    validationMessages: uploadValidationMessages,
   });
 
   const handleDrop = useCallback(

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -98,7 +98,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   searchResults,
   searchInProgress,
   clearSearchResults,
-  accept,
+  allowedFileTypes,
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<Map<string, DialFile>>(
     new Map(),
@@ -274,7 +274,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     onValidateUpload,
     maxFileSize,
     onUploadArchive,
-    accept,
+    allowedFileTypes,
     validationMessages: uploadValidationMessages,
   });
 
@@ -480,7 +480,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   const value: FileManagerContextValue = {
     className,
     items,
-    accept,
+    allowedFileTypes,
     rootItem,
     filesLoading,
     treeOptions: {

--- a/src/components/FileManager/__mocks__/files.ts
+++ b/src/components/FileManager/__mocks__/files.ts
@@ -413,6 +413,7 @@ export const itemsMock: DialFile[] = [
             path: '/All files/Design/ThisIsAVeryLongFolderNameWithoutSpacesToTestTheUIBehaviorInDifferentComponents',
             parentPath: '/All files/Design',
             nodeType: DialFileNodeType.ITEM,
+            contentType: 'image/png',
             folderId: 'design',
             updatedAt: '2025-01-11',
             items: [],

--- a/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
+++ b/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
@@ -977,7 +977,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['application/pdf'],
+          allowedFileTypes: ['application/pdf'],
         }),
       );
 
@@ -1008,7 +1008,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['image/*'],
+          allowedFileTypes: ['image/*'],
           validationMessages: {
             unsupportedFiles: 'Custom unsupported message',
           },
@@ -1040,7 +1040,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['text/plain'],
+          allowedFileTypes: ['text/plain'],
         }),
       );
 
@@ -1072,7 +1072,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['.pdf'],
+          allowedFileTypes: ['.pdf'],
         }),
       );
 
@@ -1101,7 +1101,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['text/plain'],
+          allowedFileTypes: ['text/plain'],
         }),
       );
 
@@ -1136,7 +1136,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       const { result } = renderHook(() =>
         useFileUpload({
           onUploadFiles,
-          accept: ['*/*'],
+          allowedFileTypes: ['*/*'],
         }),
       );
 

--- a/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
+++ b/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
@@ -969,4 +969,202 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       expect(document.body.contains(input)).toBe(false);
     });
   });
+
+  describe('accept file types validation', () => {
+    it('blocks upload when all files are not accepted', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['application/pdf'],
+        }),
+      );
+
+      const files = [new File([''], 'test.txt', { type: 'text/plain' })];
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files,
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(onUploadFiles).not.toHaveBeenCalled();
+      expect(result.current.uploadError).toBe(
+        'Selected files are not supported',
+      );
+    });
+
+    it('uses custom unsupportedFiles validation message', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['image/*'],
+          validationMessages: {
+            unsupportedFiles: 'Custom unsupported message',
+          },
+        }),
+      );
+
+      const files = [new File([''], 'doc.pdf', { type: 'application/pdf' })];
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files,
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(onUploadFiles).not.toHaveBeenCalled();
+      expect(result.current.uploadError).toBe('Custom unsupported message');
+    });
+
+    it('allows upload when file matches accept MIME type', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['text/plain'],
+        }),
+      );
+
+      const file = new File([''], 'test.txt', { type: 'text/plain' });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files: [file],
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(result.current.uploadError).toBeUndefined();
+      expect(onUploadFiles).toHaveBeenCalledWith(
+        [{ fileContent: file, name: 'test.txt' }],
+        '/folder',
+      );
+    });
+
+    it('allows upload when file matches accept extension', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['.pdf'],
+        }),
+      );
+
+      const file = new File([''], 'doc.pdf', { type: '' });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files: [file],
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(onUploadFiles).toHaveBeenCalled();
+      expect(result.current.uploadError).toBeUndefined();
+    });
+
+    it('filters out unsupported files and uploads only accepted ones', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['text/plain'],
+        }),
+      );
+
+      const files = [
+        new File([''], 'a.txt', { type: 'text/plain' }),
+        new File([''], 'b.pdf', { type: 'application/pdf' }),
+      ];
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files,
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(onUploadFiles).toHaveBeenCalledWith(
+        [{ fileContent: files[0], name: 'a.txt' }],
+        '/folder',
+      );
+      expect(result.current.uploadError).toBeUndefined();
+    });
+
+    it('does not filter files when accept contains */*', async () => {
+      const onUploadFiles = vi.fn();
+
+      const { result } = renderHook(() =>
+        useFileUpload({
+          onUploadFiles,
+          accept: ['*/*'],
+        }),
+      );
+
+      const files = [
+        new File([''], 'a.txt', { type: 'text/plain' }),
+        new File([''], 'b.pdf', { type: 'application/pdf' }),
+      ];
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files,
+        },
+      } as unknown as DragEvent;
+
+      await act(async () => {
+        await result.current.handleDrop(mockEvent, '/folder', []);
+      });
+
+      expect(onUploadFiles).toHaveBeenCalledWith(
+        [
+          { fileContent: files[0], name: 'a.txt' },
+          { fileContent: files[1], name: 'b.pdf' },
+        ],
+        '/folder',
+      );
+    });
+  });
 });

--- a/src/components/FileManager/hooks/use-file-upload.tsx
+++ b/src/components/FileManager/hooks/use-file-upload.tsx
@@ -39,7 +39,7 @@ export interface UseFileUploadOptions {
     destinationFolder: string,
   ) => FileUploadValidationResult | Promise<FileUploadValidationResult>;
   maxFileSize?: number;
-  accept?: DialFileAcceptType[];
+  allowedFileTypes?: DialFileAcceptType[];
   validationMessages?: FileUploadValidationMessages;
   onUploadArchive?: (
     file: File,
@@ -58,7 +58,7 @@ export const useFileUpload = ({
   onUploadFiles,
   onValidateUpload,
   maxFileSize,
-  accept,
+  allowedFileTypes,
   validationMessages = {},
   onUploadArchive,
 }: UseFileUploadOptions = {}) => {
@@ -79,13 +79,13 @@ export const useFileUpload = ({
 
   const filterAcceptedFiles = useCallback(
     (files: DialUploadFileItem[]) => {
-      if (!accept || accept.includes('*/*')) return files;
+      if (!allowedFileTypes || allowedFileTypes.includes('*/*')) return files;
 
       return files.filter(({ fileContent, name }) =>
-        isFileAccepted(accept, fileContent.type, name),
+        isFileAccepted(allowedFileTypes, fileContent.type, name),
       );
     },
-    [accept],
+    [allowedFileTypes],
   );
 
   const {
@@ -385,8 +385,8 @@ export const useFileUpload = ({
       fileInputRef.current = input;
     }
 
-    if (accept && accept.length > 0) {
-      input.accept = accept.join(',');
+    if (allowedFileTypes && allowedFileTypes.length > 0) {
+      input.accept = allowedFileTypes.join(',');
     } else {
       input.removeAttribute('accept');
     }
@@ -432,7 +432,7 @@ export const useFileUpload = ({
         fileInputRef.current = null;
       }
     };
-  }, [accept, filterAcceptedFiles, handleUpload, validationMessages]);
+  }, [allowedFileTypes, filterAcceptedFiles, handleUpload, validationMessages]);
 
   const openFileDialog = useCallback(
     (destinationFolder: string, existingFiles: DialFile[]) => {

--- a/src/components/FileManager/hooks/use-file-upload.tsx
+++ b/src/components/FileManager/hooks/use-file-upload.tsx
@@ -6,10 +6,14 @@ import {
   useRef,
 } from 'react';
 import { DialFileNodeType, type DialFile } from '@/models/file';
-import type { DialUploadFileItem } from '@/models/file-manager';
+import type {
+  DialFileAcceptType,
+  DialUploadFileItem,
+} from '@/models/file-manager';
 import { FILES_DATA_TRANSFER_TYPE } from '@/components/FileManager/constants';
 import { useConflictResolution } from './use-conflict-resolution';
 import type { FileConflictDecision } from '@/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup';
+import { isFileAccepted } from '../utils';
 
 export interface FileUploadValidationResult {
   valid: boolean;
@@ -19,6 +23,7 @@ export interface FileUploadValidationResult {
 export interface FileUploadValidationMessages {
   duplicateFiles?: string;
   oversizedFiles?: string;
+  unsupportedFiles?: string;
   validationFailed?: string;
   validationError?: string;
 }
@@ -34,6 +39,7 @@ export interface UseFileUploadOptions {
     destinationFolder: string,
   ) => FileUploadValidationResult | Promise<FileUploadValidationResult>;
   maxFileSize?: number;
+  accept?: DialFileAcceptType[];
   validationMessages?: FileUploadValidationMessages;
   onUploadArchive?: (
     file: File,
@@ -52,6 +58,7 @@ export const useFileUpload = ({
   onUploadFiles,
   onValidateUpload,
   maxFileSize,
+  accept,
   validationMessages = {},
   onUploadArchive,
 }: UseFileUploadOptions = {}) => {
@@ -69,6 +76,17 @@ export const useFileUpload = ({
   const [uploadMetadata, setUploadMetadata] = useState<{
     destinationFolder: string;
   } | null>(null);
+
+  const filterAcceptedFiles = useCallback(
+    (files: DialUploadFileItem[]) => {
+      if (!accept || accept.includes('*/*')) return files;
+
+      return files.filter(({ fileContent, name }) =>
+        isFileAccepted(accept, fileContent.type, name),
+      );
+    },
+    [accept],
+  );
 
   const {
     conflictingFiles,
@@ -331,15 +349,28 @@ export const useFileUpload = ({
       }
 
       const files = Array.from(e.dataTransfer.files);
-      if (files.length > 0) {
-        const uploadItems: DialUploadFileItem[] = files.map((file) => ({
-          fileContent: file,
-          name: file.name,
-        }));
-        await handleUpload(uploadItems, destinationFolder, existingFiles);
+      if (files.length === 0) {
+        return;
       }
+
+      const uploadItems: DialUploadFileItem[] = files.map((file) => ({
+        fileContent: file,
+        name: file.name,
+      }));
+
+      const acceptedItems = filterAcceptedFiles(uploadItems);
+
+      if (acceptedItems.length === 0) {
+        setUploadError(
+          validationMessages.unsupportedFiles ||
+            'Selected files are not supported',
+        );
+        return;
+      }
+
+      await handleUpload(acceptedItems, destinationFolder, existingFiles);
     },
-    [handleUpload],
+    [handleUpload, filterAcceptedFiles, validationMessages],
   );
 
   useEffect(() => {
@@ -354,6 +385,12 @@ export const useFileUpload = ({
       fileInputRef.current = input;
     }
 
+    if (accept && accept.length > 0) {
+      input.accept = accept.join(',');
+    } else {
+      input.removeAttribute('accept');
+    }
+
     const handleChange = async () => {
       if (!input?.files?.length) return;
 
@@ -363,8 +400,19 @@ export const useFileUpload = ({
         name: file.name,
       }));
 
+      const acceptedItems = filterAcceptedFiles(uploadItems);
+
+      if (acceptedItems.length === 0) {
+        setUploadError(
+          validationMessages.unsupportedFiles ||
+            'Selected files are not supported',
+        );
+        input.value = '';
+        return;
+      }
+
       await handleUpload(
-        uploadItems,
+        acceptedItems,
         destinationFolderRef.current,
         existingFilesRef.current,
       );
@@ -384,7 +432,7 @@ export const useFileUpload = ({
         fileInputRef.current = null;
       }
     };
-  }, [handleUpload]);
+  }, [accept, filterAcceptedFiles, handleUpload, validationMessages]);
 
   const openFileDialog = useCallback(
     (destinationFolder: string, existingFiles: DialFile[]) => {

--- a/src/components/FileManager/hooks/use-grid-actions-column.tsx
+++ b/src/components/FileManager/hooks/use-grid-actions-column.tsx
@@ -12,21 +12,21 @@ interface UseGridActionsColumnProps {
   getContextMenuItems: (row: FileManagerGridRow) => DropdownItem[];
   isRowDisabled: (
     row: FileManagerGridRow,
-    accept?: DialFileAcceptType[],
+    allowedFileTypes?: DialFileAcceptType[],
   ) => boolean;
-  accept?: DialFileAcceptType[];
+  allowedFileTypes?: DialFileAcceptType[];
 }
 
 export const useGridActionsColumn = ({
   getContextMenuItems,
   isRowDisabled,
-  accept,
+  allowedFileTypes,
 }: UseGridActionsColumnProps) => {
   const renderActionsCell = useCallback(
     (p: ICellRendererParams<FileManagerGridRow, unknown>) => {
       if (!p.data) return null;
 
-      const disabled = isRowDisabled(p.data, accept);
+      const disabled = isRowDisabled(p.data, allowedFileTypes);
 
       if (disabled) return null;
 
@@ -48,7 +48,7 @@ export const useGridActionsColumn = ({
         </DialDropdown>
       );
     },
-    [accept, getContextMenuItems, isRowDisabled],
+    [allowedFileTypes, getContextMenuItems, isRowDisabled],
   );
 
   const actionsColumnDef: ColDef<FileManagerGridRow> = useMemo(

--- a/src/components/FileManager/hooks/use-grid-actions-column.tsx
+++ b/src/components/FileManager/hooks/use-grid-actions-column.tsx
@@ -6,17 +6,29 @@ import type { ColDef, ICellRendererParams } from 'ag-grid-community';
 import { useCallback, useMemo } from 'react';
 import type { FileManagerGridRow } from '@/components/FileManager/FileManagerContext';
 import type { DropdownItem } from '@/models/dropdown';
+import type { DialFileAcceptType } from '@/models/file-manager';
 
 interface UseGridActionsColumnProps {
   getContextMenuItems: (row: FileManagerGridRow) => DropdownItem[];
+  isRowDisabled: (
+    row: FileManagerGridRow,
+    accept?: DialFileAcceptType[],
+  ) => boolean;
+  accept?: DialFileAcceptType[];
 }
 
 export const useGridActionsColumn = ({
   getContextMenuItems,
+  isRowDisabled,
+  accept,
 }: UseGridActionsColumnProps) => {
   const renderActionsCell = useCallback(
     (p: ICellRendererParams<FileManagerGridRow, unknown>) => {
       if (!p.data) return null;
+
+      const disabled = isRowDisabled(p.data, accept);
+
+      if (disabled) return null;
 
       const items = p.data ? (getContextMenuItems?.(p.data) ?? []) : [];
 
@@ -36,7 +48,7 @@ export const useGridActionsColumn = ({
         </DialDropdown>
       );
     },
-    [getContextMenuItems],
+    [accept, getContextMenuItems, isRowDisabled],
   );
 
   const actionsColumnDef: ColDef<FileManagerGridRow> = useMemo(

--- a/src/components/FileManager/utils.ts
+++ b/src/components/FileManager/utils.ts
@@ -1,4 +1,5 @@
 import { DialFileNodeType, type DialFile } from '@/models/file';
+import type { DialFileAcceptType } from '@/models/file-manager';
 
 export const findNodeByPath = (
   nodes: DialFile[] | undefined,
@@ -110,3 +111,35 @@ export const formatDate = (
     return date;
   }
 };
+
+export function isFileAccepted(
+  accept: DialFileAcceptType[] | undefined,
+  contentType: string,
+  fileName?: string,
+): boolean {
+  if (!accept || accept.length === 0 || accept.includes('*/*')) {
+    return true;
+  }
+
+  const normalizedType = contentType.toLowerCase();
+
+  const extension =
+    fileName && fileName.includes('.')
+      ? `.${fileName.split('.').at(-1)!.toLowerCase()}`
+      : undefined;
+
+  return accept.some((rule) => {
+    const normalizedRule = rule.toLowerCase();
+
+    if (normalizedRule.startsWith('.')) {
+      return extension === normalizedRule;
+    }
+
+    if (normalizedRule.endsWith('/*')) {
+      const baseType = normalizedRule.slice(0, -1);
+      return normalizedType.startsWith(baseType);
+    }
+
+    return normalizedType === normalizedRule;
+  });
+}

--- a/src/components/FileManager/utils.ts
+++ b/src/components/FileManager/utils.ts
@@ -113,11 +113,15 @@ export const formatDate = (
 };
 
 export function isFileAccepted(
-  accept: DialFileAcceptType[] | undefined,
+  allowedFileTypes: DialFileAcceptType[] | undefined,
   contentType: string,
   fileName?: string,
 ): boolean {
-  if (!accept || accept.length === 0 || accept.includes('*/*')) {
+  if (
+    !allowedFileTypes ||
+    allowedFileTypes.length === 0 ||
+    allowedFileTypes.includes('*/*')
+  ) {
     return true;
   }
 
@@ -128,7 +132,7 @@ export function isFileAccepted(
       ? `.${fileName.split('.').at(-1)!.toLowerCase()}`
       : undefined;
 
-  return accept.some((rule) => {
+  return allowedFileTypes.some((rule) => {
     const normalizedRule = rule.toLowerCase();
 
     if (normalizedRule.startsWith('.')) {

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -326,6 +326,13 @@ export const ClickableRows: Story = {
   },
 };
 
+export const WithDisabledRows: Story = {
+  args: {
+    selectedRowIds: undefined,
+    disabledRowIds: new Set(['1', '3']),
+  },
+};
+
 export const EmptyState: Story = {
   args: {
     selectedRowIds: undefined,

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -44,6 +44,7 @@ export interface DialGridProps<T extends object = Record<string, unknown>> {
   ariaLabel?: string;
   withSelectionColumn?: boolean;
   wrapCustomCellRenderers?: boolean | ((col: ColDef<T>) => boolean);
+  disabledRowIds?: Set<string>;
   selectedRowIds?: Set<string>;
   selectedRows?: Map<string, T>;
   selectionOnHover?: boolean;
@@ -159,6 +160,7 @@ export const DialGrid = <T extends object>({
   ariaLabel = 'Data grid',
   withSelectionColumn = true,
   wrapCustomCellRenderers = true,
+  disabledRowIds,
   selectedRowIds,
   selectedRows,
   selectionOnHover = true,
@@ -192,6 +194,7 @@ export const DialGrid = <T extends object>({
     onSelectionChangeWithMap,
     rowData,
     getRowId,
+    disabledRowIds,
   });
 
   const themeParams = useMemo(
@@ -212,12 +215,16 @@ export const DialGrid = <T extends object>({
 
   const getRowClass = useCallback(
     (params: RowClassParams<T>) => {
-      if (params.data) {
-        const rowId = getRowId(params.data);
-        return currentSelectedIds.has(rowId) ? 'ag-row-selected' : '';
-      }
+      if (!params.data) return '';
+
+      const rowId = getRowId(params.data);
+
+      return classNames({
+        'ag-row-selected': currentSelectedIds.has(rowId),
+        'opacity-50': disabledRowIds?.has(rowId),
+      });
     },
-    [currentSelectedIds, getRowId],
+    [currentSelectedIds, disabledRowIds, getRowId],
   );
 
   const renderHeaderSelectCell = useCallback(() => {
@@ -225,12 +232,17 @@ export const DialGrid = <T extends object>({
     const indeterminate = headerCheckboxState === 'indeterminate';
     const checkboxId = 'header-select-all';
 
+    const hasEnabledRows =
+      rowData?.some((row) => !disabledRowIds?.has(getRowId(row))) ?? false;
+
     return (
       <div className="flex items-center justify-center h-full header-checkbox-container">
         <DialCheckbox
           id={checkboxId}
           ariaLabel="Select all rows"
           checked={checked}
+          disabled={!hasEnabledRows}
+          aria-disabled={!hasEnabledRows}
           indeterminate={indeterminate}
           className={classNames(
             `dial-header-select ${headerCheckboxState}`,
@@ -240,13 +252,23 @@ export const DialGrid = <T extends object>({
         />
       </div>
     );
-  }, [headerCheckboxState, handleHeaderCheckboxChange, selectionOnHover]);
+  }, [
+    headerCheckboxState,
+    rowData,
+    selectionOnHover,
+    handleHeaderCheckboxChange,
+    disabledRowIds,
+    getRowId,
+  ]);
 
   const renderDataCell = useCallback(
     (p: ICellRendererParams<T, unknown>) => {
       if (p.data) {
-        const items = getContextMenuItems?.(p.data) ?? [];
+        const rowId = getRowId(p.data);
+        const disabled = disabledRowIds?.has(rowId);
         const valueText = p.value == null ? '' : String(p.value);
+        const items = getContextMenuItems?.(p.data) ?? [];
+
         return (
           <DialDropdown
             trigger={[DropdownTrigger.ContextMenu]}
@@ -254,6 +276,7 @@ export const DialGrid = <T extends object>({
             anchorToMouse
             matchReferenceWidth
             className="w-full"
+            disabled={disabled}
           >
             <span className="block min-w-0 h-full max-w-full">
               <DialEllipsisTooltip
@@ -265,14 +288,16 @@ export const DialGrid = <T extends object>({
         );
       }
     },
-    [getContextMenuItems],
+    [getContextMenuItems, disabledRowIds, getRowId],
   );
 
   const renderSelectCell = useCallback(
     (p: ICellRendererParams<T, unknown>) => {
       if (!p.data) return null;
+
       const rowId = getRowId(p.data);
       const checked = currentSelectedIds.has(rowId);
+      const disabled = disabledRowIds?.has(rowId);
       const checkboxId = `row-select-${rowId}`;
 
       return (
@@ -282,20 +307,28 @@ export const DialGrid = <T extends object>({
             id={checkboxId}
             ariaLabel="Select row"
             checked={checked}
-            className={classNames([
+            disabled={disabled}
+            aria-disabled={disabled}
+            className={classNames(
               'dial-row-select',
               !selectionOnHover && 'dial-row-select-visible',
-            ])}
+              disabled && 'opacity-50 cursor-not-allowed',
+            )}
             onChange={(next) => {
-              if (p.data) {
-                handleSelectionToggle(p.data, !!next);
-              }
+              if (disabled || !p.data) return;
+              handleSelectionToggle(p.data, !!next);
             }}
           />
         </div>
       );
     },
-    [currentSelectedIds, getRowId, handleSelectionToggle, selectionOnHover],
+    [
+      currentSelectedIds,
+      disabledRowIds,
+      getRowId,
+      handleSelectionToggle,
+      selectionOnHover,
+    ],
   );
 
   const wrapRendererIfNeeded = useCallback(
@@ -326,6 +359,9 @@ export const DialGrid = <T extends object>({
           content = renderDataCell(p);
         }
 
+        const rowId = p.data ? getRowId(p.data) : null;
+        const disabled = rowId ? disabledRowIds?.has(rowId) : false;
+
         return (
           <DialDropdown
             trigger={[DropdownTrigger.ContextMenu]}
@@ -333,6 +369,7 @@ export const DialGrid = <T extends object>({
             anchorToMouse
             matchReferenceWidth
             className="w-full h-full"
+            disabled={disabled}
           >
             <span className="block min-w-0 max-w-full flex-1">{content}</span>
           </DialDropdown>
@@ -341,7 +378,13 @@ export const DialGrid = <T extends object>({
 
       return { ...col, cellRenderer: Wrapped };
     },
-    [getContextMenuItems, renderDataCell, wrapCustomCellRenderers],
+    [
+      disabledRowIds,
+      getContextMenuItems,
+      getRowId,
+      renderDataCell,
+      wrapCustomCellRenderers,
+    ],
   );
 
   const selectCol: ColDef<T> = useMemo(

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -136,6 +136,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
  * @param [ariaLabel='Data grid'] - Accessible label for the grid region
  * @param [withSelectionColumn=true] - Whether to show the checkbox selection column
  * @param [wrapCustomCellRenderers=true] - Whether to wrap custom cell renderers with context menu support
+ * @param [disabledRowIds] - Set of row IDs that should be disabled. Disabled rows are non-interactive and cannot be selected. IDs must match values from `getRowId`.
  * @param [selectedRowIds] - Controlled selection: set of row IDs that should be selected
  * @param [selectedRows] - Controlled selection: map of row IDs to row data for selected rows
  * @param [selectionOnHover=true] - Whether row selection highlights are shown on hover

--- a/src/components/Grid/hooks/use-grid-selection.ts
+++ b/src/components/Grid/hooks/use-grid-selection.ts
@@ -7,6 +7,7 @@ export interface UseGridSelectionProps<T extends object> {
   onSelectionChangeWithMap?: (selectedRows: Map<string, T>) => void;
   rowData?: T[];
   getRowId: (row: T) => string;
+  disabledRowIds?: Set<string>;
 }
 
 export const useGridSelection = <T extends object>({
@@ -16,6 +17,7 @@ export const useGridSelection = <T extends object>({
   onSelectionChangeWithMap,
   rowData = [],
   getRowId,
+  disabledRowIds,
 }: UseGridSelectionProps<T>) => {
   const [internalSelectedRows, setInternalSelectedRows] = useState<
     Map<string, T>
@@ -27,6 +29,16 @@ export const useGridSelection = <T extends object>({
     [currentSelectedRows],
   );
 
+  const isRowDisabled = useCallback(
+    (row: T) => disabledRowIds?.has(getRowId(row)) ?? false,
+    [disabledRowIds, getRowId],
+  );
+
+  const enabledRows = useMemo(
+    () => rowData.filter((row) => !isRowDisabled(row)),
+    [rowData, isRowDisabled],
+  );
+
   const isControlled =
     selectedRowIds !== undefined || selectedRows !== undefined;
 
@@ -35,7 +47,7 @@ export const useGridSelection = <T extends object>({
       const newMap = new Map<string, T>();
       rowData.forEach((row) => {
         const id = getRowId(row);
-        if (selectedRowIds.has(id)) {
+        if (selectedRowIds.has(id) && !disabledRowIds?.has(id)) {
           newMap.set(id, row);
         }
       });
@@ -48,11 +60,23 @@ export const useGridSelection = <T extends object>({
         setInternalSelectedRows(newMap);
       }
     }
-  }, [selectedRowIds, selectedRows, rowData, getRowId, internalSelectedRows]);
+  }, [
+    selectedRowIds,
+    selectedRows,
+    rowData,
+    getRowId,
+    disabledRowIds,
+    internalSelectedRows,
+  ]);
 
   const handleSelectionToggle = useCallback(
     (row: T, checked: boolean) => {
       const rowId = getRowId(row);
+
+      if (disabledRowIds?.has(rowId)) {
+        return;
+      }
+
       const newMap = new Map(currentSelectedRows);
 
       if (checked) {
@@ -65,19 +89,16 @@ export const useGridSelection = <T extends object>({
         setInternalSelectedRows(newMap);
       }
 
-      if (onSelectionChangeWithMap) {
-        onSelectionChangeWithMap(newMap);
-      }
+      onSelectionChangeWithMap?.(newMap);
 
       if (onSelectionChange) {
-        const ids = new Set(newMap.keys());
-        const rows = Array.from(newMap.values());
-        onSelectionChange(ids, rows);
+        onSelectionChange(new Set(newMap.keys()), Array.from(newMap.values()));
       }
     },
     [
       currentSelectedRows,
       getRowId,
+      disabledRowIds,
       isControlled,
       onSelectionChange,
       onSelectionChangeWithMap,
@@ -85,25 +106,25 @@ export const useGridSelection = <T extends object>({
   );
 
   const headerCheckboxState = useMemo(() => {
-    if (!rowData.length) return 'unchecked';
-    const allSelected = rowData.every((row) =>
-      currentSelectedIds.has(getRowId(row)),
-    );
-    const someSelected = rowData.some((row) =>
-      currentSelectedIds.has(getRowId(row)),
-    );
+    if (!enabledRows.length) return 'unchecked';
 
-    if (allSelected) return 'checked';
-    if (someSelected) return 'indeterminate';
-    return 'unchecked';
-  }, [rowData, currentSelectedIds, getRowId]);
+    const enabledIds = enabledRows.map(getRowId);
+
+    const selectedEnabledCount = enabledIds.filter((id) =>
+      currentSelectedIds.has(id),
+    ).length;
+
+    if (selectedEnabledCount === 0) return 'unchecked';
+    if (selectedEnabledCount === enabledIds.length) return 'checked';
+    return 'indeterminate';
+  }, [enabledRows, currentSelectedIds, getRowId]);
 
   const handleHeaderCheckboxChange = useCallback(
     (checked?: boolean) => {
       const newMap = new Map<string, T>();
 
       if (checked) {
-        rowData.forEach((row) => {
+        enabledRows.forEach((row) => {
           const id = getRowId(row);
           newMap.set(id, row);
         });
@@ -124,7 +145,7 @@ export const useGridSelection = <T extends object>({
       }
     },
     [
-      rowData,
+      enabledRows,
       getRowId,
       isControlled,
       onSelectionChange,

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ export {
   type DialDeletedItem,
   type DialUploadFileItem,
   type DialFileManagerActionsRef,
+  type DialFileAcceptType,
 } from './models/file-manager';
 
 // Utils

--- a/src/models/file-manager.ts
+++ b/src/models/file-manager.ts
@@ -22,5 +22,5 @@ export interface DialFileManagerActionsRef {
 }
 
 export type DialFileAcceptType =
-  | `${string}/${string}` // MIME (incl wildcard)
+  | `${string}/${string}` // MIME (wildcard)
   | `.${string}`; // extension

--- a/src/models/file-manager.ts
+++ b/src/models/file-manager.ts
@@ -20,3 +20,7 @@ export interface DialUploadFileItem {
 export interface DialFileManagerActionsRef {
   createFolder: () => void;
 }
+
+export type DialFileAcceptType =
+  | `${string}/${string}` // MIME (incl wildcard)
+  | `.${string}`; // extension


### PR DESCRIPTION
**Description:**

add accept prop to FileManager and support disabled rows in Grid

Issues:

- Issue #114

**UI changes**

<img width="1031" height="584" alt="image" src="https://github.com/user-attachments/assets/d41c8b1f-abdf-4a0e-9658-87181d2da11a" />
<img width="1043" height="609" alt="image" src="https://github.com/user-attachments/assets/c00d8ae2-f125-4422-86cf-8829d890a2c2" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added