### PR TITLE
fix: add remove access handler for FileManager component (Issue #543)

### DIFF
--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -1193,6 +1193,58 @@ export const WithUnshareAction: Story = {
   ),
 };
 
+export const WithRemoveAccessAction: Story = {
+  render: (args) => (
+    <div className="h-[640px]">
+      <DialFileManager
+        {...args}
+        gridOptions={{
+          actionLabels: {
+            unshare: 'Unshare',
+            duplicate: 'Duplicate',
+            copy: 'Copy to',
+            move: 'Move to',
+            download: 'Download',
+            delete: 'Delete',
+            rename: 'Rename',
+            info: 'Info',
+            removeAccess: 'Remove access',
+          },
+        }}
+        treeOptions={{
+          actionLabels: {
+            unshare: 'Unshare',
+            duplicate: 'Duplicate',
+            copy: 'Copy to',
+            move: 'Move to',
+            rename: 'Rename',
+            download: 'Download',
+            delete: 'Delete',
+            removeAccess: 'Remove access',
+          },
+        }}
+        bulkActionsToolbarOptions={{
+          getSelectionLabel: (selectedCount: number) =>
+            `${selectedCount} item(s) selected`,
+          actionLabels: {
+            duplicate: 'Duplicate',
+            copy: 'Copy to',
+            move: 'Move to',
+            download: 'Download',
+            delete: 'Delete',
+            unshare: 'Unshare',
+            removeAccess: 'Remove access',
+          },
+        }}
+        onRemoveFilesAccess={(files) => {
+          alert(`Removing access file: ${files.map((f) => f.name).join(',')}`);
+        }}
+        sharedByMePaths={new Set(['All files/Design'])}
+      />
+    </div>
+  ),
+};
+
 export const WithOwnerColumn: Story = {
   args: {
     gridOptions: {

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -64,6 +64,7 @@ import {
   IconFileDescription,
   IconPencilMinus,
   IconTrashX,
+  IconUserX,
 } from '@tabler/icons-react';
 import CopyToIcon from '@/assets/icons/copy-to.svg?react';
 import MoveToIcon from '@/assets/icons/move-to.svg?react';
@@ -170,6 +171,7 @@ export interface FileTreeOptions
     [DialFileManagerActions.Move]?: string;
     [DialFileManagerActions.Unshare]?: string;
     [DialFileManagerActions.ManagePermissions]?: string;
+    [DialFileManagerActions.RemoveAccess]?: string;
   };
 }
 
@@ -216,6 +218,7 @@ export interface GridOptions
     [DialFileManagerActions.Unshare]?: string;
     [DialFileManagerActions.ManagePermissions]?: string;
     [DialFileManagerActions.Preview]?: string;
+    [DialFileManagerActions.RemoveAccess]?: string;
   };
 }
 
@@ -244,6 +247,7 @@ export type BulkActionsToolbarOptions = Omit<
     [DialFileManagerActions.Delete]?: string;
     [DialFileManagerActions.Move]?: string;
     [DialFileManagerActions.Unshare]?: string;
+    [DialFileManagerActions.RemoveAccess]?: string;
   };
 };
 
