### PR TITLE
fix: show only invalid tooltip when input is invalid

### DIFF
--- a/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
+++ b/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
@@ -130,6 +130,7 @@ export const DialFileManagerItemNameInput: FC<
         value={name}
         onChange={onChange}
         invalid={inputInvalid}
+        hideTooltip={inputInvalid}
         iconAfter={getInputIconAfter()}
         inputRef={inputRef}
       />


### PR DESCRIPTION
**Description:**

show only invalid tooltip when input is invalid

Issues:

- Issue #114 

**UI changes**

<img width="985" height="577" alt="image" src="https://github.com/user-attachments/assets/b872b5cc-6d1c-43ea-8080-50499b1106e4" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added