### PR TITLE
feat: allow to hide part of path in breadcrumbs inside navigation panel

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -413,7 +413,7 @@ export interface DialFileManagerProps {
  *
  * @param [actionsRef] - Ref exposing a limited set of imperative File Manager actions (e.g., creating a folder). Allows parent components to trigger internal behaviors programmatically. This ref is not a DOM ref and should be used only for invoking the component’s public actions API.
  *
- * @param allowedFileTypes - Allowed file types (same format as the HTML `<input accept>` attribute). Controls upload filtering and which items are disabled in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), and extensions (e.g. `.svg`).
+ * @param [allowedFileTypes] - Allowed file types (same format as the HTML `<input accept>` attribute). Controls upload filtering and which items are disabled in the File Manager UI. Supports MIME types, wildcards (e.g. `image/*`), and extensions (e.g. `.svg`).
  *
  * @param [emptyStateIcon] - Optional icon for empty state
  * @param [emptyStateTitle] - Optional title text displayed when there are no files.

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.spec.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.spec.tsx
@@ -146,4 +146,53 @@ describe('Dial UI Kit :: DialFileManagerNavigationPanel', () => {
     fireEvent.click(backButton);
     expect(screen.getByRole('navigation')).toBeInTheDocument();
   });
+
+  test('hides breadcrumbHiddenPathPart from breadcrumb segments', () => {
+    render(
+      <DialFileManagerNavigationPanel
+        path="files/user123/appdata/mindmap/Project"
+        breadcrumbsHiddenPathPart="appdata/mindmap"
+      />,
+    );
+
+    expect(screen.getByText('files')).toBeInTheDocument();
+    expect(screen.getByText('user123')).toBeInTheDocument();
+    expect(screen.getByText('Project')).toBeInTheDocument();
+
+    expect(screen.queryByText('appdata')).not.toBeInTheDocument();
+    expect(screen.queryByText('mindmap')).not.toBeInTheDocument();
+  });
+
+  test('does not modify breadcrumb when breadcrumbHiddenPathPart is not found', () => {
+    render(
+      <DialFileManagerNavigationPanel
+        path="Org/Team/Folder"
+        breadcrumbsHiddenPathPart="non/existing/path"
+      />,
+    );
+
+    expect(screen.getByText('Org')).toBeInTheDocument();
+    expect(screen.getByText('Team')).toBeInTheDocument();
+    expect(screen.getByText('Folder')).toBeInTheDocument();
+  });
+
+  test('creates correct hrefs after hiding breadcrumbHiddenPathPart', () => {
+    const onItemClick = vi.fn();
+    const makeHref = (segments: string[], index: number) =>
+      segments.slice(0, index + 1).join('/');
+
+    render(
+      <DialFileManagerNavigationPanel
+        path="files/u1/appdata/mindmap/Project/Sub"
+        breadcrumbsHiddenPathPart="appdata/mindmap"
+        makeHref={makeHref}
+        onItemClick={onItemClick}
+      />,
+    );
+
+    const projectLink = screen.getByRole('link', { name: 'Project' });
+    fireEvent.click(projectLink);
+
+    expect(onItemClick).toHaveBeenCalledWith('files/u1/Project');
+  });
 });

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
@@ -23,6 +23,7 @@ import { DialButton } from '@/components/Button/Button';
 import { ButtonVariant } from '@/types/button';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
+import { getSegments } from '@/utils/path';
 
 export interface DialFileManagerNavigationPanelProps
   extends Omit<
