### PR TITLE
feat: disable new button based on current-folder permissions

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -522,6 +522,7 @@ export const DialFileManagerView: FC = () => {
     maxFileSize,
     newActions,
     isNewButtonVisible,
+    isNewButtonDisabled,
     newFolderTempId,
     cancelFolderCreation,
     saveFolderCreation,
@@ -859,6 +860,7 @@ export const DialFileManagerView: FC = () => {
             areHiddenFilesVisible={areHiddenFilesVisible}
             onToggleHiddenFiles={toggleHiddenFilesVisibility}
             isNewButtonVisible={isNewButtonVisible}
+            isNewButtonDisabled={isNewButtonDisabled}
             newButtonDropdownItems={newActions}
           />
         </div>
@@ -892,6 +894,7 @@ export const DialFileManagerView: FC = () => {
     toggleHiddenFilesVisibility,
     toolbarOptions,
     isNewButtonVisible,
+    isNewButtonDisabled,
     newActions,
   ]);
 

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -138,6 +138,7 @@ export interface FileManagerContextValue {
 
   newActions: DropdownItem[];
   isNewButtonVisible: boolean;
+  isNewButtonDisabled: boolean;
 
   openFileDialog: () => void;
   fileInputRef: RefObject<HTMLInputElement | null>;

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -335,12 +335,15 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     validationMessages: folderCreationValidationMessages,
   });
 
-  const { newActions, isNewButtonVisible } = useNewActions({
-    newActions: toolbarOptions?.newActions,
-    onUploadFiles: openFileDialog,
-    onUploadArchive: openArchiveUpload,
-    onCreateFolder: startFolderCreation,
-  });
+  const { newActions, isNewButtonVisible, isNewButtonDisabled } = useNewActions(
+    {
+      newActions: toolbarOptions?.newActions,
+      currentFolder,
+      onUploadFiles: openFileDialog,
+      onUploadArchive: openArchiveUpload,
+      onCreateFolder: startFolderCreation,
+    },
+  );
 
   const gridRows: FileManagerGridRow[] = useMemo(() => {
     if (isSearchMode) {
@@ -604,6 +607,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
 
     newActions,
     isNewButtonVisible,
+    isNewButtonDisabled,
 
     isCreatingFolder,
     newFolderTempId,

--- a/src/components/FileManager/hooks/__tests__/use-new-actions.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-new-actions.spec.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useNewActions } from '@/components/FileManager/hooks/use-new-actions';
 import type { MouseEvent } from 'react';
+import { DialFilePermission, type DialFile } from '@/models/file';
 
 describe('Dial UI Kit :: FileManager :: useNewActions', () => {
   const mockMouseEvent = {} as MouseEvent<Element, globalThis.MouseEvent>;
@@ -280,5 +281,127 @@ describe('Dial UI Kit :: FileManager :: useNewActions', () => {
     );
 
     expect(result.current.isNewButtonVisible).toBe(true);
+  });
+
+  it('isNewButtonDisabled is true when currentFolder is undefined', () => {
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: { newFolder: { label: 'New Folder' } },
+        currentFolder: undefined,
+      }),
+    );
+
+    expect(result.current.isNewButtonDisabled).toBe(true);
+  });
+
+  it('isNewButtonDisabled is true when currentFolder.permissions is undefined', () => {
+    const folder = { id: '1' } as DialFile;
+
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: { newFolder: { label: 'New Folder' } },
+        currentFolder: folder,
+      }),
+    );
+
+    expect(result.current.isNewButtonDisabled).toBe(true);
+  });
+
+  it('isNewButtonDisabled is true when currentFolder does not include WRITE permission', () => {
+    const folder = {
+      id: '1',
+      permissions: [DialFilePermission.READ],
+    } as DialFile;
+
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: { newFolder: { label: 'New Folder' } },
+        currentFolder: folder,
+      }),
+    );
+
+    expect(result.current.isNewButtonDisabled).toBe(true);
+  });
+
+  it('isNewButtonDisabled is false when currentFolder includes WRITE permission', () => {
+    const folder = {
+      id: '1',
+      permissions: [DialFilePermission.READ, DialFilePermission.WRITE],
+    } as DialFile;
+
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: { newFolder: { label: 'New Folder' } },
+        currentFolder: folder,
+      }),
+    );
+
+    expect(result.current.isNewButtonDisabled).toBe(false);
+  });
+
+  it('isNewButtonDisabled updates when currentFolder changes', () => {
+    const folderWithoutWrite = {
+      id: '1',
+      permissions: [DialFilePermission.READ],
+    } as DialFile;
+
+    const folderWithWrite = {
+      id: '2',
+      permissions: [DialFilePermission.WRITE],
+    } as DialFile;
+
+    const { result, rerender } = renderHook((props) => useNewActions(props), {
+      initialProps: {
+        newActions: { newFolder: { label: 'New Folder' } },
+        currentFolder: folderWithoutWrite,
+      },
+    });
+
+    expect(result.current.isNewButtonDisabled).toBe(true);
+
+    rerender({
+      newActions: { newFolder: { label: 'New Folder' } },
+      currentFolder: folderWithWrite,
+    });
+
+    expect(result.current.isNewButtonDisabled).toBe(false);
+  });
+
+  it('isNewButtonDisabled does not depend on newActions (still true with WRITE missing, even if actions exist)', () => {
+    const folder = {
+      id: '1',
+      permissions: [DialFilePermission.READ],
+    } as DialFile;
+
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: {
+          newFolder: { label: 'New Folder' },
+          uploadFiles: { label: 'Upload Files' },
+          uploadArchive: { label: 'Upload Archive' },
+        },
+        currentFolder: folder,
+      }),
+    );
+
+    expect(result.current.isNewButtonVisible).toBe(true);
+    expect(result.current.isNewButtonDisabled).toBe(true);
+  });
+
+  it('isNewButtonDisabled is true even when there are no actions (disabled state is permission-based)', () => {
+    const folder = {
+      id: '1',
+      permissions: [DialFilePermission.WRITE],
+    } as DialFile;
+
+    const { result } = renderHook(() =>
+      useNewActions({
+        newActions: undefined,
+        currentFolder: folder,
+      }),
+    );
+
+    expect(result.current.isNewButtonVisible).toBe(false);
+    expect(result.current.isNewButtonDisabled).toBe(false);
   });
 });

