### PR TITLE
fix: assign another id for search input in destination folder file manager

### DIFF
--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -190,7 +190,7 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
           ...restProps.gridOptions,
         }}
         navigationPanelOptions={{
-          elementId: 'fm-destination-search',
+          elementId: 'file-manager-destination-search',
           ...restProps.navigationPanelOptions,
         }}
         onUploadFiles={onUploadFiles}

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -189,6 +189,10 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
           withSelectionColumn: false,
           ...restProps.gridOptions,
         }}
+        navigationPanelOptions={{
+          elementId: 'fm-destination-search',
+          ...restProps.navigationPanelOptions,
+        }}
         onUploadFiles={onUploadFiles}
         onValidateUpload={onValidateUpload}
         maxFileSize={maxFileSize}

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
@@ -70,7 +70,7 @@ export interface DialFileManagerNavigationPanelProps
  * <FileManagerNavigationPanel
  *   path="Organization/Folder 4"
  *   searchable
- *   elementId="fm-search"
+ *   elementId="file-manager-search"
  *   value={query}
  *   onSearchChange={(val) => setQuery(val)}
  * />
@@ -91,7 +91,7 @@ export interface DialFileManagerNavigationPanelProps
  * @param [breadcrumbClassName] - ClassName forwarded to inner `DialBreadcrumb`
  * @param [searchable=true] - Whether to render the search control
  * @param [value] - Controlled value for the search input (parent-managed)
- * @param [elementId="fm-search"] - DOM id for the internal DialSearch input
+ * @param [elementId="file-manager-search"] - DOM id for the internal DialSearch input
  * @param [size=SearchSize.Base] - Size of the search input (from DialSearchProps)
  * @param [onSearchChange] - Callback fired when the search value changes
  * @param [searchClassName] - Extra classes for the search input element
@@ -115,7 +115,7 @@ export const DialFileManagerNavigationPanel: FC<
 
   searchable = true,
   value,
-  elementId = 'fm-search',
+  elementId = 'file-manager-search',
   disabled,
   readonly,
   invalid,

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
@@ -183,14 +183,14 @@ export const DialFileManagerNavigationPanel: FC<
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
 
   const expandSearch = useCallback(() => {
-    if (!isSearchExpanded) {
+    if (isCompactView && !isSearchExpanded) {
       setIsSearchExpanded(true);
       const searchElement = document.getElementById(elementId);
       if (searchElement) {
         searchElement.focus();
       }
     }
-  }, [elementId, isSearchExpanded]);
+  }, [elementId, isSearchExpanded, isCompactView]);
 
   const handleSearchBlur = useCallback(() => {
     if (!value || String(value).trim() === '') {


### PR DESCRIPTION
**Description:**

assign another id for search input in destination folder file manager

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added