@@ -340,6 +344,7 @@ export interface DialFileManagerProps {
   onGetInfo?: (file: DialFile) => void | Promise<void>;
 
   onUnshareFiles?: (files: DialFile[]) => void | Promise<void>;
+  onRemoveFilesAccess?: (files: DialFile[]) => void | Promise<void>;
   actionsRef?: Ref<DialFileManagerActionsRef>;
 
   onSearchFiles?: (folder: string, query: string) => void;
@@ -585,6 +590,7 @@ export const DialFileManagerView: FC = () => {
     closeMetadataPopup,
 
     onUnshareFiles,
+    onRemoveFilesAccess,
 
     actionsRef,
     searchInProgress,
@@ -818,6 +824,24 @@ export const DialFileManagerView: FC = () => {
           });
         }
         if (
+          treeOptions.actionLabels[DialFileManagerActions.RemoveAccess] &&
+          sharedByMePaths?.has(file.path) &&
+          !isRootNode
+        ) {
+          elements.push({
+            key: DialFileManagerActions.RemoveAccess,
+            label:
+              treeOptions.actionLabels[DialFileManagerActions.RemoveAccess],
+            icon: (
+              <IconUserX
+                size={BASE_ICON_PROPS.size}
+                className="text-secondary"
+              />
+            ),
+            onClick: () => onRemoveFilesAccess?.([file]),
+          });
+        }
+        if (
           treeOptions.actionLabels[DialFileManagerActions.ManagePermissions] &&
           typeof onManagePermissions === 'function' &&
           file.nodeType === DialFileNodeType.FOLDER &&
@@ -878,7 +902,9 @@ export const DialFileManagerView: FC = () => {
       handleDownloadFiles,
       onTreeRename,
       onUnshareFiles,
+      onRemoveFilesAccess,
       sharedWithMeIds,
+      sharedByMePaths,
       openDeleteConfirmation,
       onManagePermissions,
     ],
@@ -924,8 +950,10 @@ export const DialFileManagerView: FC = () => {
     onRename: onGridRename,
     onDelete: openDeleteConfirmation,
     onUnshare: onUnshareFiles,
+    onRemoveAccess: onRemoveFilesAccess,
     getCurrentFolderPath: () => currentPath ?? '/',
     sharedWithMeIds,
+    sharedByMePaths,
     onClearSelection: clearSelection,
   });
 
