### PR TITLE
feat: add sourceFolder and disabledPathTooltip to DestinationFolderPopup for improved user feedback

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -124,6 +124,7 @@ export type DialFileManagerDestinationFolderPopupOptions = Pick<
   | 'onCreateFolder'
   | 'onCreateFolderValidate'
   | 'folderCreationValidationMessages'
+  | 'disabledPathTooltip'
 > & {
   getCopyHeader?: (itemsCount: number, itemName?: string) => string;
   getMoveHeader?: (itemsCount: number, itemName?: string) => string;
@@ -1259,6 +1260,7 @@ export const DialFileManagerView: FC = () => {
         onPathChange={(newPath) => {
           destinationFolderPopupOptions?.setDestinationFolderPath?.(newPath);
         }}
+        sourceFolder={currentPath || '/'}
       />
       <ConflictResolutionPopup
         {...conflictResolutionPopupOptions}

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -48,7 +48,9 @@ export interface FileManagerContextValue {
   toolbarOptions?: ToolbarOptions;
   bulkActionsToolbarOptions?: BulkActionsToolbarOptions;
   deleteConfirmationOptions?: DeleteConfirmationOptions;
-  destinationFolderPopupOptions?: DialFileManagerDestinationFolderPopupOptions;
+  destinationFolderPopupOptions?: DialFileManagerDestinationFolderPopupOptions & {
+    sourceFolder?: string;
+  };
   conflictResolutionPopupOptions?: DialFileManagerConflictResolutionPopupOptions;
   fileMetadataPopupOptions?: FileMetadataPopupOptions;
 

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
@@ -491,4 +491,77 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
       expect(rowsAfter.length).toBe(rowsBefore.length + 1);
     });
   });
