### PR TITLE
fix: set bg color for destination folder popup

### DIFF
--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -23,6 +23,7 @@ import {
 import { DestinationFolderMode } from '@/types/file-manager';
 import type { DialFileManagerActionsRef } from '@/models/file-manager';
 import { DialTooltip } from '@/components/Tooltip/Tooltip';
+import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DestinationFolderPopupProps extends DialFileManagerProps {
   onClose: () => void;
@@ -176,6 +177,7 @@ export const DestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
     >
       <DialFileManager
         {...restProps}
+        className={mergeClasses(restProps.className, 'bg-layer-2')}
         actionsRef={fileManagerActionRef}
         path={path}
         showHiddenFiles={showHiddenFiles}


### PR DESCRIPTION
**Description:**

set bg color for destination folder popup

Issues:

- Issue #114 
- Issue https://github.com/epam/ai-dial-chat/issues/5550

**UI changes**

<img width="904" height="818" alt="image" src="https://github.com/user-attachments/assets/fa379dcd-5c88-4a72-9061-09468ce85a22" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added