### PR TITLE
feat: Add possibility to control open state for Select

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { IconAbc, IconEqual, IconDashboardOff } from '@tabler/icons-react';
 import { DialSelect, type DialSelectProps } from './Select';
 import type { SelectOption } from '@/models/select';
 import { SelectSize, SelectVariant } from '@/types/select';
 import { DialPrimaryButton } from '@/components/Button/ButtonWrappers';
+import { useState, useRef } from 'react';
 
 const iconSize = 16;
 const baseOptions: SelectOption[] = [
@@ -78,8 +80,11 @@ const meta = {
     disabled: { control: { type: 'boolean' } },
     className: { control: { type: 'text' } },
     closable: { control: { type: 'boolean' } },
+    open: { control: { type: 'boolean' } },
+    onOpenChange: { control: false },
     onClose: { control: false },
     onChange: { control: false },
+    onInlineQueryChange: { control: false },
   },
   args: {
     options: baseOptions,
@@ -214,6 +219,72 @@ export const InlineSearch: Story = {
   args: {
     inlineSearch: true,
     searchPlaceholder: 'Display name',
+  },
+};
+
+const productsMockOptions: SelectOption[] = [
+  { value: 'laptop', label: 'Laptop' },
+  { value: 'smartphone', label: 'Smartphone' },
+  { value: 'tablet', label: 'Tablet' },
+  { value: 'smartwatch', label: 'Smartwatch' },
+  { value: 'headphones', label: 'Headphones' },
+  { value: 'camera', label: 'Camera' },
+  { value: 'printer', label: 'Printer' },
+  { value: 'monitor', label: 'Monitor' },
+  { value: 'keyboard', label: 'Keyboard' },
+  { value: 'mouse', label: 'Mouse' },
+];
+export const InlineWithExternalRequest: Story = {
+  name: 'Inline search with external request',
+  args: {
+    inlineSearch: true,
+    searchPlaceholder: 'Start typing device name, e.g. smartphone...',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Simulates fetching options from an external source based on user input with debounce. Uses controlled open ',
+      },
+    },
+  },
+  render: (args) => {
+    const [options, setOptions] = useState<SelectOption[]>([]);
+    const [open, setOpen] = useState(false);
+    const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
+
+    const handleSearch = (query: string) => {
+      // Clear previous timeout
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+
+      // Simulate an API request with debounce
+      debounceTimeoutRef.current = setTimeout(() => {
+        const filtered = query.length
+          ? productsMockOptions.filter((option) =>
+              option.label.toLowerCase().includes(query.toLowerCase()),
+            )
+          : [];
+        setOptions(filtered);
+      }, 300);
+    };
+
+    return (
+      <div className="w-[320px]">
+        <DialSelect
+          {...args}
+          options={options}
+          onInlineQueryChange={(v) => {
+            handleSearch(v as string);
+          }}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      </div>
+    );
   },
 };
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -63,6 +63,9 @@ export interface DialSelectProps {
   invalid?: boolean;
   header?: ReactNode | (() => ReactNode);
   footer?: ReactNode | (() => ReactNode);
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onInlineQueryChange?: (query: string) => void;
   dismissRef?: Ref<unknown>;
   onClose?: (e: MouseEvent<HTMLButtonElement>) => void;
   onChange?: (next: string | string[]) => void;
@@ -117,9 +120,12 @@ export interface DialSelectProps {
  * @param [closable=false] - Show a close button in the dropdown header.
  * @param [header] - Custom node/function rendered above the options.
  * @param [footer] - Custom node/function rendered below the options.
+ * @param [open] - Controlled open state of the dropdown. When provided, makes the dropdown controlled.
+ * @param [onOpenChange] - Called when the dropdown open state changes.
  * @param [onClose] - Called when the dropdown close button is clicked.
  * @param [onChange] - Called when the selection changes.
  * @param [inlineSearch=false] - Render a plain input inside trigger (single mode only).
+ * @param [onInlineQueryChange] - Called when the inline search query changes
  * @param [onFooterClick] - Called when the footer element is clicked. When provided, automatically closes the dropdown.
  * @param [dismissRef] - Ref object to expose a `dismiss` method to programmatically close the select.
  */
@@ -153,13 +159,36 @@ export const DialSelect: FC<DialSelectProps> = ({
   inlineSearch = false,
   dismissRef,
   onFooterClick,
+  open,
+  onOpenChange,
+  onInlineQueryChange,
 }) => {
   const listId = useId();
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState(
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlledOpen = open !== undefined;
+  const isOpen = isControlledOpen ? !!open : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlledOpen) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlledOpen, onOpenChange],
+  );
+
+  const [query, setInternalQuery] = useState(
     inlineSearch ? customSelectedValue || '' : '',
   );
   const inlineSearchInputRef = useRef<HTMLInputElement>(null);
+  const setQuery = useCallback(
+    (next: string) => {
+      if (next !== query) {
+        setInternalQuery(next);
+        onInlineQueryChange?.(next);
+      }
+    },
+    [onInlineQueryChange, query],
+  );
 
   const isControlled = value !== undefined;
   const [uncontrolled, setUncontrolled] = useState<
@@ -179,12 +208,13 @@ export const DialSelect: FC<DialSelectProps> = ({
   }, [options, query]);
 
   useEffect(() => {
-    if (!open && !inlineSearch) setQuery('');
-  }, [inlineSearch, open]);
+    if (!isOpen && !inlineSearch) setQuery('');
+  }, [inlineSearch, isOpen, setQuery]);
 
   useEffect(() => {
-    if (inlineSearch) setQuery(customSelectedValue || '');
-  }, [customSelectedValue, inlineSearch]);
+    if (inlineSearch && !isOpen && customSelectedValue)
+      setQuery(customSelectedValue || '');
+  }, [customSelectedValue, inlineSearch, isOpen, setQuery]);
 
   const setSelection = useCallback(
     (next: string | string[]) => {
@@ -194,20 +224,39 @@ export const DialSelect: FC<DialSelectProps> = ({
     [isControlled, onChange],
   );
 
-  const handleToggle = (val: string) => {
-    if (multiple) {
-      const set = new Set(selectedValues);
-      if (set.has(val)) {
-        set.delete(val);
-      } else {
-        set.add(val);
+  const handleToggle = useCallback(
+    (val: string) => {
+      if (multiple) {
+        const set = new Set(selectedValues);
+        if (set.has(val)) {
+          set.delete(val);
+        } else {
+          set.add(val);
+        }
+        setSelection(Array.from(set));
+        return;
       }
-      setSelection(Array.from(set));
-    } else {
       setSelection(val);
+      if (inlineSearch) {
+        const selectedOption = options.find((o) => o.value === val);
+        if (selectedOption) {
+          setQuery(selectedOption.label);
+          onInlineQueryChange?.(selectedOption.label);
+        }
+      }
       setOpen(false);
-    }
-  };
+    },
+    [
+      multiple,
+      setSelection,
+      inlineSearch,
+      setOpen,
+      selectedValues,
+      options,
+      setQuery,
+      onInlineQueryChange,
+    ],
+  );
 
   const handleRemoveTag = useCallback(
     (event: MouseEvent<HTMLButtonElement>, val: string) => {
@@ -266,7 +315,7 @@ export const DialSelect: FC<DialSelectProps> = ({
   const hasSelection = selectedValues.length > 0;
 
   useEffect(() => {
-    if (open && inlineSearch && !multiple && !disabled) {
+    if (isOpen && inlineSearch && !multiple && !disabled) {
       requestAnimationFrame(() => {
         const el = inlineSearchInputRef.current;
         if (!el) return;
@@ -275,7 +324,7 @@ export const DialSelect: FC<DialSelectProps> = ({
         el.setSelectionRange?.(len, len);
       });
     }
-  }, [open, inlineSearch, multiple, disabled]);
+  }, [isOpen, inlineSearch, multiple, disabled]);
 
   const singleSelectedValue =
     !multiple && hasSelection ? selectedValues[0] : undefined;
@@ -356,21 +405,21 @@ export const DialSelect: FC<DialSelectProps> = ({
     setQuery(
       selectedValues.length === 1 ? (singleSelectedOption?.label ?? query) : '',
     );
-  }, [query, selectedValues.length, singleSelectedOption]);
+  }, [query, selectedValues.length, setQuery, singleSelectedOption?.label]);
 
   const handleTriggerAction = useCallback(() => {
     if (disabled) return;
-    setOpen((v) => !v);
+    setOpen(!isOpen);
 
     if (inlineSearch && !multiple) {
       setInlineSearchQuery();
       inlineSearchInputRef.current?.focus();
     }
-  }, [disabled, inlineSearch, multiple, setInlineSearchQuery]);
+  }, [disabled, inlineSearch, isOpen, multiple, setInlineSearchQuery, setOpen]);
 
   return (
     <DialDropdown
-      open={open}
+      open={isOpen}
       onOpenChange={handleClose}
       disabled={disabled}
       closable={closable}
@@ -531,7 +580,7 @@ export const DialSelect: FC<DialSelectProps> = ({
         tabIndex={0}
         aria-roledescription="button to open select list"
         aria-haspopup="listbox"
-        aria-expanded={open}
+        aria-expanded={isOpen}
         aria-controls={`list-${elementId || listId}`}
         className={mergeClasses(
           selectTriggerBaseClassName,
@@ -595,7 +644,7 @@ export const DialSelect: FC<DialSelectProps> = ({
         {!inlineSearch && (
           <DialIcon
             icon={selectChevronIcon}
-            className={classNames('text-primary', open && 'rotate-180')}
+            className={classNames('text-primary', isOpen && 'rotate-180')}
           />
         )}
       </div>


### PR DESCRIPTION
**Description:**

Added possibility to control open state for Select and also trigger on inlineSearch change.

This is needed for the use case when options list is too big and we need to get the results by parts using the API request for each search input

Issues:

- Issue #<TICKET_ID>

**UI changes**

no changes

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added