@@ -130,16 +131,10 @@ export const DialFileManagerNavigationPanel: FC<
   const breadcrumbPathItems: DialBreadcrumbPathItem[] | undefined =
     useMemo(() => {
       if (!path) return undefined;
-      let segments = path
-        .split('/')
-        .map((s) => s.trim())
-        .filter(Boolean);
+      let segments = getSegments(path);
 
       if (breadcrumbsHiddenPathPart) {
-        const hiddenSegments = breadcrumbsHiddenPathPart
-          .split('/')
-          .map((s) => s.trim())
-          .filter(Boolean);
+        const hiddenSegments = getSegments(breadcrumbsHiddenPathPart);
 
         if (hiddenSegments.length) {
           const hiddenIndex = segments.findIndex((_, idx) =>

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.tsx
@@ -46,6 +46,7 @@ export interface DialFileManagerNavigationPanelProps
   onItemClick?: (href?: string) => void;
   rootItemPath?: string;
   rootItemLabel?: string;
+  breadcrumbsHiddenPathPart?: string;
 
   searchable?: boolean;
   value?: string | number | null;
@@ -89,6 +90,7 @@ export interface DialFileManagerNavigationPanelProps
  * @param [onItemClick] - Callback fired when a breadcrumb item is clicked
  * @param [className] - Additional classes for the panel container
  * @param [breadcrumbClassName] - ClassName forwarded to inner `DialBreadcrumb`
+ * @param [breadcrumbsHiddenPathPart] - A slash-separated path fragment whose segments will be omitted from the rendered breadcrumb trail.
  * @param [searchable=true] - Whether to render the search control
  * @param [value] - Controlled value for the search input (parent-managed)
  * @param [elementId="file-manager-search"] - DOM id for the internal DialSearch input
@@ -109,6 +111,7 @@ export const DialFileManagerNavigationPanel: FC<
   makeHref,
   rootItemPath,
   rootItemLabel,
+  breadcrumbsHiddenPathPart,
 
   className,
   breadcrumbClassName,
@@ -127,10 +130,31 @@ export const DialFileManagerNavigationPanel: FC<
   const breadcrumbPathItems: DialBreadcrumbPathItem[] | undefined =
     useMemo(() => {
       if (!path) return undefined;
-      const segments = path
+      let segments = path
         .split('/')
         .map((s) => s.trim())
         .filter(Boolean);
+
+      if (breadcrumbsHiddenPathPart) {
+        const hiddenSegments = breadcrumbsHiddenPathPart
+          .split('/')
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+        if (hiddenSegments.length) {
+          const hiddenIndex = segments.findIndex((_, idx) =>
+            hiddenSegments.every((seg, hIdx) => segments[idx + hIdx] === seg),
+          );
+
+          if (hiddenIndex !== -1) {
+            segments = [
+              ...segments.slice(0, hiddenIndex),
+              ...segments.slice(hiddenIndex + hiddenSegments.length),
+            ];
+          }
+        }
+      }
+
       if (!segments.length) return [{ label: '/' }];
 
       const items = segments.map((segment, index) => {
@@ -178,7 +202,14 @@ export const DialFileManagerNavigationPanel: FC<
       }
 
       return items;
-    }, [path, makeHref, onItemClick, rootItemPath, rootItemLabel]);
+    }, [
+      path,
+      breadcrumbsHiddenPathPart,
+      rootItemPath,
+      rootItemLabel,
+      makeHref,
+      onItemClick,
+    ]);
 
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
 

--- a/src/utils/__tests__/merge-classes.spec.ts
+++ b/src/utils/__tests__/merge-classes.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { mergeClasses } from './merge-classes';
+import { mergeClasses } from '@/utils/merge-classes';
 
 describe('mergeClasses utility', () => {
   test('resolves Tailwind width conflicts (last one wins)', () => {

--- a/src/utils/__tests__/path.spec.ts
+++ b/src/utils/__tests__/path.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { getSegments } from '@/utils/path';
+
+describe('getSegments utility', () => {
+  test('splits a simple path into segments', () => {
+    expect(getSegments('Org/Design/Assets')).toEqual([
+      'Org',
+      'Design',
+      'Assets',
+    ]);
+  });
+
+  test('trims whitespace around segments', () => {
+    expect(getSegments(' Org / Design / Assets ')).toEqual([
+      'Org',
+      'Design',
+      'Assets',
+    ]);
+  });
+
+  test('removes empty segments caused by leading and trailing slashes', () => {
+    expect(getSegments('/Org/Design/Assets/')).toEqual([
+      'Org',
+      'Design',
+      'Assets',
+    ]);
+  });
+
+  test('removes empty segments caused by repeated slashes', () => {
+    expect(getSegments('Org//Design///Assets')).toEqual([
+      'Org',
+      'Design',
+      'Assets',
+    ]);
+  });
+
+  test('returns an empty array for an empty string', () => {
+    expect(getSegments('')).toEqual([]);
+  });
+
+  test('returns an empty array for a path with only slashes', () => {
+    expect(getSegments('///')).toEqual([]);
+  });
+
+  test('handles mixed slashes and whitespace correctly', () => {
+    expect(getSegments(' / Org //  Design /  / Assets / ')).toEqual([
+      'Org',
+      'Design',
+      'Assets',
+    ]);
+  });
+
+  test('does not alter valid segment content', () => {
+    expect(getSegments('shared-mindmap/v1.0/_internal')).toEqual([
+      'shared-mindmap',
+      'v1.0',
+      '_internal',
+    ]);
+  });
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,14 @@
+/**
+ * Splits a path string into normalized, non-empty segments.
+ *
+ * Trims whitespace from each segment and removes empty values
+ * caused by leading, trailing, or repeated slashes.
+ *
+ * @param path - A path string (e.g. "Org / Design / Assets/")
+ * @returns An array of path segments
+ */
+export const getSegments = (path: string) =>
+  path
+    .split('/')
+    .map((s) => s.trim())
+    .filter(Boolean);


### PR DESCRIPTION
**Description:**

allow to hide part of path in breadcrumbs inside navigation panel

Issues:

- Issue #114 

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added