### PR TITLE
fix: Fix textarea having black outline on focus

### DIFF
--- a/src/styles/textarea.scss
+++ b/src/styles/textarea.scss
@@ -1,3 +1,7 @@
 .dial-textarea {
   @apply min-h-[72px] resize whitespace-normal overflow-auto;
+
+  &:focus {
+    @apply outline-none;
+  }
 }


### PR DESCRIPTION
**Description:**

Remove outline on textarea focus

Issues:

- Issue #<TICKET_ID>

**UI changes**

before

<img width="467" height="235" alt="image" src="https://github.com/user-attachments/assets/96dba2cb-60ec-405a-99d0-af93f36482d2" />


after

<img width="1088" height="465" alt="image" src="https://github.com/user-attachments/assets/19c1b06c-de51-407c-a92f-6373a4959877" />


**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [X] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added