@@ -1080,7 +1108,9 @@ export const DialFileManagerView: FC = () => {
       openDeleteConfirmation([file], parentFolderPath),
     onInfo: (file) => openMetadataPopup(file),
     onUnshare: (file) => onUnshareFiles?.([file]),
+    onRemoveAccess: (file) => onRemoveFilesAccess?.([file]),
     sharedWithMeIds,
+    sharedByMePaths,
     onAddChild: (file) => handleAddChild?.([file]),
     onAddSibling: (file) => handleAddSibling?.([file]),
     onManagePermissions: (path) => onManagePermissions?.(path),

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -180,6 +180,7 @@ export interface FileManagerContextValue {
   onGetInfo?: (file: DialFile) => void | Promise<void>;
 
   onUnshareFiles?: (file: DialFile[]) => void;
+  onRemoveFilesAccess?: (file: DialFile[]) => void;
 
   actionsRef?: Ref<DialFileManagerActionsRef>;
 

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -104,6 +104,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   fileMetadataPopupOptions,
   onGetInfo,
   onUnshareFiles,
+  onRemoveFilesAccess,
   actionsRef,
   sharedByMePaths,
   onSearchFiles,
@@ -677,6 +678,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     onGetInfo,
 
     onUnshareFiles,
+    onRemoveFilesAccess,
 
     actionsRef,
     sharedByMePaths,

--- a/src/components/FileManager/hooks/__tests__/use-bulk-actions.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-bulk-actions.spec.tsx
@@ -544,4 +544,41 @@ describe('Dial UI Kit :: useBulkActions', () => {
     expect(onUnshare).toHaveBeenCalledWith([testFiles[0]]);
     expect(onClearSelection).toHaveBeenCalledTimes(1);
   });
+
+  test('remove access action calls onRemoveAccess and onClearSelection with selected files', () => {
+    const onRemoveAccess = vi.fn();
+    const onClearSelection = vi.fn();
+    const selectedFiles = new Map<string, DialFile>([
+      [testFiles[0].path, testFiles[0]],
+    ]);
+
+    const { result } = renderHook(() =>
+      useBulkActions({
+        selectedFiles,
+        actionLabels: {
+          [DialFileManagerActions.RemoveAccess]: 'Remove access',
+        },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onUnshare: vi.fn(),
+        getCurrentFolderPath: () => '/test',
+        onRemoveAccess,
+        onClearSelection,
+      }),
+    );
+
+    const removeAccessAction = result.current[0];
+    removeAccessAction.onClick?.({
+      key: removeAccessAction.key,
+      domEvent: mockMouseEvent,
+    });
+
+    expect(onRemoveAccess).toHaveBeenCalledTimes(1);
+    expect(onRemoveAccess).toHaveBeenCalledWith([testFiles[0]]);
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
@@ -466,6 +466,68 @@ describe('Dial UI Kit :: useGridContextMenu', () => {
     expect(onUnshare).toHaveBeenCalledWith(testFolder);
   });
 
+  test('remove access action calls onRemoveAccess with file', () => {
+    const onRemoveAccess = vi.fn();
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: {
+          [DialFileManagerActions.RemoveAccess]: 'Remove access',
+        },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+        onRemoveAccess,
+        sharedByMePaths: new Set([testFile.path]),
+      }),
+    );
+
+    const menuItems = result.current(testFile);
+    const removeAccessAction = menuItems[0];
+    removeAccessAction.onClick?.({
+      key: removeAccessAction.key,
+      domEvent: mockMouseEvent,
+    });
+
+    expect(onRemoveAccess).toHaveBeenCalledTimes(1);
+    expect(onRemoveAccess).toHaveBeenCalledWith(testFile);
+  });
+
+  test('remove access action works with folders', () => {
+    const onRemoveAccess = vi.fn();
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: {
+          [DialFileManagerActions.RemoveAccess]: 'Remove access',
+        },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+        onRemoveAccess,
+        sharedByMePaths: new Set([testFolder.path]),
+      }),
+    );
+
+    const menuItems = result.current(testFolder);
+    const removeAccessAction = menuItems[0];
+    removeAccessAction.onClick?.({
+      key: removeAccessAction.key,
+      domEvent: mockMouseEvent,
+    });
+
+    expect(onRemoveAccess).toHaveBeenCalledTimes(1);
+    expect(onRemoveAccess).toHaveBeenCalledWith(testFolder);
+  });
+
   test('menu items have correct properties', () => {
     const { result } = renderHook(() =>
       useGridContextMenu({

--- a/src/components/FileManager/hooks/use-bulk-actions.tsx
+++ b/src/components/FileManager/hooks/use-bulk-actions.tsx
@@ -7,6 +7,7 @@ import CopyToIcon from '@/assets/icons/copy-to.svg?react';
 import MoveToIcon from '@/assets/icons/move-to.svg?react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import IconUnshare from '@/assets/icons/unshare.svg?react';
+import { IconUserX } from '@tabler/icons-react';
 
 export interface UseBulkActionsProps {
   selectedFiles: Map<string, DialFile>;
@@ -18,16 +19,19 @@ export interface UseBulkActionsProps {
     [DialFileManagerActions.Unshare]?: string;
     [DialFileManagerActions.Delete]?: string;
     [DialFileManagerActions.Move]?: string;
+    [DialFileManagerActions.RemoveAccess]?: string;
   };
   onDuplicate: (files: DialFile[]) => void;
   onCopy: (files: DialFile[]) => void;
   onMove: (files: DialFile[]) => void;
   onDownload: (files: DialFile[]) => void;
   onUnshare?: (files: DialFile[]) => void;
+  onRemoveAccess?: (files: DialFile[]) => void;
   onRename: (filePath: string) => void;
   onDelete: (files: DialFile[], parentFolderPath: string) => void;
   getCurrentFolderPath: () => string;
   sharedWithMeIds?: string[];
+  sharedByMePaths?: Set<string>;
   onClearSelection: () => void;
 }
 
@@ -39,9 +43,11 @@ export const useBulkActions = ({
   onMove,
   onDownload,
   onUnshare,
+  onRemoveAccess,
   onDelete,
   getCurrentFolderPath,
   sharedWithMeIds,
+  sharedByMePaths,
   onClearSelection,
 }: UseBulkActionsProps): DialActionDropdownItem[] => {
   return useMemo(() => {
@@ -148,18 +154,40 @@ export const useBulkActions = ({
       });
     }
 
+    if (actionLabels[DialFileManagerActions.RemoveAccess] && onRemoveAccess) {
+      const disabled = selectedFilesArray.some(
+        (file) => !sharedByMePaths?.has(file.path),
+      );
+
+      actions.push({
+        key: DialFileManagerActions.RemoveAccess,
+        label: actionLabels[DialFileManagerActions.RemoveAccess],
+        title: actionLabels[DialFileManagerActions.RemoveAccess],
+        disabled,
+        icon: (
+          <IconUserX size={BASE_ICON_PROPS.size} className="text-secondary" />
+        ),
+        onClick: () => {
+          onRemoveAccess(selectedFilesArray);
+          onClearSelection();
+        },
+      });
+    }
+
     return actions;
   }, [
     selectedFiles,
     actionLabels,
+    onUnshare,
+    onRemoveAccess,
     onMove,
     onCopy,
     onDuplicate,
     getCurrentFolderPath,
     onDelete,
     onDownload,
-    onUnshare,
     sharedWithMeIds,
     onClearSelection,
+    sharedByMePaths,
   ]);
 };

--- a/src/components/FileManager/hooks/use-grid-context-menu.tsx
+++ b/src/components/FileManager/hooks/use-grid-context-menu.tsx
@@ -10,6 +10,7 @@ import {
   IconInfoCircle,
   IconExternalLink,
   IconEye,
+  IconUserX,
 } from '@tabler/icons-react';
 import CopyToIcon from '@/assets/icons/copy-to.svg?react';
 import MoveToIcon from '@/assets/icons/move-to.svg?react';
@@ -35,6 +36,7 @@ export interface UseGridContextMenuProps {
     [DialFileManagerActions.Move]?: string;
     [DialFileManagerActions.Info]?: string;
     [DialFileManagerActions.Unshare]?: string;
+    [DialFileManagerActions.RemoveAccess]?: string;
   };
   onDuplicate: (file: DialFile) => void;
   onCopy: (file: DialFile) => void;
@@ -44,7 +46,9 @@ export interface UseGridContextMenuProps {
   onDelete: (file: DialFile, parentFolderPath: string) => void;
   onInfo: (file: DialFile) => void;
   onUnshare: (file: DialFile) => void;
+  onRemoveAccess?: (file: DialFile) => void;
   sharedWithMeIds?: string[];
+  sharedByMePaths?: Set<string>;
   onAddSibling?: (file: DialFile) => void;
   onAddChild?: (file: DialFile) => void;
   onManagePermissions?: (path?: string) => void;
@@ -63,7 +67,9 @@ export const useGridContextMenu = ({
   onDelete,
   onInfo,
   onUnshare,
+  onRemoveAccess,
   sharedWithMeIds,
+  sharedByMePaths,
   onAddSibling,
   onAddChild,
   onManagePermissions,
@@ -269,6 +275,21 @@ export const useGridContextMenu = ({
         });
       }
 
+      if (
+        actionLabels[DialFileManagerActions.RemoveAccess] &&
+        sharedByMePaths?.has(file.path) &&
+        onRemoveAccess
+      ) {
+        items.push({
+          key: DialFileManagerActions.RemoveAccess,
+          label: actionLabels[DialFileManagerActions.RemoveAccess],
+          icon: (
+            <IconUserX size={BASE_ICON_PROPS.size} className="text-secondary" />
+          ),
+          onClick: () => onRemoveAccess(file),
+        });
+      }
+
       return items;
     };
   }, [
@@ -283,7 +304,9 @@ export const useGridContextMenu = ({
     onRename,
     onInfo,
     onUnshare,
+    onRemoveAccess,
     sharedWithMeIds,
+    sharedByMePaths,
     onManagePermissions,
     onPreview,
     previewExtensions,

--- a/src/types/file-manager.ts
+++ b/src/types/file-manager.ts
@@ -15,6 +15,7 @@ export enum DialFileManagerActions {
   Rename = 'rename',
   Info = 'info',
   Unshare = 'unshare',
+  RemoveAccess = 'removeAccess',
   ManagePermissions = 'managePermissions',
   Preview = 'preview',
 }


### PR DESCRIPTION
**Description and UI changes:**

- added abscent menu option for FileManager: **Remove access** for files shared by user.

Issues:

- Issue #543 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added