### PR TITLE
fix: 'Key' field that is used as password type causes passwords to be saved in the browser (Issue #1946)

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -178,7 +178,7 @@ export const DialInput: FC<DialInputProps> = ({
         <input
           ref={ref}
           type={type}
-          autoComplete="off"
+          autoComplete={type === 'password' ? 'new-password' : 'off'}
           id={elementId}
           placeholder={placeholder}
           value={defaultValue ? undefined : (value ?? '')}


### PR DESCRIPTION
**Description:**

added correct autocomplete for password inputs

Issues:

- Issue ['Key' field that is used as password type causes passwords to be saved in the browser](https://github.com/epam/ai-dial-admin-frontend/issues/1946)

**UI changes**

<Please, provide Screenshots or Figma links>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name starts with `fix:`, `feat:`, `feature:`, `chore:`, `hotfix:` or `e2e:`. If contains breaking changes then the pull request name must start with `fix!:`, `feat!:`, `feature!:`, `chore!:`, `hotfix!:` or `e2e!:`.
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
- [x] I confirm that do not share any confidential information

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added