### PR TITLE
fix: file tree options context menu items list

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -888,14 +888,6 @@ export const DialFileManagerView: FC = () => {
           });
         }
 
-        if (treeOptions.actionLabels[DialFileManagerActions.Duplicate]) {
-          items.push({
-            key: 'duplicate',
-            label: treeOptions.actionLabels[DialFileManagerActions.Duplicate],
-            icon: <IconCopy {...BASE_ICON_PROPS} className="text-secondary" />,
-            onClick: () => handleDuplicate([file]),
-          });
-        }
         if (treeOptions.actionLabels[DialFileManagerActions.Copy]) {
           items.push({
             key: DestinationFolderMode.Copy,

--- a/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
+++ b/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
@@ -139,24 +139,25 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
   const renderDesktopActions = () => (
     <>
       {showHiddenFilesToggle && (
-        <DialSwitch
-          switchId="hidden-files-switch"
-          label={hiddenFilesSwitcherLabel}
-          isOn={areHiddenFilesVisible}
-          onChange={onToggleHiddenFiles}
-        />
+        <>
+          <DialSwitch
+            switchId="hidden-files-switch"
+            label={hiddenFilesSwitcherLabel}
+            isOn={areHiddenFilesVisible}
+            onChange={onToggleHiddenFiles}
+          />
+
+          <div className="h-6 border-l border-primary" />
+        </>
       )}
 
       {isNewButtonVisible && (
-        <>
-          <div className="h-6 border-l border-primary" />
-          <DialButtonDropdown
-            label={newButtonLabel}
-            variant={newButtonVariant}
-            items={newButtonDropdownItems}
-            disabled={isNewButtonDisabled}
-          />
-        </>
+        <DialButtonDropdown
+          label={newButtonLabel}
+          variant={newButtonVariant}
+          items={newButtonDropdownItems}
+          disabled={isNewButtonDisabled}
+        />
       )}
     </>
   );


### PR DESCRIPTION
**Description:**

Fix file tree options context menu items list
Hide vertical divider when show hidden files toggle is hidden

<img width="1221" height="804" alt="Screenshot 2026-01-19 at 17 47 13" src="https://github.com/user-attachments/assets/057faf69-6711-4b06-87ad-8ad1d4fa708b" />
<img width="1920" height="746" alt="Screenshot 2026-01-19 at 17 38 49" src="https://github.com/user-attachments/assets/cb3df29a-bfb4-4ab0-9e10-ac23199b41aa" />


Issues:

- Issue #423

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added