### PR TITLE
fix: remove redundant fixed height for the `Link button`.

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -80,9 +80,10 @@ export const DialButton: FC<DialButtonProps> = ({
   const btnClassName = classNames(
     variant && getButtonClassNames(variant, appearance),
     !isOnlyIcon &&
-      (size === ButtonSize.Small
-        ? 'min-h-[24px] dial-tiny-text px-2'
-        : 'min-h-[40px] dial-small-text px-3'),
+      (size === ButtonSize.Small ? 'dial-tiny-text' : 'dial-small-text'),
+    !isOnlyIcon &&
+      appearance !== ButtonAppearance.Link &&
+      (size === ButtonSize.Small ? 'min-h-[24px] px-2' : 'min-h-[40px] px-3'),
     'disabled:cursor-not-allowed focus-visible:outline outline-offset-0',
     className,
   );

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -39,7 +39,7 @@
 }
 
 .dial-primary-link-button {
-  @apply dial-base-button bg-transparent text-accent-primary px-2 h-[24px];
+  @apply dial-base-button bg-transparent text-accent-primary px-2;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
**Description:**

-  Remove redundant fixed height for the `Link button`.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added