### PR TITLE
feat: Add Leave Guard to Breadcrumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -117,4 +117,157 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
     const icons = screen.getAllByLabelText('icon');
     expect(icons.length).toBe(2);
   });
+
+  test('navigation guard allows navigation when returning true', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(true);
+    const onClick = vi.fn();
+
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Home', href: '#home', onClick },
+          { label: 'Current' },
+        ]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Home' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('navigation guard prevents navigation when returning false', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(false);
+    const onClick = vi.fn();
+
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Home', href: '#home', onClick },
+          { label: 'Current' },
+        ]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Home' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard supports async checks with Promise', async () => {
+    const onBeforeNavigate = vi.fn().mockResolvedValue(true);
+    const onClick = vi.fn();
+
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Home', href: '#home', onClick },
+          { label: 'Current' },
+        ]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Home' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    // Wait for async guard to complete
+    await vi.waitFor(() => {
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('navigation guard prevents async navigation when Promise resolves to false', async () => {
+    const onBeforeNavigate = vi.fn().mockResolvedValue(false);
+    const onClick = vi.fn();
+
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Home', href: '#home', onClick },
+          { label: 'Current' },
+        ]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Home' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    // Wait to ensure onClick is never called
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard is not called for last/current item', async () => {
+    const onBeforeNavigate = vi.fn();
+
+    render(
+      <DialBreadcrumb
+        pathItems={[{ label: 'Home', href: '#home' }, { label: 'Current' }]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    const currentText = screen.getByText('Current');
+    await fireEvent.click(currentText);
+
+    expect(onBeforeNavigate).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard works with composition API children', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(false);
+    const onClick = vi.fn();
+
+    render(
+      <DialBreadcrumb onBeforeNavigate={onBeforeNavigate}>
+        <DialBreadcrumbItem label="Home" href="#" onClick={onClick} />
+        <DialBreadcrumbItem label="Current" />
+      </DialBreadcrumb>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Home' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard works with collapsed dropdown items', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(false);
+
+    // Create 5+ items to trigger collapsed view with dropdown
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Home', href: '#home' },
+          { label: 'Level 2', href: '#level2' },
+          { label: 'Level 3', href: '#level3' },
+          { label: 'Level 4', href: '#level4' },
+          { label: 'Current' },
+        ]}
+        onBeforeNavigate={onBeforeNavigate}
+      />,
+    );
+
+    // Find and click the ellipsis button to open dropdown
+    const ellipsisButton = screen.getByRole('button', {
+      name: /more breadcrumbs/i,
+    });
+    await fireEvent.click(ellipsisButton);
+
+    // The dropdown items should appear - find one and try to click
+    const dropdownItem = screen.getByText('Level 2');
+    await fireEvent.click(dropdownItem);
+
+    expect(onBeforeNavigate).toHaveBeenCalled();
+  });
 });

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DialBreadcrumb } from './Breadcrumb';
 import { DialBreadcrumbItem } from './BreadcrumbItem';
 import { IconFolder } from '@tabler/icons-react';
