### PR TITLE
fix: Fix class names for dial-*-semi-text

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -23,7 +23,7 @@
 }
 
 .dial-body-semi-text {
-  @apply dial-body font-semibold;
+  @apply dial-body-text font-semibold;
 }
 
 .dial-small-text {
@@ -31,7 +31,7 @@
 }
 
 .dial-small-semi-text {
-  @apply dial-small font-semibold;
+  @apply dial-small-text font-semibold;
 }
 
 .dial-tiny-text {
@@ -39,7 +39,7 @@
 }
 
 .dial-tiny-semi-text {
-  @apply dial-tiny font-semibold;
+  @apply dial-tiny-text font-semibold;
 }
 
 .dial-caption-text {


### PR DESCRIPTION
**Description and UI changes:**

Semibold versions of several dial-*-text classes were referencing wrong base class (e.g. dial-small instead of dial-small-text), which resulted in incorrect styles

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added