--- a/src/components/FileManager/hooks/use-new-actions.tsx
+++ b/src/components/FileManager/hooks/use-new-actions.tsx
@@ -3,6 +3,7 @@ import { IconFile, IconFileZip, IconFolder } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import type { DropdownItem } from '@/models/dropdown';
 import type { NewAction } from '../FileManager';
+import { DialFilePermission, type DialFile } from '@/models/file';
 
 export interface UseNewActionsProps {
   newActions?: {
@@ -10,6 +11,7 @@ export interface UseNewActionsProps {
     newFolder?: NewAction;
     uploadArchive?: NewAction;
   };
+  currentFolder?: DialFile;
   onUploadFiles?: () => void;
   onCreateFolder?: () => void;
   onUploadArchive?: () => void;
@@ -18,10 +20,12 @@ export interface UseNewActionsProps {
 export interface UseNewActionsResult {
   newActions: DropdownItem[];
   isNewButtonVisible: boolean;
+  isNewButtonDisabled: boolean;
 }
 
 export const useNewActions = ({
   newActions,
+  currentFolder,
   onUploadFiles,
   onCreateFolder,
   onUploadArchive,
@@ -95,5 +99,14 @@ export const useNewActions = ({
     [newActionItems],
   );
 
-  return { newActions: newActionItems, isNewButtonVisible };
+  const isNewButtonDisabled = useMemo(
+    () => !currentFolder?.permissions?.includes(DialFilePermission.WRITE),
+    [currentFolder],
+  );
+
+  return {
+    newActions: newActionItems,
+    isNewButtonVisible,
+    isNewButtonDisabled,
+  };
 };


### PR DESCRIPTION
**Description:**

disable new button based on current-folder permissions

Issues:

- Issue #114 
- Issue https://github.com/epam/ai-dial-chat/issues/5498

**UI changes**

<img width="1177" height="527" alt="image" src="https://github.com/user-attachments/assets/a1bcd3de-ae3e-4f32-b339-1685aaf0e7aa" />
<img width="1181" height="529" alt="image" src="https://github.com/user-attachments/assets/45c72102-9978-46c3-a445-2566e7d945f3" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added