+import { useState } from 'react';
 
 const meta = {
   title: 'Navigation/Breadcrumb',
@@ -14,6 +16,7 @@ const meta = {
     pathItems: { control: false },
     children: { control: false },
     labelClassName: { control: { type: 'text' } },
+    onBeforeNavigate: { control: false },
   },
   args: {
     ariaLabel: 'Breadcrumb',
@@ -101,6 +104,55 @@ export const CompositionAPI: Story = {
       />
     </DialBreadcrumb>
   ),
+};
+
+export const WithNavigationGuard: Story = {
+  name: 'With Navigation Guard (Unsaved Changes)',
+  render: () => {
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(true);
+
+    const handleBeforeNavigate = async () => {
+      if (!hasUnsavedChanges) {
+        return true;
+      }
+
+      // Simulate a confirmation dialog
+      const userConfirmed = window.confirm(
+        'You have unsaved changes. Do you want to leave this page?',
+      );
+
+      if (userConfirmed) {
+        setHasUnsavedChanges(false);
+      }
+
+      return userConfirmed;
+    };
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={hasUnsavedChanges}
+              onChange={(e) => setHasUnsavedChanges(e.target.checked)}
+            />
+            <span className="dial-small text-primary">
+              Has unsaved changes (try clicking breadcrumb items)
+            </span>
+          </label>
+        </div>
+        <DialBreadcrumb
+          pathItems={[
+            { label: 'Home', href: '#' },
+            { label: 'Projects', href: '#' },
+            { label: 'Current Project (with unsaved changes)' },
+          ]}
+          onBeforeNavigate={handleBeforeNavigate}
+        />
+      </div>
+    );
+  },
 };
 
 export const LongLabelsTruncate: Story = {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,10 @@ import {
   DialBreadcrumbItem,
   type DialBreadcrumbItemProps,
 } from './BreadcrumbItem';
-import type { DialBreadcrumbPathItem } from '@/models/breadcrumb';
+import type {
+  DialBreadcrumbPathItem,
+  NavigationGuard,
+} from '@/models/breadcrumb';
 import { DialDropdown } from '@/components/Dropdown/Dropdown';
 import { IconDots } from '@tabler/icons-react';
 import type { DropdownItem } from '@/models/dropdown';
@@ -25,6 +28,7 @@ export interface DialBreadcrumbProps {
   className?: string;
   children?: ReactNode;
   labelClassName?: string;
+  onBeforeNavigate?: NavigationGuard;
 }
 
 /**
@@ -56,6 +60,23 @@ export interface DialBreadcrumbProps {
  * @param [className] - Additional CSS classes for the `<nav>` container.
  * @param [children] - Alternatively, compose with `<DialBreadcrumbItem/>` as children.
  * @param [labelClassName] - Additional CSS classes applied to each item when using `pathItems` prop.
+ * @param [onBeforeNavigate] - Navigation guard called before navigating to a breadcrumb item.
+ *  Guard function called before navigating to a different breadcrumb item.
+ *  Return `true` to allow navigation, `false` to prevent it.
+ *  Can return a Promise for async checks (e.g., showing a confirmation dialog).
+ *
+ *  @example
+ *  ```tsx
+ *  <DialBreadcrumb
+ *    pathItems={items}
+ *    onBeforeNavigate={async () => {
+ *      if (hasUnsavedChanges) {
+ *        return await confirmLeave();
+ *      }
+ *      return true;
+ *    }}
+ *  />
+ *  ```
  */
 export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
   pathItems,
@@ -64,6 +85,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
   className,
   children,
   labelClassName,
+  onBeforeNavigate,
 }) => {
   const items = useMemo(() => {
     if (pathItems?.length) {
@@ -79,16 +101,26 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
   }, [pathItems, children]);
 
   const handleDropdownItemClick = useCallback(
-    (info: { key: string; domEvent: MouseEvent }) => {
+    async (info: { key: string; domEvent: MouseEvent }) => {
       const index = parseInt(info.key, 10);
       const item = items[index];
+
+      // Check navigation guard before proceeding
+      if (onBeforeNavigate) {
+        const canNavigate = await onBeforeNavigate();
+        if (!canNavigate) {
+          info.domEvent.preventDefault();
+          return;
+        }
+      }
+
       if (item.onClick) {
         item.onClick(info.domEvent as MouseEvent<HTMLAnchorElement>);
       } else if (item.href) {
         window.location.href = item.href;
       }
     },
-    [items],
+    [items, onBeforeNavigate],
   );
 
   const content = useMemo(() => {
@@ -102,6 +134,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           isLast={index === items.length - 1}
           separator={separator}
           labelClassName={labelClassName}
+          onBeforeNavigate={onBeforeNavigate}
         />
       ));
     }
@@ -126,6 +159,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           key="item-0"
           separator={separator}
           labelClassName={labelClassName}
+          onBeforeNavigate={onBeforeNavigate}
         />
 
         <li className={mergeClasses(breadcrumbItemBaseClassName)}>
@@ -153,6 +187,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           key={`item-${items.length - 2}`}
           separator={separator}
           labelClassName={labelClassName}
+          onBeforeNavigate={onBeforeNavigate}
         />
 
         <DialBreadcrumbItem
@@ -161,10 +196,17 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
           isLast
           separator={separator}
           labelClassName={labelClassName}
+          onBeforeNavigate={onBeforeNavigate}
         />
       </>
     );
-  }, [items, separator, labelClassName, handleDropdownItemClick]);
+  }, [
+    items,
+    separator,
+    labelClassName,
+    handleDropdownItemClick,
+    onBeforeNavigate,
+  ]);
 
   return (
     <nav

--- a/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
@@ -115,4 +115,143 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
     expect(li).toBeInTheDocument();
     expect(li).toHaveAttribute('aria-label', 'custom-breadcrumb-item');
   });
