### PR TITLE
fix: select input options width

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -125,7 +125,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('error item has proper class and overlay width hugs content', () => {
     render(
-      <DialDropdown menu={{ items }}>
+      <DialDropdown menu={{ items }} matchReferenceWidth={false}>
         <button type="button">Open</button>
       </DialDropdown>,
     );

--- a/src/components/Dropdown/constants.tsx
+++ b/src/components/Dropdown/constants.tsx
@@ -8,7 +8,6 @@ export const dropdownBaseClassName = classNames(
 
 export const dropdownListBaseClassName = classNames(
   'z-[53] overflow-auto rounded bg-layer-0 text-primary shadow focus-visible:outline-none',
-  'w-max',
 );
 
 export const dropdownItemBaseClassName = classNames(

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -58,6 +58,7 @@ export interface DialSelectProps {
   emptyStateIcon?: ReactNode;
   disabled?: boolean;
   className?: string;
+  listClassName?: string;
   closable?: boolean;
   header?: ReactNode | (() => ReactNode);
   footer?: ReactNode | (() => ReactNode);
@@ -110,6 +111,7 @@ export interface DialSelectProps {
  * @param [emptyStateIcon] - Icon to display when there are no options.
  * @param [disabled=false] - Disable the control.
  * @param [className] - Additional CSS classes for the trigger.
+ * @param [listClassName] - Additional CSS classes for the list dropdown.
  * @param [closable=false] - Show a close button in the dropdown header.
  * @param [header] - Custom node/function rendered above the options.
  * @param [footer] - Custom node/function rendered below the options.
@@ -139,6 +141,7 @@ export const DialSelect: FC<DialSelectProps> = ({
   emptyStateIcon,
   disabled = false,
   className,
+  listClassName,
   closable = false,
   header,
   footer,
@@ -362,6 +365,7 @@ export const DialSelect: FC<DialSelectProps> = ({
       placement="bottom-start"
       allowedPlacements={['bottom-start', 'top-start']}
       maxDropdownHeight={searchable ? null : dropdownMenuMaxHeight}
+      listClassName={listClassName}
       renderOverlay={() => (
         <div
           id={`list-${elementId || listId}`}

--- a/src/components/SelectField/SelectField.stories.tsx
+++ b/src/components/SelectField/SelectField.stories.tsx
@@ -32,6 +32,11 @@ const meta = {
       { value: 'SSE', label: 'Server-Sent Events (SSE)' },
       { value: 'WS', label: 'WebSocket' },
       { value: 'LP', label: 'Long Polling' },
+      {
+        value: 'SLN',
+        label:
+          'Some long label to show different behavior of list items fit in available space',
+      },
     ],
   },
 } satisfies Meta<DialSelectFieldProps>;
@@ -49,6 +54,7 @@ export const Single: Story = {
           {...args}
           value={value}
           onChange={(v) => setValue(v as string)}
+          listClassName="w-[320px]"
         />
       </div>
     );


### PR DESCRIPTION
**Description:**

added possibility to change width of dropdown list for select options

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="435" height="243" alt="image" src="https://github.com/user-attachments/assets/f9a96198-b70e-453b-9608-d2789b06b51f" />
<img width="550" height="225" alt="image" src="https://github.com/user-attachments/assets/0a7efd71-1130-4cd7-8bf1-e31aabbb5ed8" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added