### PR TITLE
feat: disable and hide delete option when no write permission

### DIFF
--- a/src/components/FileManager/__mocks__/files.ts
+++ b/src/components/FileManager/__mocks__/files.ts
@@ -175,6 +175,7 @@ export const itemsMock: DialFile[] = [
                         contentLength: 5120,
                         author: authors[0],
                         owner: owners[0],
+                        permissions: [DialFilePermission.READ],
                       },
                       {
                         id: 'ico-settings',
@@ -190,6 +191,10 @@ export const itemsMock: DialFile[] = [
                         contentLength: 61440 * 1000,
                         author: authors[3],
                         owner: owners[2],
+                        permissions: [
+                          DialFilePermission.READ,
+                          DialFilePermission.WRITE,
+                        ],
                       },
                       {
                         id: '.hidden-file',

--- a/src/components/FileManager/hooks/__tests__/use-bulk-actions.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-bulk-actions.spec.tsx
@@ -5,6 +5,7 @@ import { DialFileManagerActions } from '@/types/file-manager';
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type { MouseEvent } from 'react';
+import { DialFilePermission } from '@/models/file';
 
 const testFiles: DialFile[] = [
   {
@@ -35,6 +36,21 @@ const testFiles: DialFile[] = [
     updatedAt: '2024-01-01T00:00:00Z',
   },
 ];
+
+const writableFile: DialFile = {
+  ...testFiles[0],
+  permissions: [DialFilePermission.WRITE],
+};
+
+const readOnlyFile: DialFile = {
+  ...testFiles[1],
+  permissions: [],
+};
+
+const noPermissionsFile: DialFile = {
+  ...testFiles[2],
+  permissions: undefined,
+};
 
 const defaultActionLabels = {
   [DialFileManagerActions.Duplicate]: 'Duplicate',
@@ -397,5 +413,82 @@ describe('Dial UI Kit :: useBulkActions', () => {
       domEvent: mockMouseEvent,
     });
     expect(onDuplicate).toHaveBeenLastCalledWith([testFiles[0], testFiles[1]]);
+  });
+
+  test('delete action is disabled when at least one file lacks WRITE permission', () => {
+    const selectedFiles = new Map<string, DialFile>([
+      [writableFile.path, writableFile],
+      [readOnlyFile.path, readOnlyFile],
+    ]);
+
+    const { result } = renderHook(() =>
+      useBulkActions({
+        selectedFiles,
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        getCurrentFolderPath: () => '/test',
+      }),
+    );
+
+    const deleteAction = result.current[0];
+
+    expect(deleteAction.disabled).toBe(true);
+  });
+
+  test('delete action is enabled when all files have WRITE permission', () => {
+    const selectedFiles = new Map<string, DialFile>([
+      [writableFile.path, writableFile],
+      [
+        testFiles[1].path,
+        { ...testFiles[1], permissions: [DialFilePermission.WRITE] },
+      ],
+    ]);
+
+    const { result } = renderHook(() =>
+      useBulkActions({
+        selectedFiles,
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        getCurrentFolderPath: () => '/test',
+      }),
+    );
+
+    const deleteAction = result.current[0];
+
+    expect(deleteAction.disabled).toBe(false);
+  });
+
+  test('delete action is enabled when files have no permissions defined', () => {
+    const selectedFiles = new Map<string, DialFile>([
+      [noPermissionsFile.path, noPermissionsFile],
+    ]);
+
+    const { result } = renderHook(() =>
+      useBulkActions({
+        selectedFiles,
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        getCurrentFolderPath: () => '/test',
+      }),
+    );
+
+    const deleteAction = result.current[0];
+
+    expect(deleteAction.disabled).toBe(false);
   });
 });

