### PR TITLE
fix: Add missing left paddings in multiselect

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -443,7 +443,7 @@ export const DialSelect: FC<DialSelectProps> = ({
                         <DialCheckbox
                           id={`${elementId || listId}-${opt.value}`}
                           label={
-                            <span className="flex w-full flex-1 min-w-0 items-center gap-2 text-primary">
+                            <span className="flex w-full flex-1 pl-2 min-w-0 items-center gap-2 text-primary">
                               {opt.icon && <DialIcon icon={opt.icon} />}
                               <span className="truncate">{opt.label}</span>
                             </span>


### PR DESCRIPTION
**Description:**

fix paddings in select with multiple=true

before fix:
<img width="938" height="368" alt="image" src="https://github.com/user-attachments/assets/0e961201-8ec7-415a-9f92-398d6718c78e" />


after fix: 
<img width="955" height="343" alt="image" src="https://github.com/user-attachments/assets/f87ed02e-7ce8-4bdc-af19-2b7ff1ea9dd6" />


Issues:

- Issue #<TICKET_ID>

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added