### PR TITLE
feat(tab): allow to render extra details in Tab component

### DIFF
--- a/src/components/Tab/Tab.spec.tsx
+++ b/src/components/Tab/Tab.spec.tsx
@@ -187,4 +187,19 @@ describe('Dial UI Kit :: DialTab', () => {
     const tab = screen.getByRole('tab');
     expect(tab.className).toMatch(/h-\[38px\]/);
   });
+
+  test('Render details element correctly', () => {
+    const text = 'details';
+    const { container } = render(
+      <DialTab
+        tab={baseTab}
+        active={false}
+        onClick={vi.fn()}
+        details={<p>{text}</p>}
+      />,
+    );
+
+    expect(container.querySelector('p')).toBeInTheDocument();
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
 });

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -89,6 +89,20 @@ export const TooLongText: Story = {
   },
 };
 
+export const Details: Story = {
+  args: {
+    tab: {
+      id: 'analytics',
+      label: 'Analytics',
+    },
+    active: false,
+    horizontal: true,
+    onClick: () => null,
+    className: 'w-[200px]',
+    details: <p className="text-small text-secondary">Details</p>,
+  },
+};
+
 export const OrientationVariants: Story = {
   render: () => {
     const TabDemo = () => {

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,5 +1,5 @@
 import { IconExclamationCircle } from '@tabler/icons-react';
-import type { ButtonHTMLAttributes, FC } from 'react';
+import type { ButtonHTMLAttributes, FC, ReactNode } from 'react';
 
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import type { TabModel } from '@/models/tab';
@@ -17,6 +17,7 @@ export interface DialTabProps extends NativeButtonProps {
   invalid?: boolean;
   horizontal?: boolean;
   onClick: (id: string) => void;
+  details?: ReactNode;
 }
 /**
  * A single tab element used within the {@link DialTabs} component.
@@ -37,6 +38,7 @@ export interface DialTabProps extends NativeButtonProps {
  * @param active - Whether the tab is currently active.
  * @param [horizontal=false] - Whether the tab is displayed in horizontal orientation.
  * @param onClick - Callback fired when the tab is clicked. Receives the tab’s `id`.
+ * @param {details} - React element to render additional details of tab.
  */
 export const DialTab: FC<DialTabProps> = ({
   tab,
@@ -45,6 +47,7 @@ export const DialTab: FC<DialTabProps> = ({
   className,
   horizontal,
   onClick,
+  details,
 }) => {
   const baseClassName = mergeClasses(
     'rounded h-[38px] items-center flex flex-row border-transparent cursor-pointer dial-small leading-4 hover:text-accent-primary',
@@ -75,6 +78,8 @@ export const DialTab: FC<DialTabProps> = ({
         contentClassName="max-w-[200px]"
         className="max-w-[200px]"
       />
+
+      {details}
 
       {(invalid || tab.invalid) && (
         <div className="text-error pl-1">


### PR DESCRIPTION
**Description:**

Allow add details element as ReactNode to Tab component

**UI changes**

<img width="700" height="316" alt="image" src="https://github.com/user-attachments/assets/a7536432-9f4e-4b3d-a2ce-6f15be9d5e2f" />

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added