### PR TITLE
feat: add option to skip single duplicated file without canceling whole uploading process

### DIFF
--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -1,10 +1,10 @@
 import { DialPopup } from '@/components/Popup/Popup';
 import { PopupSize } from '@/types/popup';
 import {
-  DialPrimaryButton,
   DialNeutralButton,
+  DialPrimaryButton,
 } from '@/components/Button/ButtonWrappers';
-import { type FC, useState, useMemo, useCallback } from 'react';
+import { type FC, useCallback, useMemo, useState } from 'react';
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import { DialRadioGroup } from '@/components/RadioGroup/RadioGroup';
@@ -210,8 +210,12 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
         id: DialFileManagerConflictActions.Duplicate,
         name: duplicateLabel,
       },
+      {
+        id: DialFileManagerConflictActions.Cancel,
+        name: cancelActionLabel,
+      },
     ],
-    [replaceLabel, duplicateLabel],
+    [replaceLabel, duplicateLabel, cancelActionLabel],
   );
 
   const gridRows = useMemo<ConflictGridRow[]>(() => {
@@ -387,8 +391,18 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
     if (isSingleFile) {
       if (singleFileMode === DialFileManagerConflictActions.Replace) {
         onReplace();
-      } else {
+      } else if (singleFileMode === DialFileManagerConflictActions.Duplicate) {
         onDuplicate();
+      } else if (
+        singleFileMode === DialFileManagerConflictActions.Cancel &&
+        onDecideForEach
+      ) {
+        onDecideForEach([
+          {
+            file: conflictingFiles[0],
+            action: DialFileManagerConflictActions.Cancel,
+          },
+        ]);
       }
     } else {
       if (strategy === DialFileManagerConflictStrategies.ReplaceAll) {


### PR DESCRIPTION
**Description and UI changes:**

File manager changes.
Added **Cancel** option for single duplicated file alongside with **Duplicate** and **Replace**.
This allows user to skip this file without having to cancel whole uploading process.
<img width="412" height="314" alt="image" src="https://github.com/user-attachments/assets/79558f48-9c5f-4e72-bcfa-5792dd3874cb" />


Issues:

- Issue N/A

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added