### PR TITLE
feat: extract existing columns to reusable constants

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -182,7 +182,14 @@ export type NavigationPanelOptions = Omit<
 
 export interface GridOptions
   extends Omit<DialGridProps<GridRow>, 'rowData' | 'columnDefs'> {
-  columnDefs?: ColDef<GridRow>[];
+  columnDefs?: (
+    | ColDef<GridRow>
+    | ((
+        dateLocale: Intl.LocalesArgument,
+        dateOptions: Intl.DateTimeFormatOptions | undefined,
+        isCompactView: boolean,
+      ) => ColDef<GridRow, unknown>)
+  )[];
   filterable?: boolean;
   dateLocale?: Intl.LocalesArgument;
   dateOptions?: Intl.DateTimeFormatOptions;

--- a/src/components/FileManager/hooks/use-file-manager-columns.tsx
+++ b/src/components/FileManager/hooks/use-file-manager-columns.tsx
@@ -1,18 +1,15 @@
-import { mergeClasses } from '@/utils/merge-classes';
 import { useMemo } from 'react';
 import type { ColDef, SuppressKeyboardEventParams } from 'ag-grid-community';
-import { DialFileNodeType, type DialFile } from '@/models/file';
-import { DialFileName } from '@/components/FileName/FileName';
-import { DialFolderName } from '@/components/FolderName/FolderName';
-import { DialDateCellRenderer } from '@/components/Grid/renderers/DateCellRenderer';
+import { type DialFile } from '@/models/file';
 import { FileManagerRenameTriggerView } from '@/types/file-manager';
-import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
-import { DialItemType } from '@/types/item';
-import { DialFileManagerItemSummaryCell } from '@/components/FileManager/components/DialFileManagerItemSummaryCell/DialFileManagerItemSummaryCell';
 import { FileManagerColumnKey } from '@/types/file-manager';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import type { FileManagerGridRow } from '@/components/FileManager/FileManagerContext';
-import { BASE_FILE_MANAGER_ICON_SIZE } from '@/components/FileManager/constants';
+import {
+  NAME_COLUMN,
+  UPDATED_AT_COLUMN,
+  SIZE_COLUMN,
+} from '@/constants/file-grid-columns';
 
 type GridRow = FileManagerGridRow;
 
@@ -36,7 +33,14 @@ export interface FileManagerGridContext {
 }
 
 export interface UseFileManagerColumnsArgs {
-  userColumnDefs?: ColDef<GridRow>[];
+  userColumnDefs?: (
+    | ColDef<GridRow>
+    | ((
+        dateLocale: Intl.LocalesArgument,
+        dateOptions: Intl.DateTimeFormatOptions | undefined,
+        isCompactView: boolean,
+      ) => ColDef<GridRow, unknown>)
+  )[];
   filterable: boolean;
   dateLocale?: Intl.LocalesArgument;
   dateOptions?: Intl.DateTimeFormatOptions;
@@ -91,128 +95,7 @@ export function useFileManagerColumns({
 }: UseFileManagerColumnsArgs): UseFileManagerColumnsResult {
   const defaultColumns = useMemo<ColDef<GridRow>[]>(() => {
     return [
-      {
-        colId: FileManagerColumnKey.Name,
-        field: 'name',
-        headerName: 'Name',
-        flex: 1,
-        minWidth: 200,
-        cellRenderer: (params: {
-          data: GridRow;
-          context: FileManagerGridContext;
-        }) => {
-          const type = params.data.nodeType;
-          const {
-            saveFolderCreation,
-            validateFolderName,
-            cancelFolderCreation,
-            newFolderTempId,
-            sharedByMePaths,
-            selectedPaths,
-          } = params.context;
-
-          const isSharedByMe = sharedByMePaths?.has(params.data.path);
-          const isSelected = selectedPaths?.has(params.data.path);
-
-          const sharedIndicatorClassName = mergeClasses([
-            'group-hover/grid-row:bg-accent-primary-alpha',
-            isSelected && 'bg-accent-primary-alpha',
-          ]);
-
-          if (params.data?.isTemporary && params.data.id === newFolderTempId) {
-            return (
-              <DialFileManagerItemName
-                name=""
-                type={DialItemType.Folder}
-                elementId={`new-folder-${params.data.id}`}
-                editing={true}
-                shared={isSharedByMe}
-                sharedIndicatorClassName={sharedIndicatorClassName}
-                iconSize={BASE_FILE_MANAGER_ICON_SIZE}
-                validate={validateFolderName}
-                onSave={saveFolderCreation}
-                onCancel={cancelFolderCreation}
-                inputContainerClassName={mergeClasses([
-                  '!h-9',
-                  isCompactView && type === DialFileNodeType.ITEM && '!h-10',
-                ])}
-              />
-            );
-          }
-
-          const {
-            renameTriggerView,
-            renamedPath,
-            renamedItem,
-            getDisplayName,
-            onRenameValidate,
-            onRenameSave,
-            onRenameCancel,
-          } = params.context;
-
-          const isBeingRenamed =
-            renameTriggerView === FileManagerRenameTriggerView.Grid &&
-            renamedPath === params.data?.path;
-
-          if (isBeingRenamed && renamedItem && params.data) {
-            const displayName = getDisplayName(renamedItem);
-            return (
-              <DialFileManagerItemName
-                name={displayName}
-                type={
-                  type === DialFileNodeType.FOLDER
-                    ? DialItemType.Folder
-                    : DialItemType.File
-                }
-                elementId={`rename-${params.data.id}`}
-                editing={true}
-                shared={isSharedByMe}
-                sharedIndicatorClassName={sharedIndicatorClassName}
-                iconSize={BASE_FILE_MANAGER_ICON_SIZE}
-                validate={(value) => onRenameValidate(value, renamedItem)}
-                onSave={onRenameSave}
-                onCancel={onRenameCancel}
-                inputContainerClassName={mergeClasses([
-                  '!h-9',
-                  isCompactView && type === DialFileNodeType.ITEM && '!h-10',
-                ])}
-              />
-            );
-          }
-
-          if (isCompactView) {
-            return (
-              <DialFileManagerItemSummaryCell
-                id={params.data.id}
-                name={params.data.name}
-                nodeType={type}
-                size={params.data.size}
-                shared={isSharedByMe}
-                sharedIndicatorClassName={sharedIndicatorClassName}
-                updatedAt={params.data.updatedAt}
-                dateLocale={dateLocale}
-                dateOptions={dateOptions}
-              />
-            );
-          }
-
-          return type === DialFileNodeType.FOLDER ? (
-            <DialFolderName
-              name={params.data.name}
-              shared={isSharedByMe}
-              sharedIndicatorClassName={sharedIndicatorClassName}
-              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
-            />
-          ) : (
-            <DialFileName
-              name={params.data.name}
-              shared={isSharedByMe}
-              sharedIndicatorClassName={sharedIndicatorClassName}
-              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
-            />
-          );
-        },
-      },
+      NAME_COLUMN('Name')(dateLocale, dateOptions, isCompactView),
       {
         colId: FileManagerColumnKey.Path,
         field: 'path',
@@ -227,25 +110,8 @@ export function useFileManagerColumns({
           return <DialEllipsisTooltip text={path} />;
         },
       },
-      {
-        colId: FileManagerColumnKey.UpdatedAt,
-        field: 'updatedAt',
-        headerName: 'Modified Date',
-        width: 168,
-        suppressSizeToFit: true,
-        cellRenderer: DialDateCellRenderer,
-        cellRendererParams: {
-          locale: dateLocale,
-          options: dateOptions,
-        },
-      },
-      {
-        colId: FileManagerColumnKey.Size,
-        field: 'size',
-        headerName: 'Size',
-        width: 120,
-        suppressSizeToFit: true,
-      },
+      UPDATED_AT_COLUMN('Modified Date')(dateLocale, dateOptions),
+      SIZE_COLUMN('Size'),
       {
         colId: FileManagerColumnKey.Author,
         field: 'author',
@@ -270,9 +136,25 @@ export function useFileManagerColumns({
   }, [dateLocale, dateOptions, isCompactView, rootItemLabel, rootItemPath]);
 
   const columnDefs = useMemo<ColDef<GridRow>[]>(() => {
-    let columns = userColumnDefs ?? defaultColumns;
+    const processedUserColumns = userColumnDefs?.map(
+      (
+        column:
+          | ColDef<FileManagerGridRow, unknown>
+          | ((
+              dateLocale: Intl.LocalesArgument,
+              dateOptions: Intl.DateTimeFormatOptions | undefined,
+              isCompactView: boolean,
+            ) => ColDef<FileManagerGridRow, unknown>),
+      ) => {
+        return typeof column === 'function'
+          ? column(dateLocale, dateOptions, isCompactView)
+          : column;
+      },
+    );
 
-    if (!userColumnDefs) {
+    let columns = processedUserColumns ?? defaultColumns;
+
+    if (!processedUserColumns) {
       columns = columns.filter(
         (col) =>
           col.colId &&
@@ -307,6 +189,8 @@ export function useFileManagerColumns({
     });
   }, [
     actionsColumnDef,
+    dateLocale,
+    dateOptions,
     defaultColumns,
     effectiveVisibleColumns,
     filterable,

--- a/src/constants/file-grid-columns.tsx
+++ b/src/constants/file-grid-columns.tsx
@@ -1,0 +1,172 @@
+import { mergeClasses } from '@/utils/merge-classes';
+import { DialFileNodeType } from '@/models/file';
+import { DialFileName } from '@/components/FileName/FileName';
+import { DialFolderName } from '@/components/FolderName/FolderName';
+import { DialDateCellRenderer } from '@/components/Grid/renderers/DateCellRenderer';
+import { FileManagerRenameTriggerView } from '@/types/file-manager';
+import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
+import { DialItemType } from '@/types/item';
+import { DialFileManagerItemSummaryCell } from '@/components/FileManager/components/DialFileManagerItemSummaryCell/DialFileManagerItemSummaryCell';
+import { FileManagerColumnKey } from '@/types/file-manager';
+import type { FileManagerGridRow } from '@/components/FileManager/FileManagerContext';
+import { BASE_FILE_MANAGER_ICON_SIZE } from '@/components/FileManager/constants';
+import type { FileManagerGridContext } from '@/components/FileManager/hooks/use-file-manager-columns';
+
+type GridRow = FileManagerGridRow;
+
+export const NAME_COLUMN =
+  (headerName: string) =>
+  (
+    dateLocale: Intl.LocalesArgument,
+    dateOptions: Intl.DateTimeFormatOptions | undefined,
+    isCompactView: boolean,
+  ) => {
+    return {
+      colId: FileManagerColumnKey.Name,
+      field: 'name' as keyof FileManagerGridRow,
+      headerName,
+      flex: 1,
+      minWidth: 200,
+      cellRenderer: (params: {
+        data: GridRow;
+        context: FileManagerGridContext;
+      }) => {
+        const type = params.data.nodeType;
+        const {
+          saveFolderCreation,
+          validateFolderName,
+          cancelFolderCreation,
+          newFolderTempId,
+          sharedByMePaths,
+          selectedPaths,
+        } = params.context;
+
+        const isSharedByMe = sharedByMePaths?.has(params.data.path);
+        const isSelected = selectedPaths?.has(params.data.path);
+
+        const sharedIndicatorClassName = mergeClasses([
+          'group-hover/grid-row:bg-accent-primary-alpha',
+          isSelected && 'bg-accent-primary-alpha',
+        ]);
+
+        if (params.data?.isTemporary && params.data.id === newFolderTempId) {
+          return (
+            <DialFileManagerItemName
+              name=""
+              type={DialItemType.Folder}
+              elementId={`new-folder-${params.data.id}`}
+              editing={true}
+              shared={isSharedByMe}
+              sharedIndicatorClassName={sharedIndicatorClassName}
+              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+              validate={validateFolderName}
+              onSave={saveFolderCreation}
+              onCancel={cancelFolderCreation}
+              inputContainerClassName={mergeClasses([
+                '!h-9',
+                isCompactView && type === DialFileNodeType.ITEM && '!h-10',
+              ])}
+            />
+          );
+        }
+
+        const {
+          renameTriggerView,
+          renamedPath,
+          renamedItem,
+          getDisplayName,
+          onRenameValidate,
+          onRenameSave,
+          onRenameCancel,
+        } = params.context;
+
+        const isBeingRenamed =
+          renameTriggerView === FileManagerRenameTriggerView.Grid &&
+          renamedPath === params.data?.path;
+
+        if (isBeingRenamed && renamedItem && params.data) {
+          const displayName = getDisplayName(renamedItem);
+          return (
+            <DialFileManagerItemName
+              name={displayName}
+              type={
+                type === DialFileNodeType.FOLDER
+                  ? DialItemType.Folder
+                  : DialItemType.File
+              }
+              elementId={`rename-${params.data.id}`}
+              editing={true}
+              shared={isSharedByMe}
+              sharedIndicatorClassName={sharedIndicatorClassName}
+              iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+              validate={(value) => onRenameValidate(value, renamedItem)}
+              onSave={onRenameSave}
+              onCancel={onRenameCancel}
+              inputContainerClassName={mergeClasses([
+                '!h-9',
+                isCompactView && type === DialFileNodeType.ITEM && '!h-10',
+              ])}
+            />
+          );
+        }
+
+        if (isCompactView) {
+          return (
+            <DialFileManagerItemSummaryCell
+              id={params.data.id}
+              name={params.data.name}
+              nodeType={type}
+              size={params.data.size}
+              shared={isSharedByMe}
+              sharedIndicatorClassName={sharedIndicatorClassName}
+              updatedAt={params.data.updatedAt}
+              dateLocale={dateLocale}
+              dateOptions={dateOptions}
+            />
+          );
+        }
+
+        return type === DialFileNodeType.FOLDER ? (
+          <DialFolderName
+            name={params.data.name}
+            shared={isSharedByMe}
+            sharedIndicatorClassName={sharedIndicatorClassName}
+            iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+          />
+        ) : (
+          <DialFileName
+            name={params.data.name}
+            shared={isSharedByMe}
+            sharedIndicatorClassName={sharedIndicatorClassName}
+            iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+          />
+        );
+      },
+    };
+  };
+
+export const UPDATED_AT_COLUMN =
+  (headerName: string) =>
+  (
+    dateLocale: Intl.LocalesArgument,
+    dateOptions: Intl.DateTimeFormatOptions | undefined,
+  ) => ({
+    colId: FileManagerColumnKey.UpdatedAt,
+    field: 'updatedAt' as keyof FileManagerGridRow,
+    headerName: headerName,
+    width: 168,
+    suppressSizeToFit: true,
+    cellRenderer: DialDateCellRenderer,
+    cellRendererParams: {
+      locale: dateLocale,
+      options: dateOptions,
+    },
+  });
+
+export const SIZE_COLUMN = (headerName: string) => ({
+  colId: FileManagerColumnKey.Size,
+  field: 'size' as keyof FileManagerGridRow,
+  headerName: headerName,
+  width: 120,
+  suppressSizeToFit: true,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,3 +147,10 @@ export {
 
 // Utils
 export { mergeClasses } from './utils/merge-classes';
+
+// Constants
+export {
+  NAME_COLUMN,
+  SIZE_COLUMN,
+  UPDATED_AT_COLUMN,
+} from './constants/file-grid-columns';


### PR DESCRIPTION
**Description:**

Extract Existing Columns to Constants

Refactor the existing columns and define them as reusable constants.
This will enable consistent use of these columns so that they can be reused in client applications, with different column Titles

Issues:

- Issue #430

**UI changes**

<img width="1908" height="734" alt="Screenshot 2026-01-21 at 13 36 09" src="https://github.com/user-attachments/assets/8069e040-abc7-436b-953d-0fdd04f28d32" />

<img width="1908" height="734" alt="Screenshot 2026-01-21 at 13 34 59" src="https://github.com/user-attachments/assets/15497e1c-e653-40cd-8974-0b899ba9a2a0" />

<img width="1908" height="734" alt="Screenshot 2026-01-21 at 13 35 13" src="https://github.com/user-attachments/assets/6032c4fe-7c09-4372-a0cb-416312dc9332" />



**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added