### PR TITLE
fix: adjust font for breadcrumbs and collapsed folders-tree

### DIFF
--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -6,7 +6,7 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 shrink-0 dial-small';
+  'flex items-center gap-2 min-w-0 shrink-0 dial-tiny';
 
 export const breadcrumbItemVisibleClassName =
   'max-w-[20%] basis-[20%] flex-none';

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -6,7 +6,7 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 shrink-0 dial-tiny';
+  'flex items-center gap-2 min-w-0 shrink-0 dial-small';
 
 export const breadcrumbItemVisibleClassName =
   'max-w-[20%] basis-[20%] flex-none';

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1045,6 +1045,7 @@ export const DialFileManagerView: FC = () => {
             width={sidebarCurrentWidth}
             title={header}
             containerClassName={containerClassName}
+            titleClassName="dial-body-text text-primary"
             additionalButtons={additionalButtons}
             isOpened={!isTreeCollapsed}
             onToggle={toggleTreeCollapse}

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1245,6 +1245,7 @@ export const DialFileManagerView: FC = () => {
             value={effectiveSearchValue}
             onSearchChange={handleSearchChange}
             isCompactView={isCompactView}
+            labelClassName="dial-tiny"
           />
 
           <section


### PR DESCRIPTION
**Description:**

adjust font for breadcrumbs and collapsed folders-tree

Issues:

- Issue #114 
- Issue https://github.com/epam/ai-dial-chat/issues/5493
- Issue https://github.com/epam/ai-dial-chat/issues/5492

**UI changes**

<img width="974" height="228" alt="image" src="https://github.com/user-attachments/assets/ed482bd9-b006-4788-9a21-b5ff71b33d5b" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added