### PR TITLE
fix: add border to footer in ConflictResolutionPopup for better separation

### DIFF
--- a/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -125,7 +125,7 @@ export const DialCollapsibleSidebar: FC<DialCollapsibleSidebarProps> = ({
       </div>
       <div className={titleClass}>{title}</div>
       <div
-        className={mergeClasses('border-t border-primary h-12', buttonClass)}
+        className={mergeClasses('border-t border-tertiary h-12', buttonClass)}
       >
         {opened && additionalButtons}
         <DialButton

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -431,7 +431,7 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
       header={title}
       dividers={false}
       footer={
-        <div className="flex justify-end gap-3 py-4 px-6">
+        <div className="flex justify-end gap-3 py-4 px-6 border-t border-stroke">
           <DialNeutralButton onClick={onClose} label={cancelLabel} />
           <DialPrimaryButton onClick={handleConfirm} label={confirmLabel} />
         </div>


### PR DESCRIPTION
**Description:**

add border to footer in ConflictResolutionPopup for better separation

Issues:

- [Issue](https://github.com/epam/ai-dial-chat/issues/5459)

**UI changes**

<img width="533" height="440" alt="image" src="https://github.com/user-attachments/assets/4eb23985-c4ff-4639-8df9-7c3bb938a48b" />
<img width="91" height="97" alt="image" src="https://github.com/user-attachments/assets/ef1e9b33-8e49-4ed6-a529-f0dc6494621c" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added