### PR TITLE
fix: adjust conflicts resolution popup width for single and multiple files modes (Issue #114)

### DIFF
--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.spec.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.spec.tsx
@@ -369,4 +369,36 @@ describe('Dial UI Kit :: ConflictResolutionPopup', () => {
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
   });
+
+  it('applies correct width for single file mode', () => {
+    render(
+      <ConflictResolutionPopup
+        open
+        conflictingFiles={singleFile}
+        onReplace={vi.fn()}
+        onDuplicate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+
+    expect(dialog).toHaveClass('dial-sm-popup');
+  });
+
+  it('applies correct width for multiple files mode', () => {
+    render(
+      <ConflictResolutionPopup
+        open
+        conflictingFiles={multipleFiles}
+        onReplace={vi.fn()}
+        onDuplicate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+
+    expect(dialog).toHaveClass('w-[600px]');
+  });
 });

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -424,7 +424,8 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
     <DialPopup
       open={open}
       onClose={onClose}
-      size={PopupSize.Md}
+      size={isSingleFile ? PopupSize.Sm : PopupSize.Md}
+      className={classNames([!isSingleFile && 'w-[600px]'])}
       header={title}
       dividers={false}
       footer={


### PR DESCRIPTION
**Description:**

adjust conflicts resolution popup width for single and multiple files modes

Issues:

- Issue #114 

**UI changes**

<img width="433" height="312" alt="image" src="https://github.com/user-attachments/assets/87323d6c-2c57-442e-b18f-e079f2dcae5d" />
<img width="624" height="305" alt="image" src="https://github.com/user-attachments/assets/65cbb9a3-0131-4785-9c64-7a1a6de2a20f" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added