### PR TITLE
fix: sync expanded paths in control mode (Issue #114)

### DIFF
--- a/src/components/FileManager/components/FoldersTree/hooks/use-expanded-paths.spec.tsx
+++ b/src/components/FileManager/components/FoldersTree/hooks/use-expanded-paths.spec.tsx
@@ -250,4 +250,34 @@ describe('Dial UI Kit :: FileManager :: useExpandedPaths', () => {
     expect(initialPaths.size).toBe(1);
     expect(initialPaths.has('/folder2')).toBe(false);
   });
+
+  it('syncs internal expandedPaths when external expandedPaths changes in controlled mode', () => {
+    const onExpandedPathsChange = vi.fn();
+    const initialPaths = new Set<string>(['/folder1']);
+
+    const { result, rerender } = renderHook(
+      ({ paths }) =>
+        useExpandedPaths({
+          expandedPaths: paths,
+          onExpandedPathsChange,
+        }),
+      { initialProps: { paths: initialPaths } },
+    );
+
+    expect(result.current.expandedPaths).toEqual(initialPaths);
+
+    const updatedPaths = new Set<string>(['/folder1', '/folder2']);
+
+    rerender({ paths: updatedPaths });
+
+    expect(result.current.expandedPaths).toEqual(updatedPaths);
+
+    act(() => {
+      result.current.togglePath('/folder3');
+    });
+
+    expect(onExpandedPathsChange).toHaveBeenCalledWith(
+      new Set<string>(['/folder1', '/folder2', '/folder3']),
+    );
+  });
 });

--- a/src/components/FileManager/components/FoldersTree/hooks/use-expanded-paths.ts
+++ b/src/components/FileManager/components/FoldersTree/hooks/use-expanded-paths.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 
 export interface UseExpandedPathsOptions {
   expandedPaths?: Set<string>;
@@ -22,6 +22,12 @@ export const useExpandedPaths = (options?: UseExpandedPathsOptions) => {
         : internalExpandedPaths,
     [isControlled, options?.expandedPaths, internalExpandedPaths],
   );
+
+  useEffect(() => {
+    if (isControlled && options?.expandedPaths) {
+      setInternalExpandedPaths(new Set(options.expandedPaths));
+    }
+  }, [isControlled, options?.expandedPaths]);
 
   const setExpandedPaths = useCallback(
     (newSet: Set<string>) => {


### PR DESCRIPTION
**Description:**

sync expanded paths in control mode

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added