### PR TITLE
feat(radio): add caption to radion button and radion group components

### DIFF
--- a/src/components/RadioButton/RadioButton.spec.tsx
+++ b/src/components/RadioButton/RadioButton.spec.tsx
@@ -154,4 +154,17 @@ describe('Dial UI Kit :: DialRadioButton', () => {
     // no description relationship when there's no description/checked
     expect(radio).not.toHaveAttribute('aria-describedby');
   });
+
+  test('caption is rendered when provided', () => {
+    render(
+      <DialRadioButton
+        name="group1"
+        value="opt-n"
+        inputId="radio-n"
+        caption="caption"
+      />,
+    );
+    const caption = screen.getByText('caption');
+    expect(caption).toBeInTheDocument();
+  });
 });

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -141,6 +141,12 @@ export const DisabledChecked: Story = {
     description: 'This option is locked by policy.',
   },
 };
+export const Caption: Story = {
+  args: {
+    label: 'Disabled & checked',
+    caption: 'This option is locked by policy.',
+  },
+};
 
 export const GroupControlled: Story = {
   render: () => <ControlledGroup />,

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -5,6 +5,7 @@ export interface DialRadioButtonProps {
   name: string;
   value: string;
   label?: ReactNode;
+  caption?: string;
   description?: ReactNode;
   checked?: boolean;
   inputId: string;
@@ -37,6 +38,7 @@ export interface DialRadioButtonProps {
  * @param name - Radio group name
  * @param value - Radio value emitted on change
  * @param [label] - Visible label text
+ * @param [caption] - Caption text describing label
  * @param [description] - Supporting text shown when checked
  * @param [checked=false] - Controlled checked state
  * @param inputId - ID associated with the label
@@ -58,11 +60,12 @@ export const DialRadioButton: FC<DialRadioButtonProps> = ({
   disabled,
   onChange,
   descriptionClassName,
+  caption,
 }) => {
   const descId = `${inputId}-desc`;
 
   const allLabelClassName = classNames(
-    'dial-small cursor-pointer',
+    'dial-small cursor-pointer py-[1px]',
     disabled ? 'text-secondary' : 'text-primary',
     labelClassName,
   );
@@ -90,7 +93,7 @@ export const DialRadioButton: FC<DialRadioButtonProps> = ({
 
   return (
     <div className={containerClassName}>
-      <div className="flex flex-row items-center">
+      <div className="flex flex-row">
         <input
           type="radio"
           id={inputId}
@@ -102,11 +105,24 @@ export const DialRadioButton: FC<DialRadioButtonProps> = ({
           className={inputClassName}
           onChange={handleChange}
         />
-        {label ? (
-          <label className={allLabelClassName} htmlFor={inputId}>
-            {label}
-          </label>
-        ) : null}
+        {(label || caption) && (
+          <div className="flex flex-col gap-1 ml-2">
+            {label && (
+              <label
+                className={allLabelClassName}
+                htmlFor={inputId}
+                aria-describedby={caption && 'caption'}
+              >
+                {label}
+              </label>
+            )}
+            {caption && (
+              <span id="caption" className="dial-tiny text-secondary">
+                {caption}
+              </span>
+            )}
+          </div>
+        )}
       </div>
       {checked && description && (
         <div id={descId} className={allDescriptionClassName}>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -5,7 +5,7 @@ export interface DialRadioButtonProps {
   name: string;
   value: string;
   label?: ReactNode;
-  caption?: string;
+  caption?: ReactNode;
   description?: ReactNode;
   checked?: boolean;
   inputId: string;
@@ -111,7 +111,7 @@ export const DialRadioButton: FC<DialRadioButtonProps> = ({
               <label
                 className={allLabelClassName}
                 htmlFor={inputId}
-                aria-describedby={caption && 'caption'}
+                aria-describedby={caption ? 'caption' : ''}
               >
                 {label}
               </label>

--- a/src/components/RadioGroup/RadioGroup.spec.tsx
+++ b/src/components/RadioGroup/RadioGroup.spec.tsx
@@ -140,4 +140,29 @@ describe('Dial UI Kit :: DialRadioGroup', () => {
       screen.getByRole('radio', { name: 'All attachments' }),
     ).toBeDisabled();
   });
+
+  test('caption is rendered when provided', () => {
+    const radiosWithCaption = [
+      { id: 'none', name: '— None —', caption: 'caption 1' },
+      {
+        id: 'all',
+        name: 'All attachments',
+        caption: 'caption',
+      },
+    ];
+    render(
+      <DialRadioGroup
+        elementId="attachments"
+        radioButtons={radiosWithCaption}
+        activeRadioButton="none"
+        orientation={RadioGroupOrientation.Row}
+        disabled
+        onChange={() => null}
+      />,
+    );
+    const caption = screen.getByText('caption');
+    const caption1 = screen.getByText('caption 1');
+    expect(caption).toBeInTheDocument();
+    expect(caption1).toBeInTheDocument();
+  });
 });

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -229,6 +229,47 @@ export const Column: Story = {
     onChange: () => null,
   },
 };
+const CaptionExample = (
+  args: JSX.IntrinsicAttributes & DialRadioGroupProps,
+) => {
+  const [active, setActive] = useState('pickup');
+  return (
+    <DialRadioGroup
+      {...args}
+      radioButtons={[
+        {
+          id: 'pickup',
+          name: 'Pickup',
+          caption: 'Free, ready today',
+        },
+        {
+          id: 'courier',
+          name: 'Courier',
+          caption: 'Arrives tomorrow',
+        },
+      ]}
+      activeRadioButton={active}
+      onChange={(id) => {
+        setActive(id);
+        args.onChange?.(id);
+      }}
+    />
+  );
+};
+export const Caption: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Vertical layout with radio buttons stacked in a column.',
+      },
+    },
+  },
+  render: CaptionExample,
+  args: {
+    orientation: RadioGroupOrientation.Column,
+    onChange: () => null,
+  },
+};
 
 export const DisabledGroup: Story = {
   parameters: {

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -130,6 +130,7 @@ export const DialRadioGroup: FC<DialRadioGroupProps> = ({
                 radio.id === activeRadioButton && selectedLabelClassName,
               )}
               label={radio.name}
+              caption={radio.caption}
               checked={radio.id === activeRadioButton}
               onChange={() => onChange(radio.id)}
             />

--- a/src/models/radio.ts
+++ b/src/models/radio.ts
@@ -4,5 +4,5 @@ export interface RadioButtonWithContent {
   id: string;
   name: string;
   content?: ReactNode;
-  caption?: string;
+  caption?: ReactNode;
 }

--- a/src/models/radio.ts
+++ b/src/models/radio.ts
@@ -4,4 +4,5 @@ export interface RadioButtonWithContent {
   id: string;
   name: string;
   content?: ReactNode;
+  caption?: string;
 }


### PR DESCRIPTION
**Description and UI changes:**

Allow to add caption to RadioButton and RadioButtonGroup
<img width="279" height="61" alt="image" src="https://github.com/user-attachments/assets/cded27aa-1ce8-4751-bbbe-60effafb0464" />
<img width="212" height="147" alt="image" src="https://github.com/user-attachments/assets/e81b137a-6957-4c1b-a061-255a8d9b0140" />


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added