--- a/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
@@ -5,6 +5,7 @@ import { DialFileManagerActions } from '@/types/file-manager';
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type { MouseEvent } from 'react';
+import { DialFilePermission } from '@/models/file';
 
 const testFile: DialFile = {
   id: '1',
@@ -26,6 +27,21 @@ const testFolder: DialFile = {
   nodeType: DialFileNodeType.FOLDER,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const fileWithWritePermission: DialFile = {
+  ...testFile,
+  permissions: [DialFilePermission.WRITE],
+};
+
+const fileWithoutWritePermission: DialFile = {
+  ...testFile,
+  permissions: [],
+};
+
+const fileWithoutPermissions: DialFile = {
+  ...testFile,
+  permissions: undefined,
 };
 
 const defaultActionLabels = {
@@ -718,5 +734,70 @@ describe('Dial UI Kit :: useGridContextMenu', () => {
       domEvent: mockMouseEvent,
     });
     expect(onUnshare2).toHaveBeenCalledWith(testFile);
+  });
+
+  test('delete action is not shown when file lacks WRITE permission', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithoutWritePermission);
+
+    expect(menuItems).toHaveLength(0);
+    expect(
+      menuItems.find((item) => item.key === DialFileManagerActions.Delete),
+    ).toBeUndefined();
+  });
+
+  test('delete action is shown when file has WRITE permission', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithWritePermission);
+
+    expect(menuItems).toHaveLength(1);
+    expect(menuItems[0].key).toBe(DialFileManagerActions.Delete);
+  });
+
+  test('delete action is shown when file has no permissions defined', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Delete]: 'Delete' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithoutPermissions);
+
+    expect(menuItems).toHaveLength(1);
+    expect(menuItems[0].key).toBe(DialFileManagerActions.Delete);
   });
 });

--- a/src/components/FileManager/hooks/use-bulk-actions.tsx
+++ b/src/components/FileManager/hooks/use-bulk-actions.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { DialFile } from '@/models/file';
+import { DialFilePermission, type DialFile } from '@/models/file';
 import { DialFileManagerActions } from '@/types/file-manager';
 import type { DialActionDropdownItem } from '@/components/FileManager/components/FileManagerBulkActionsToolbar/FileManagerBulkActionsToolbar';
 import { IconCopy, IconDownload, IconTrashX } from '@tabler/icons-react';
@@ -91,11 +91,18 @@ export const useBulkActions = ({
     }
 
     if (actionLabels[DialFileManagerActions.Delete]) {
+      const isDisabled = selectedFilesArray.some(
+        (file) =>
+          file.permissions &&
+          !file.permissions.includes(DialFilePermission.WRITE),
+      );
+
       actions.push({
         key: DialFileManagerActions.Delete,
         label: actionLabels[DialFileManagerActions.Delete],
         title: actionLabels[DialFileManagerActions.Delete],
         icon: <IconTrashX {...BASE_ICON_PROPS} className="text-secondary" />,
+        disabled: isDisabled,
         onClick: () => {
           const currentFolderPath = getCurrentFolderPath();
           onDelete(selectedFilesArray, currentFolderPath);

--- a/src/components/FileManager/hooks/use-grid-context-menu.tsx
+++ b/src/components/FileManager/hooks/use-grid-context-menu.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { type DialFile } from '@/models/file';
+import { DialFilePermission, type DialFile } from '@/models/file';
 import { DialFileManagerActions } from '@/types/file-manager';
 import type { DropdownItem } from '@/models/dropdown';
 import {
@@ -105,7 +105,14 @@ export const useGridContextMenu = ({
         });
       }
 
-      if (actionLabels[DialFileManagerActions.Delete]) {
+      const emptyOrWritePermissions =
+        !file.permissions ||
+        file.permissions.includes(DialFilePermission.WRITE);
+
+      if (
+        actionLabels[DialFileManagerActions.Delete] &&
+        emptyOrWritePermissions
+      ) {
         items.push({
           key: DialFileManagerActions.Delete,
           label: actionLabels[DialFileManagerActions.Delete],


### PR DESCRIPTION
**Description:**

disable and hide delete option when no write permission

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added