+
+  test('disables button when destination matches source folder', () => {
+    render(
+      <DestinationFolderPopup
+        open={true}
+        onClose={vi.fn()}
+        mode="move"
+        items={mockFiles}
+        rootItem={{
+          id: 'root',
+          name: 'Root',
+          path: '/',
+          folderId: 'root-folder',
+          nodeType: DialFileNodeType.FOLDER,
+          label: 'Root',
+        }}
+        sourceFolder="/Documents"
+        path="/Documents"
+      />,
+    );
+
+    const moveButton = screen.getByRole('button', { name: 'Move' });
+    expect(moveButton).toBeDisabled();
+  });
+
+  test('enables button when destination differs from source folder', () => {
+    render(
+      <DestinationFolderPopup
+        open={true}
+        onClose={vi.fn()}
+        mode="move"
+        items={mockFiles}
+        rootItem={{
+          id: 'root',
+          name: 'Root',
+          path: '/',
+          folderId: 'root-folder',
+          nodeType: DialFileNodeType.FOLDER,
+          label: 'Root',
+        }}
+        sourceFolder="/Documents"
+        path="/Photos"
+      />,
+    );
+
+    const moveButton = screen.getByRole('button', { name: 'Move' });
+    expect(moveButton).not.toBeDisabled();
+  });
+
+  test('displays tooltip when button is disabled', async () => {
+    render(
+      <DestinationFolderPopup
+        open={true}
+        onClose={vi.fn()}
+        mode="copy"
+        items={mockFiles}
+        rootItem={{
+          id: 'root',
+          name: 'Root',
+          path: '/',
+          folderId: 'root-folder',
+          nodeType: DialFileNodeType.FOLDER,
+          label: 'Root',
+        }}
+        sourceFolder="/Documents"
+        path="/Documents"
+        disabledPathTooltip="Cannot copy to the same location"
+      />,
+    );
+
+    const copyButton = screen.getByRole('button', { name: 'Copy' });
+    expect(copyButton).toBeDisabled();
+  });
 });

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
@@ -66,12 +66,17 @@ const meta: Meta<DestinationFolderPopupProps> = {
     copyLabel: { control: 'text' },
     moveLabel: { control: 'text' },
     hiddenFilesSwitcherLabel: { control: 'text' },
+    disabledPathTooltip: { control: 'text' },
+    sourceFolder: { control: 'text' },
+    destinationFolderPath: { control: 'text' },
   },
   args: {
     mode: 'copy',
     copyLabel: 'Copy',
     moveLabel: 'Move',
     hiddenFilesSwitcherLabel: 'Show hidden files',
+    disabledPathTooltip:
+      'Unavailable for the original path. Please select another folder',
     items: itemsMock,
     rootItem: {
       id: 'root',
@@ -108,5 +113,25 @@ export const CustomLabels: Story = {
     moveLabel: 'Move Here',
     hiddenFilesSwitcherLabel: 'Display hidden items',
     header: '2 item(s) selected to copy',
+  },
+};
+
+export const DisabledDestination: Story = {
+  args: {
+    mode: 'move',
+    sourceFolder: '/Documents',
+    path: '/Documents',
+    header: 'Moving 1 item: Project Files',
+  },
+};
+
+export const CustomDisabledTooltip: Story = {
+  args: {
+    mode: 'copy',
+    sourceFolder: '/Photos/2024',
+    path: '/Photos/2024',
+    disabledPathTooltip:
+      'Cannot copy to the same location. Choose a different folder.',
+    header: 'Copying 3 items',
   },
 };

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -9,9 +9,17 @@ import { ButtonVariant } from '@/types/button';
 import { IconFolderPlus } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import { DialSwitch } from '@/components/Switch/Switch';
-import { useState, useCallback, type FC, useRef, type ReactNode } from 'react';
+import {
+  useState,
+  useCallback,
+  type FC,
+  useRef,
+  type ReactNode,
+  useMemo,
+} from 'react';
 import { DestinationFolderMode } from '@/types/file-manager';
 import type { DialFileManagerActionsRef } from '@/models/file-manager';
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
 
 export interface DestinationFolderPopupProps extends DialFileManagerProps {
   onClose: () => void;
@@ -25,6 +33,8 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
   hiddenFilesSwitcherLabel?: string;
   mode?: 'copy' | 'move';
   header?: ReactNode;
+  sourceFolder?: string;
+  disabledPathTooltip?: string;
 }
 
 /**
@@ -62,6 +72,8 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
  * @param rootItem - Root folder item
  * @param path - Current path in the File Manager
  * @param onPathChange - Callback fired when the path changes
+ * @param [sourceFolder] - The source folder path for move operations
+ * @param [disabledPathTooltip="Unavailable for the original path. Please select another folder"] - Tooltip text when destination is disabled
  */
 export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   onClose,
@@ -76,6 +88,9 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   onValidateUpload,
   maxFileSize,
   header,
+  sourceFolder,
+  disabledPathTooltip = 'Unavailable for the original path. Please select another folder',
+  path,
   ...restProps
 }: DestinationFolderPopupProps) => {
   const [showHiddenFiles, setShowHiddenFiles] = useState(false);
@@ -87,6 +102,14 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
 
   const defaultTitle =
     mode === DestinationFolderMode.Copy ? 'Copy to' : 'Move to';
+
+  const isDestinationDisabled = useMemo(() => {
+    if (!path || !sourceFolder) {
+      return false;
+    }
+
+    return sourceFolder === path;
+  }, [path, sourceFolder]);
 
   return (
     <DialPopup
@@ -129,11 +152,23 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
               label="Cancel"
               variant={ButtonVariant.Secondary}
             />
-            <DialButton
-              onClick={onConfirm}
-              label={mode === 'copy' ? copyLabel : moveLabel}
-              variant={ButtonVariant.Primary}
-            />
+            {isDestinationDisabled ? (
+              <DialTooltip tooltip={disabledPathTooltip}>
+                <DialButton
+                  onClick={onConfirm}
+                  label={mode === 'copy' ? copyLabel : moveLabel}
+                  variant={ButtonVariant.Primary}
+                  disabled={isDestinationDisabled}
+                  aria-disabled={isDestinationDisabled}
+                />
+              </DialTooltip>
+            ) : (
+              <DialButton
+                onClick={onConfirm}
+                label={mode === 'copy' ? copyLabel : moveLabel}
+                variant={ButtonVariant.Primary}
+              />
+            )}
           </div>
         </div>
       }
@@ -142,6 +177,7 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
       <DialFileManager
         {...restProps}
         actionsRef={fileManagerActionRef}
+        path={path}
         showHiddenFiles={showHiddenFiles}
         onShowHiddenFilesChange={handleShowHiddenFilesChange}
         treeOptions={{


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="1222" height="875" alt="image" src="https://github.com/user-attachments/assets/5c53f9b2-4563-40a2-aa60-968417bc677b" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added