### PR TITLE
fix: add long name file example and update display message styling in ConflictResolutionPopup

### DIFF
--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -364,7 +364,6 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
           extension: node.extension,
           isTemporary: false,
           owner: node.owner,
-          // permissions: node.permissions,
         }));
       }
 
@@ -382,7 +381,6 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
         extension: node.extension,
         isTemporary: false,
         owner: node.owner,
-        // permissions: node.permissions,
       }));
     }
 

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -364,6 +364,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
           extension: node.extension,
           isTemporary: false,
           owner: node.owner,
+          // permissions: node.permissions,
         }));
       }
 
@@ -381,6 +382,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
         extension: node.extension,
         isTemporary: false,
         owner: node.owner,
+        // permissions: node.permissions,
       }));
     }
 

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.stories.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.stories.tsx
@@ -17,6 +17,14 @@ const singleFile: DialFile = {
   parentPath: '/Design/Icons',
 } as DialFile;
 
+const singleFileWithLongName: DialFile = {
+  id: '1',
+  name: '6afef8c65740fe16e022d90cfc5942f6f7961e0b06b64851c638a01210243068.png',
+  path: '/Design/Icons/6afef8c65740fe16e022d90cfc5942f6f7961e0b06b64851c638a01210243068.png',
+  nodeType: DialFileNodeType.ITEM,
+  parentPath: '/Design/Icons',
+} as DialFile;
+
 const multipleFiles: DialFile[] = [
   {
     id: '1',
@@ -164,6 +172,12 @@ type Story = StoryObj<typeof meta>;
 export const SingleFileConflict: Story = {
   args: {
     conflictingFiles: [singleFile],
+  },
+};
+
+export const SingleFileConflictWithLongName: Story = {
+  args: {
+    conflictingFiles: [singleFileWithLongName],
   },
 };
 

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -438,7 +438,7 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
       }
     >
       <div className="px-6 py-4">
-        <p className="text-secondary mb-4">{displayMessage}</p>
+        <p className="text-secondary mb-4 break-words">{displayMessage}</p>
 
         {isSingleFile ? (
           <DialRadioGroup


### PR DESCRIPTION

**Description:**

<SHORT_DESCRIPTION>

Issues:

- [Issue](https://github.com/epam/ai-dial-chat/issues/5464)

**UI changes**

<img width="521" height="487" alt="image" src="https://github.com/user-attachments/assets/d806d6c5-5464-46ea-a109-66c359569669" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added