### PR TITLE
fix: custom icon for shared indicator. change grid rows colors.

### DIFF
--- a/src/assets/icons/arrow-up-right.svg
+++ b/src/assets/icons/arrow-up-right.svg
@@ -1,0 +1,4 @@
+<svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.5 7.5L7.5 1.5M7.5 1.5V6.9M7.5 1.5H2.1" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round" />
+</svg>

--- a/src/components/Grid/constants.ts
+++ b/src/components/Grid/constants.ts
@@ -2,8 +2,8 @@ export const gridBaseClassName = 'h-full';
 
 export const GRID_THEME_COLORS = {
   accentColor: 'var(--controls-bg-accent, #5C8DEA)',
-  backgroundColor: 'var(--bg-layer-2, #141A23)',
-  oddRowBackgroundColor: 'var(--bg-layer-3, #222932)',
+  backgroundColor: 'var(--bg-layer-3, #222932)',
+  oddRowBackgroundColor: 'var(--bg-layer-4, #333942)',
   borderColor: 'var(--bg-layer-4, #333942)',
   rowBorder: '1px solid var(--stroke-tertiary, #090D13)',
   borderRadius: 3,

--- a/src/components/SharedEntityIndicator/SharedEntityIndicator.spec.tsx
+++ b/src/components/SharedEntityIndicator/SharedEntityIndicator.spec.tsx
@@ -38,7 +38,7 @@ describe('Dial UI Kit :: DialSharedEntityIndicator', () => {
     });
     expect(svg.getAttribute('width')).toBe('10');
     expect(svg.getAttribute('height')).toBe('10');
-    expect(svg.getAttribute('stroke-width')).toBe('2');
+    expect(svg.getAttribute('stroke-width')).toBe('1.5');
   });
 
   test('respects provided size and stroke props', () => {

--- a/src/components/SharedEntityIndicator/SharedEntityIndicator.stories.tsx
+++ b/src/components/SharedEntityIndicator/SharedEntityIndicator.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
   args: {
     label: 'Shared entity',
     size: 10,
-    stroke: 2,
+    stroke: 1.5,
   },
 } satisfies Meta<DialSharedEntityIndicatorProps>;
 

--- a/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
+++ b/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
@@ -1,7 +1,8 @@
-import { IconArrowUpRight } from '@tabler/icons-react';
 import type { FC, ReactNode } from 'react';
 
 import { DialIcon } from '@/components/Icon/Icon';
+
+import ArrowUpRightIcon from '@/assets/icons/arrow-up-right.svg?react';
 
 import { mergeClasses } from '@/utils/merge-classes';
 
@@ -26,22 +27,23 @@ export interface DialSharedEntityIndicatorProps {
  * @param [label="Shared entity"] - Accessible label for assistive tech
  * @param [size=10] - Pixel size for the icon
  * @param [className] - Additional Tailwind classes appended to the container
- * @param [stroke=2] - Stroke width for the icon
+ * @param [stroke=1.5] - Stroke width for the icon
  *
  */
 export const DialSharedEntityIndicator: FC<DialSharedEntityIndicatorProps> = ({
   label = 'Shared entity',
   size = 10,
   className,
-  stroke = 2,
+  stroke = 1.5,
 }) => {
   return (
     <DialIcon
       className={mergeClasses('text-accent-primary', className)}
       icon={
-        <IconArrowUpRight
-          size={size}
-          stroke={stroke}
+        <ArrowUpRightIcon
+          width={size}
+          height={size}
+          strokeWidth={stroke}
           aria-label={typeof label === 'string' ? label : undefined}
           className="bg-layer-3"
           role="img"


### PR DESCRIPTION
**Description:**

custom icon for shared indicator. change grid rows colors.

Issues:

- Issue #114 
- Issue https://github.com/epam/ai-dial-chat/issues/5461

**UI changes**

<img width="844" height="526" alt="image" src="https://github.com/user-attachments/assets/a92bd1bf-9f27-47b4-9abb-9b0a21f58758" />
<img width="462" height="529" alt="image" src="https://github.com/user-attachments/assets/e46c4c96-9614-4806-87c9-91e589782f6f" />


**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [ ] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added