### PR TITLE
feat: add configurable empty state view for FileManager component

### DIFF
--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -269,4 +269,53 @@ describe('Dial UI Kit :: FileManager', () => {
       expect(rowsAfter).toBe(rowsBefore + 1);
     });
   });
+
+  test('shows My Files empty state when My Files tab active', async () => {
+    renderWithinSizedShell(
+      <DialFileManager
+        items={[]}
+        toolbarOptions={{
+          tabs: [
+            { id: 'my_files', label: 'My Files' },
+            { id: 'shared', label: 'Shared with Me' },
+            { id: 'organization', label: 'Organization' },
+          ],
+          activeTab: 'my_files',
+        }}
+      />,
+    );
+
+    expect(screen.getByText("You don't have any files")).toBeInTheDocument();
+    expect(
+      screen.getByText('Upload or drag and drop files'),
+    ).toBeInTheDocument();
+  });
+
+  test('custom title + description override default empty state for active tab', async () => {
+    renderWithinSizedShell(
+      <DialFileManager
+        items={[]}
+        emptyStateTitle="Custom title goes here"
+        emptyStateDescription="Custom description text"
+        toolbarOptions={{
+          tabs: [
+            { id: 'my_files', label: 'My Files' },
+            { id: 'shared', label: 'Shared with Me' },
+            { id: 'organization', label: 'Organization' },
+          ],
+          activeTab: 'my_files',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Custom title goes here')).toBeInTheDocument();
+    expect(screen.getByText('Custom description text')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText("You don't have any files"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Upload or drag and drop files'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -21,9 +21,15 @@ import type { DialUploadFileItem } from '@/models/file-manager';
 import {
   DialFileManagerConflictActions,
   DialFileManagerConflictStrategies,
+  DialFileManagerTabs,
 } from '@/types/file-manager';
 import { PopupSize } from '@/types/popup';
 import { FileManagerColumnKey } from '@/types/file-manager';
+import {
+  IconBuildingCommunity,
+  IconFileDescription,
+  IconUsers,
+} from '@tabler/icons-react';
 
 const meta = {
   title: 'FileManager/FileManager',
@@ -1217,6 +1223,86 @@ export const WithSearchInPopup: Story = {
       description: {
         story:
           'File Manager with search functionality inside a popup. Local search is enabled by default.',
+      },
+    },
+  },
+};
+
+const EmptyStatePerTabComponent = (args: DialFileManagerProps) => {
+  const { activeTab, handleTabChange, tabs } = useDialFileManagerTabs({
+    my_files: 'My Files',
+    shared: 'Shared with Me',
+    organization: 'Organization',
+  });
+
+  const emptyState = useMemo(() => {
+    switch (activeTab) {
+      case DialFileManagerTabs.MyFiles:
+        return {
+          icon: (
+            <IconFileDescription
+              size={100}
+              stroke={0.5}
+              className="text-secondary"
+            />
+          ),
+          title: "You don't have any files",
+          description: 'Upload or drag and drop files',
+        };
+
+      case DialFileManagerTabs.Shared:
+        return {
+          icon: (
+            <IconUsers size={100} stroke={0.5} className="text-secondary" />
+          ),
+          title: 'Nothing has been shared with you',
+          description: 'Ask teammates to share files or upload your own',
+        };
+
+      case DialFileManagerTabs.Organization:
+        return {
+          icon: (
+            <IconBuildingCommunity
+              size={100}
+              stroke={0.5}
+              className="text-secondary"
+            />
+          ),
+          title: 'No organization files found',
+          description: 'Files shared within your organization will appear here',
+        };
+
+      default:
+        return undefined;
+    }
+  }, [activeTab]);
+
+  return (
+    <div className="h-[640px] w-full flex items-center justify-center">
+      <DialFileManager
+        {...args}
+        items={[]}
+        emptyStateIcon={emptyState?.icon}
+        emptyStateTitle={emptyState?.title}
+        emptyStateDescription={emptyState?.description}
+        toolbarOptions={{
+          ...args.toolbarOptions,
+          tabs: tabs,
+          activeTab: activeTab,
+          onTabChange: handleTabChange,
+        }}
+      />
+    </div>
+  );
+};
+
+export const EmptyStatePerTab: Story = {
+  render: EmptyStatePerTabComponent,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates how the File Manager displays different empty states depending on the active tab. The example configures unique icons, titles, and descriptions for the "My Files", "Shared with Me", and "Organization" tabs, and shows how to control the active tab via toolbar options.',
       },
     },
   },

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1149,7 +1149,7 @@ export const DialFileManagerView: FC = () => {
         title={emptyStateTitle}
         description={emptyStateDescription}
         descriptionClassName="text-sm"
-        containerClassName="gap-3 absolute size-full bg-layer-2 border rounded-[4px] border-primary z-40"
+        containerClassName="gap-3 size-full bg-layer-2 border rounded-[4px] border-primary"
         titleClassName="mt-2 !text-lg"
         icon={
           emptyStateIcon || (
@@ -1210,55 +1210,60 @@ export const DialFileManagerView: FC = () => {
             onDragOver={handleDragOver}
             onDrop={handleDrop}
           >
-            {gridRows.length === 0 && !isSearchMode && emptyStateRenderer()}
-            <DialGrid<GridRow>
-              columnDefs={columnDefs}
-              rowData={gridRows}
-              getRowId={(row) => row.path}
-              loading={filesLoading || searchInProgress}
-              getContextMenuItems={getGridContextMenuItems}
-              withoutHeaderBorders={isCompactView}
-              selectionOnHover={!isCompactView}
-              className={classNames(
-                isDragging ? 'border border-dashed border-accent-primary' : '',
-                isDraggingOverWindow && !isDragging
-                  ? 'border border-dashed border-primary'
-                  : '',
-              )}
-              {...forwardedGridOptions}
-              additionalGridOptions={{
-                ...forwardedGridOptions.additionalGridOptions,
-                onCellClicked: cellClickHandler,
-                headerHeight: COMPACT_VIEW_HEADER_HEIGHT,
-                rowHeight: COMPACT_VIEW_HEADER_HEIGHT,
-                ...(isCompactView
-                  ? {
-                      getRowHeight: (params) =>
-                        params.data?.nodeType === DialFileNodeType.FOLDER
-                          ? COMPACT_VIEW_HEADER_HEIGHT
-                          : COMPACT_VIEW_FILE_ROW_HEIGHT,
-                    }
-                  : {}),
-                context: {
-                  cancelFolderCreation,
-                  saveFolderCreation,
-                  getDisplayName,
-                  onRenameCancel,
-                  onRenameSave,
-                  onRenameValidate,
-                  renameTriggerView,
-                  validateFolderName,
-                  renamedItem,
-                  renamedPath,
-                  newFolderTempId,
-                  sharedByMePaths,
-                } as FileManagerGridContext,
-              }}
-              selectedRows={selectedGridRows}
-              onSelectionChangeWithMap={handleSelectionChange}
-              wrapperBorder={!isDragging && !isDraggingOverWindow}
-              disabledRowIds={disabledGridRowIds}
-            />
+            {gridRows.length === 0 && !isSearchMode ? (
+              emptyStateRenderer()
+            ) : (
+              <DialGrid<GridRow>
+                columnDefs={columnDefs}
+                rowData={gridRows}
+                getRowId={(row) => row.path}
+                loading={filesLoading || searchInProgress}
+                getContextMenuItems={getGridContextMenuItems}
+                withoutHeaderBorders={isCompactView}
+                selectionOnHover={!isCompactView}
+                className={classNames(
+                  isDragging
+                    ? 'border border-dashed border-accent-primary'
+                    : '',
+                  isDraggingOverWindow && !isDragging
+                    ? 'border border-dashed border-primary'
+                    : '',
+                )}
+                {...forwardedGridOptions}
+                additionalGridOptions={{
+                  ...forwardedGridOptions.additionalGridOptions,
+                  onCellClicked: cellClickHandler,
+                  headerHeight: COMPACT_VIEW_HEADER_HEIGHT,
+                  rowHeight: COMPACT_VIEW_HEADER_HEIGHT,
+                  ...(isCompactView
+                    ? {
+                        getRowHeight: (params) =>
+                          params.data?.nodeType === DialFileNodeType.FOLDER
+                            ? COMPACT_VIEW_HEADER_HEIGHT
+                            : COMPACT_VIEW_FILE_ROW_HEIGHT,
+                      }
+                    : {}),
+                  context: {
+                    cancelFolderCreation,
+                    saveFolderCreation,
+                    getDisplayName,
+                    onRenameCancel,
+                    onRenameSave,
+                    onRenameValidate,
+                    renameTriggerView,
+                    validateFolderName,
+                    renamedItem,
+                    renamedPath,
+                    newFolderTempId,
+                    sharedByMePaths,
+                  } as FileManagerGridContext,
+                }}
+                selectedRows={selectedGridRows}
+                onSelectionChangeWithMap={handleSelectionChange}
+                wrapperBorder={!isDragging && !isDraggingOverWindow}
+                disabledRowIds={disabledGridRowIds}
+              />
+            )}
           </section>
         </div>
       </div>

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -60,6 +60,7 @@ import {
 import {
   IconCopy,
   IconDownload,
+  IconFileDescription,
   IconPencilMinus,
   IconTrashX,
 } from '@tabler/icons-react';
@@ -104,6 +105,7 @@ import { useTriggerViewRename } from '@/components/FileManager/hooks/use-trigger
 import { FileMetadataPopup } from './components/FileMetadataPopup/FileMetadataPopup';
 import IconUnshare from '@/assets/icons/unshare.svg?react';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
+import { DialNoDataContent } from '../NoDataContent/NoDataContent';
 
 type GridRow = FileManagerGridRow;
 
@@ -325,6 +327,10 @@ export interface DialFileManagerProps {
   searchInProgress?: boolean;
   searchResults?: DialFile[];
   clearSearchResults?: () => void;
+
+  emptyStateIcon?: ReactNode;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
 }
 
 /**
@@ -407,6 +413,10 @@ export interface DialFileManagerProps {
  * @param [actionsRef] - Ref exposing a limited set of imperative File Manager actions (e.g., creating a folder). Allows parent components to trigger internal behaviors programmatically. This ref is not a DOM ref and should be used only for invoking the component’s public actions API.
  *
  * @param allowedFileTypes - Allowed file types (same format as the HTML `<input accept>` attribute). Controls upload filtering and which items are disabled in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), and extensions (e.g. `.svg`).
+ *
+ * @param [emptyStateIcon] - Optional icon for empty state
+ * @param [emptyStateTitle] - Optional title text displayed when there are no files.
+ * @param [emptyStateDescription] - Optional description text displayed below the empty state title.
  */
 export const DialFileManager: FC<DialFileManagerProps> = (props) => {
   return (
@@ -526,6 +536,10 @@ export const DialFileManagerView: FC = () => {
     actionsRef,
     searchInProgress,
     isSearchMode,
+
+    emptyStateIcon,
+    emptyStateTitle = "You don't have any files",
+    emptyStateDescription = 'Upload or drag and drop files',
   } = useFileManagerContext();
   const {
     width = sidebarWidth,
@@ -1129,6 +1143,28 @@ export const DialFileManagerView: FC = () => {
     [renamedPath, handleTableRowClick],
   );
 
+  const emptyStateRenderer = useCallback(
+    () => (
+      <DialNoDataContent
+        title={emptyStateTitle}
+        description={emptyStateDescription}
+        descriptionClassName="text-sm"
+        containerClassName="gap-3 absolute size-full bg-layer-2 border rounded-[4px] border-primary z-40"
+        titleClassName="mt-2 !text-lg"
+        icon={
+          emptyStateIcon || (
+            <IconFileDescription
+              size={100}
+              stroke={0.5}
+              className="text-secondary"
+            />
+          )
+        }
+      />
+    ),
+    [emptyStateDescription, emptyStateIcon, emptyStateTitle],
+  );
+
   return (
     <section
       ref={containerRef}
@@ -1174,6 +1210,7 @@ export const DialFileManagerView: FC = () => {
             onDragOver={handleDragOver}
             onDrop={handleDrop}
           >
+            {gridRows.length === 0 && !isSearchMode && emptyStateRenderer()}
             <DialGrid<GridRow>
               columnDefs={columnDefs}
               rowData={gridRows}

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, type DragEvent, type Ref, type RefObject } from 'react';
+import {
+  createContext,
+  type DragEvent,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+} from 'react';
 import type { DialFile, DialRootFolder } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type {
@@ -171,6 +177,10 @@ export interface FileManagerContextValue {
   searchResults?: DialFile[];
   clearSearchResults?: () => void;
   isSearchMode: boolean;
+
+  emptyStateIcon?: ReactNode;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
 }
 
 export const FileManagerContext = createContext<

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -105,6 +105,10 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   searchInProgress,
   clearSearchResults,
   allowedFileTypes,
+
+  emptyStateIcon,
+  emptyStateTitle,
+  emptyStateDescription,
 }) => {
   const {
     selectedPaths: effectiveSelectedPaths,
@@ -635,6 +639,10 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     searchResults,
     clearSearchResults,
     isSearchMode,
+
+    emptyStateIcon,
+    emptyStateTitle,
+    emptyStateDescription,
   };
 
   return (

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
@@ -466,12 +466,13 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
     expect(screen.getByText('Documents')).toBeInTheDocument();
   });
 
-  test('clicking Add folder inserts a new placeholder row in the FileManager grid', async () => {
+  test('clicking Add folder inserts a new placeholder folder entry', async () => {
     render(
       <DestinationFolderPopup
         open={true}
         onClose={vi.fn()}
         items={mockFiles}
+        emptyStateTitle="Empty folder"
         rootItem={{
           id: 'root',
           name: 'Root',
@@ -483,12 +484,12 @@ describe('Dial UI Kit :: DestinationFolderPopup', () => {
       />,
     );
 
-    const rowsBefore = await screen.findAllByRole('row');
-    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }));
+    expect(screen.getByText('Empty folder')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /add folder/i }));
 
     await waitFor(() => {
-      const rowsAfter = screen.getAllByRole('row');
-      expect(rowsAfter.length).toBe(rowsBefore.length + 1);
+      expect(screen.queryByText('Empty folder')).not.toBeInTheDocument();
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(0);
     });
   });
 

--- a/src/components/FileManager/constants.tsx
+++ b/src/components/FileManager/constants.tsx
@@ -16,7 +16,7 @@ export const treeBaseClassName =
   'w-full h-full rounded bg-layer-3 text-secondary overflow-auto min-w-0';
 
 export const gridBaseClassName =
-  'flex-1 w-full rounded text-secondary overflow-auto min-h-0 min-w-0 relative';
+  'flex-1 w-full rounded text-secondary overflow-auto min-h-0 min-w-0';
 
 export const sidebarWidth = 280;
 export const sidebarTitleDefault = 'Files';

--- a/src/components/FileManager/constants.tsx
+++ b/src/components/FileManager/constants.tsx
@@ -16,7 +16,7 @@ export const treeBaseClassName =
   'w-full h-full rounded bg-layer-3 text-secondary overflow-auto min-w-0';
 
 export const gridBaseClassName =
-  'flex-1 w-full rounded text-secondary overflow-auto min-h-0 min-w-0';
+  'flex-1 w-full rounded text-secondary overflow-auto min-h-0 min-w-0 relative';
 
 export const sidebarWidth = 280;
 export const sidebarTitleDefault = 'Files';


### PR DESCRIPTION
**Description:**

add configurable empty state view for FileManager component

Issues:

- Issue #114 

**UI changes**

<img width="1058" height="622" alt="image" src="https://github.com/user-attachments/assets/c8a6a192-4cc5-475d-b627-5d72826ba103" />
<img width="1065" height="620" alt="image" src="https://github.com/user-attachments/assets/e0c889cb-0a61-47bc-bd51-d4fa6d741279" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added