+
+  test('navigation guard allows navigation when returning true', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(true);
+    const onClick = vi.fn();
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Guarded"
+          href="#test"
+          onClick={onClick}
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Guarded' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('navigation guard prevents navigation when returning false', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(false);
+    const onClick = vi.fn();
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Guarded"
+          href="#test"
+          onClick={onClick}
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Guarded' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard supports async checks with Promise', async () => {
+    const onBeforeNavigate = vi.fn().mockResolvedValue(true);
+    const onClick = vi.fn();
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Async Guard"
+          href="#test"
+          onClick={onClick}
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Async Guard' });
+    await fireEvent.click(link);
+
+    expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    // Wait for async guard to complete
+    await vi.waitFor(() => {
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('navigation guard is not called for last item', async () => {
+    const onBeforeNavigate = vi.fn();
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Current"
+          isLast
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const text = screen.getByText('Current');
+    await fireEvent.click(text);
+
+    expect(onBeforeNavigate).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard is not called for disabled item', async () => {
+    const onBeforeNavigate = vi.fn();
+    const onClick = vi.fn();
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Disabled"
+          href="#test"
+          onClick={onClick}
+          disabled
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const text = screen.getByText('Disabled');
+    await fireEvent.click(text);
+
+    expect(onBeforeNavigate).not.toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('navigation guard prevents default when returning false', async () => {
+    const onBeforeNavigate = vi.fn().mockReturnValue(false);
+
+    render(
+      <ul>
+        <DialBreadcrumbItem
+          label="Link"
+          href="#test"
+          onBeforeNavigate={onBeforeNavigate}
+        />
+      </ul>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Link' });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    link.dispatchEvent(event);
+
+    await vi.waitFor(() => {
+      expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.waitFor(() => {
+      expect(preventDefault).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -11,6 +11,7 @@ import {
   breadcrumbItemLastClassName,
 } from './constants';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
+import type { NavigationGuard } from '@/models/breadcrumb';
 
 export interface DialBreadcrumbItemProps
   extends Omit<HTMLAttributes<HTMLLIElement>, 'onClick'> {
@@ -22,6 +23,7 @@ export interface DialBreadcrumbItemProps
   labelClassName?: string;
   isLast?: boolean;
   separator?: ReactNode;
+  onBeforeNavigate?: NavigationGuard;
 }
 
 export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
@@ -34,8 +36,24 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
   className,
   iconBefore,
   labelClassName,
+  onBeforeNavigate,
   ...props
 }) => {
+  const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // Check navigation guard before proceeding
+    if (onBeforeNavigate && !isLast) {
+      const canNavigate = await onBeforeNavigate();
+      if (!canNavigate) {
+        e.preventDefault();
+        return;
+      }
+    }
+
+    // Call original onClick if provided
+    if (onClick) {
+      onClick(e);
+    }
+  };
   const containerClassName = mergeClasses(
     breadcrumbItemBaseClassName,
     isLast ? breadcrumbItemLastClassName : breadcrumbItemVisibleClassName,
@@ -57,14 +75,14 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
   const Content =
     typeof label === 'string' ? (
       <DialEllipsisTooltip
-        className={labelClassName}
+        className={mergeClasses('cursor-pointer', labelClassName)}
         text={label}
         id="breadcrumb-item-content"
       />
     ) : (
       <span
         className={mergeClasses(
-          'flex-1 min-w-0 max-w-full truncate',
+          'flex-1 min-w-0 max-w-full truncate cursor-pointer',
           labelClassName,
         )}
         aria-label="breadcrumb-item-content"
@@ -80,7 +98,7 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
       aria-label={props['aria-label'] || 'breadcrumb-item'}
     >
       {interactive ? (
-        <a href={href} onClick={onClick} className={contentClassName}>
+        <a href={href} onClick={handleClick} className={contentClassName}>
           {iconBefore}
           {Content}
         </a>

--- a/src/models/breadcrumb.ts
+++ b/src/models/breadcrumb.ts
@@ -1,5 +1,7 @@
 import type { ReactNode, MouseEvent } from 'react';
 
+export type NavigationGuard = () => boolean | Promise<boolean>;
+
 export interface DialBreadcrumbPathItem {
   label: ReactNode;
   href?: string;


### PR DESCRIPTION
**Description:**

Added possibility to check some condition before navigating to breadcrumb link

Issues:

- Issue #<TICKET_ID>

**UI changes**

no changes

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added