### PR TITLE
fix: pass items directly to DialDropdown in DialButtonDropdown

### DIFF
--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -6,7 +6,8 @@ import type { DropdownItem } from '@/models/dropdown';
 import { buttonChevronDown, buttonChevronUp } from './constants';
 import { ButtonAppearance, ButtonVariant } from '@/types/button';
 
-export interface DialButtonDropdownProps extends DialButtonProps {
+export interface DialButtonDropdownProps
+  extends Omit<DialButtonProps, 'iconAfter'> {
   items: DropdownItem[];
 }
 
@@ -28,6 +29,7 @@ export interface DialButtonDropdownProps extends DialButtonProps {
 export const DialButtonDropdown: FC<DialButtonDropdownProps> = ({
   variant,
   appearance,
+  items,
   ...props
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -39,7 +41,7 @@ export const DialButtonDropdown: FC<DialButtonDropdownProps> = ({
     <div>
       <DialDropdown
         menu={{
-          items: props.items,
+          items,
         }}
         onOpenChange={(open) => setIsDropdownOpen(open)}
       >


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**UI changes**

<img width="522" height="43" alt="image" src="https://github.com/user-attachments/assets/be027a52-7811-491e-bd7a-3bbb48424d69" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added