### PR TITLE
feat: add alert support to DialDestinationFolderPopup component

### DIFF
--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { DialDestinationFolderPopup } from './DestinationFolderPopup';
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
+import { AlertVariant } from '@/types/alert';
 
 const mockFiles: DialFile[] = [
   {
@@ -558,5 +559,35 @@ describe('Dial UI Kit :: DialDestinationFolderPopup', () => {
 
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     expect(copyButton).toBeDisabled();
+  });
+
+  test('renders alert when alertProps provided', () => {
+    render(
+      <DialDestinationFolderPopup
+        open={true}
+        onClose={vi.fn()}
+        items={mockFiles}
+        alertProps={{
+          message: 'Action unavailable in this folder',
+          variant: AlertVariant.Warning,
+          closable: true,
+        }}
+        rootItem={{
+          id: 'root',
+          name: 'Root',
+          path: '/',
+          folderId: 'root-folder',
+          nodeType: DialFileNodeType.FOLDER,
+          label: 'Root',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Action unavailable in this folder',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Close alert' }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
@@ -7,6 +7,7 @@ import {
   type DestinationFolderPopupProps,
 } from './DestinationFolderPopup';
 import { DialPrimaryButton } from '@/components/Button/ButtonWrappers';
+import { AlertVariant } from '@/types/alert';
 
 const StoryWrapper = (args: DestinationFolderPopupProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -131,5 +132,19 @@ export const CustomDisabledTooltip: Story = {
     disabledPathTooltip:
       'Cannot copy to the same location. Choose a different folder.',
     header: 'Copying 3 items',
+  },
+};
+
+export const WithAlert: Story = {
+  args: {
+    mode: 'move',
+    header: 'Moving items',
+    alertProps: {
+      variant: AlertVariant.Warning,
+      message:
+        'You cannot move items to the current folder. Choose another one.',
+    },
+    sourceFolder: '/Documents',
+    path: '/Documents',
   },
 };

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -24,6 +24,7 @@ import { DestinationFolderMode } from '@/types/file-manager';
 import type { DialFileManagerActionsRef } from '@/models/file-manager';
 import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
+import { DialAlert, type DialAlertProps } from '@/components/Alert/Alert';
 
 export interface DestinationFolderPopupProps extends DialFileManagerProps {
   onClose: () => void;
@@ -40,6 +41,7 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
   sourceFolder?: string;
   disabledPathTooltip?: string;
   collapsedFileTree?: boolean;
+  alertProps?: DialAlertProps;
 }
 
 /**
@@ -98,6 +100,7 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   disabledPathTooltip = 'Unavailable for the original path. Please select another folder',
   path,
   collapsedFileTree = false,
+  alertProps,
   ...restProps
 }: DestinationFolderPopupProps) => {
   const [showHiddenFiles, setShowHiddenFiles] = useState(false);
@@ -169,31 +172,40 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
       }
       header={header ?? defaultTitle}
     >
-      <DialFileManager
-        {...restProps}
-        className={mergeClasses(restProps.className, 'bg-layer-2')}
-        actionsRef={fileManagerActionRef}
-        path={path}
-        showHiddenFiles={showHiddenFiles}
-        onShowHiddenFilesChange={handleShowHiddenFilesChange}
-        treeOptions={{
-          ...restProps.treeOptions,
-          collapsed: collapsedFileTree,
-          expandedPaths: new Set<string>([restProps.rootItem?.path || '/']),
-          header: restProps.treeOptions?.header,
-        }}
-        gridOptions={{
-          withSelectionColumn: false,
-          ...restProps.gridOptions,
-        }}
-        navigationPanelOptions={{
-          elementId: 'file-manager-destination-search',
-          ...restProps.navigationPanelOptions,
-        }}
-        onUploadFiles={onUploadFiles}
-        onValidateUpload={onValidateUpload}
-        maxFileSize={maxFileSize}
-      />
+      <div className="bg-layer-2 h-full flex flex-col">
+        {alertProps && (
+          <div className="px-4 pt-4">
+            <DialAlert {...alertProps} />
+          </div>
+        )}
+        <div className="flex-1 min-h-0">
+          <DialFileManager
+            {...restProps}
+            className={mergeClasses(restProps.className, 'bg-layer-2 h-full')}
+            actionsRef={fileManagerActionRef}
+            path={path}
+            showHiddenFiles={showHiddenFiles}
+            onShowHiddenFilesChange={handleShowHiddenFilesChange}
+            treeOptions={{
+              ...restProps.treeOptions,
+              collapsed: collapsedFileTree,
+              expandedPaths: new Set<string>([restProps.rootItem?.path || '/']),
+              header: restProps.treeOptions?.header,
+            }}
+            gridOptions={{
+              withSelectionColumn: false,
+              ...restProps.gridOptions,
+            }}
+            navigationPanelOptions={{
+              elementId: 'file-manager-destination-search',
+              ...restProps.navigationPanelOptions,
+            }}
+            onUploadFiles={onUploadFiles}
+            onValidateUpload={onValidateUpload}
+            maxFileSize={maxFileSize}
+          />
+        </div>
+      </div>
     </DialPopup>
   );
 };


### PR DESCRIPTION
**Description:**

<SHORT_DESCRIPTION>

Issues:

- [Issue](https://github.com/epam/ai-dial-chat/issues/5518)

**UI changes**

<img width="1156" height="811" alt="image" src="https://github.com/user-attachments/assets/d2c725cd-6e27-4b07-8933-95fd35f4f53a" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added