### PR TITLE
fix: support folder name with dots in name conflict resolution logic

### DIFF
--- a/src/components/FileManager/hooks/__tests__/use-conflict-resolution.spec.ts
+++ b/src/components/FileManager/hooks/__tests__/use-conflict-resolution.spec.ts
@@ -506,4 +506,80 @@ describe('Dial UI Kit :: FileManager :: useConflictResolution', () => {
     expect(result.current.conflictResolutionOpen).toBe(false);
     expect(result.current.conflictingFiles).toEqual([]);
   });
+
+  it('resolveConflictsWithStrategy: FOLDER with dot in name is duplicated as "name (n)"', () => {
+    destinationFiles = [
+      {
+        id: '1',
+        name: 'foo.bar',
+        path: '/dest/foo.bar',
+        nodeType: DialFileNodeType.FOLDER,
+      } as DialFile,
+    ];
+
+    const { result } = renderHook(() =>
+      useConflictResolution({ getDestinationFiles }),
+    );
+
+    const files: DialFile[] = [
+      {
+        id: '2',
+        name: 'foo.bar',
+        path: '/src/foo.bar',
+        nodeType: DialFileNodeType.FOLDER,
+      } as DialFile,
+    ];
+
+    const resolved = result.current.resolveConflictsWithStrategy(
+      '/dest',
+      files,
+      false,
+    );
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toEqual({
+      sourceUrl: '/src/foo.bar',
+      destinationUrl: '/dest/foo.bar (1)',
+      overwrite: false,
+      nodeType: DialFileNodeType.FOLDER,
+    });
+  });
+
+  it('resolveConflictsWithStrategy: ITEM multi-dot filename keeps last extension', () => {
+    destinationFiles = [
+      {
+        id: '1',
+        name: 'archive.tar.gz',
+        path: '/dest/archive.tar.gz',
+        nodeType: DialFileNodeType.ITEM,
+      } as DialFile,
+    ];
+
+    const { result } = renderHook(() =>
+      useConflictResolution({ getDestinationFiles }),
+    );
+
+    const files: DialFile[] = [
+      {
+        id: '2',
+        name: 'archive.tar.gz',
+        path: '/src/archive.tar.gz',
+        nodeType: DialFileNodeType.ITEM,
+      } as DialFile,
+    ];
+
+    const resolved = result.current.resolveConflictsWithStrategy(
+      '/dest',
+      files,
+      false,
+    );
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toEqual({
+      sourceUrl: '/src/archive.tar.gz',
+      destinationUrl: '/dest/archive.tar (1).gz',
+      overwrite: false,
+      nodeType: DialFileNodeType.ITEM,
+    });
+  });
 });

--- a/src/components/FileManager/hooks/use-conflict-resolution.ts
+++ b/src/components/FileManager/hooks/use-conflict-resolution.ts
@@ -18,28 +18,27 @@ export interface ConflictResolutionResult {
 const resolveNameConflict = (
   originalName: string,
   existingNames: Set<string>,
+  type: DialFileNodeType,
 ): string => {
   if (!existingNames.has(originalName)) {
     return originalName;
   }
 
-  const lastDotIndex = originalName.lastIndexOf('.');
-  const hasExtension = lastDotIndex > 0;
+  const makeCandidate =
+    type === DialFileNodeType.FOLDER
+      ? (name: string, n: number) => `${name} (${n})`
+      : (name: string, n: number) => {
+          const lastDotIndex = name.lastIndexOf('.');
+          const hasExtension = lastDotIndex > 0;
+          const base = hasExtension ? name.slice(0, lastDotIndex) : name;
+          const extension = hasExtension ? name.slice(lastDotIndex) : '';
+          return `${base} (${n})${extension}`;
+        };
 
-  const baseName = hasExtension
-    ? originalName.substring(0, lastDotIndex)
-    : originalName;
-  const extension = hasExtension ? originalName.substring(lastDotIndex) : '';
-
-  let counter = 1;
-  let newName: string;
-
-  do {
-    newName = `${baseName} (${counter})${extension}`;
-    counter++;
-  } while (existingNames.has(newName));
-
-  return newName;
+  for (let n = 1; ; n++) {
+    const candidate = makeCandidate(originalName, n);
+    if (!existingNames.has(candidate)) return candidate;
+  }
 };
 
 const getFileName = (file: DialFile): string => {
@@ -108,7 +107,7 @@ export const useConflictResolution = ({
         const finalName =
           overwrite && hasConflict
             ? originalName
-            : resolveNameConflict(originalName, existingNames);
+            : resolveNameConflict(originalName, existingNames, file.nodeType);
 
         if (!overwrite || !hasConflict) {
           existingNames.add(finalName);
@@ -149,7 +148,7 @@ export const useConflictResolution = ({
 
         const finalName = shouldOverwrite
           ? file.name
-          : resolveNameConflict(file.name, existingNames);
+          : resolveNameConflict(file.name, existingNames, file.nodeType);
 
         if (!shouldOverwrite) {
           existingNames.add(finalName);


### PR DESCRIPTION
**Description:**

support folder name with dots in name conflict resolution logic

Issues:

- Issue #114 
- Issue https://github.com/epam/ai-dial-chat/issues/5495

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added