### PR TITLE
fix:  jsdoc for ConfirmationPopup

### DIFF
--- a/src/components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -39,7 +39,7 @@ export interface DialConfirmationPopupProps extends DialPopupProps {
  * ```tsx
  * <ConfirmationModal
  *   open
- *   title="Delete item?"
+ *   header="Delete item?"
  *   description="This action cannot be undone."
  *   confirmLabel="Delete"
  *   onClose={() => setOpen(false)}
@@ -47,7 +47,7 @@ export interface DialConfirmationPopupProps extends DialPopupProps {
  * />
  * ```
  *
- * @param title - Title content for the header
+ * @param header - Title content for the header
  * @param [description] - Secondary text (ignored when `children` set)
  * @param [descriptionClassName] - Custom CSS class for the description
  * @param [open=false] - Controls visibility of the popup

--- a/src/components/FormPopup/FormPopup.tsx
+++ b/src/components/FormPopup/FormPopup.tsx
@@ -33,13 +33,13 @@ export interface DialFormPopupProps extends DialPopupProps {
  * ```tsx
  * <DialFormPopup
  *   open
- *   title="Create Model"
+ *   header="Create Model"
  *   onClose={() => setOpen(false)}
  *   onSubmit={handleSubmit}
  * />
  * ```
  *
- * @param title - Title content for the header
+ * @param header - Title content for the header
  * @param [open=false] - Controls visibility of the popup
  * @param [submitLabel="Submit"] - Label for the primary action button
  * @param [cancelLabel="Cancel"] - Label for the cancel button

--- a/src/components/RadioGroupPopupField/RadioGroupPopupField.tsx
+++ b/src/components/RadioGroupPopupField/RadioGroupPopupField.tsx
@@ -75,7 +75,7 @@ export interface RadioGroupPopupFieldProps
  * @param [inputClassName] - Extra classes applied to the collapsed input container
  * @param emptyValueText - Placeholder text when no value is selected
  * @param [onClose] - Callback fired when the popup closes
- * @param title - Title text shown in the popup header
+ * @param header - Title text shown in the popup header
  * @param [portalId] - Target portal id for rendering the popup
  * @param onApply - Callback fired when the Apply button is clicked
  * @param [cancelButtonTitle="Cancel"] - Text for the Cancel button


### PR DESCRIPTION
**Description:**

Fixed several places where jsdoc uses old property name ('title')

Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added