### PR TITLE
feat: add allowDisabledContextMenu flag for DialGrid and FileManager (Issue #555)

### DIFF
--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -1785,6 +1785,9 @@ const WithAllowedFileTypesComponent = (args: DialFileManagerProps) => {
         {...args}
         allowedFileTypes={allowedFileTypes}
         gridOptions={{
+          ...(args.gridOptions ?? {}),
+          filterable: false,
+          selectionMode: GridSelectionMode.MULTIPLE,
           actionLabels: {
             duplicate: 'Duplicate',
             download: 'Download',

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -16,7 +16,10 @@ import {
   DialFileResourceType,
   type DialRootFolder,
 } from '@/models/file';
-import type { DialUploadFileItem } from '@/models/file-manager';
+import type {
+  DialFileAcceptType,
+  DialUploadFileItem,
+} from '@/models/file-manager';
 import {
   DialFileManagerConflictActions,
   DialFileManagerConflictStrategies,
@@ -33,6 +36,8 @@ import type { FileManagerGridRow } from './FileManagerContext';
 import type { ColDef } from 'ag-grid-community';
 import { DialDateCellRenderer } from '@/components/Grid/renderers/DateCellRenderer';
 import { GridSelectionMode } from '@/models/selection-mode.ts';
+import { DialCheckbox } from '@/components/Checkbox/Checkbox.tsx';
+import { DialSwitch } from '@/components/Switch/Switch.tsx';
 
 const meta = {
   title: 'FileManager/FileManager',
@@ -1720,4 +1725,97 @@ export const ControlledSelection: Story = {
       },
     },
   },
+};
+
+const WithAllowedFileTypesComponent = (args: DialFileManagerProps) => {
+  const FILE_TYPES: Record<string, DialFileAcceptType> = {
+    SVG: '.svg',
+    PNG: '.png',
+    TXT: '.txt',
+  };
+
+  const [allowedFileTypes, setAllowedFileTypes] = useState<
+    DialFileAcceptType[]
+  >([FILE_TYPES.SVG]);
+  const [allowDisabledContextMenu, setAllowDisabledContextMenu] =
+    useState(false);
+
+  const handleCheck = (value?: boolean, id?: string) => {
+    const type = id as DialFileAcceptType;
+    const excludeType = (t: DialFileAcceptType) => t !== type;
+
+    setAllowedFileTypes((prev) =>
+      value ? [...prev, type] : prev.filter(excludeType),
+    );
+  };
+
+  return (
+    <div className="h-[640px] flex flex-col gap-4">
+      <div className="flex gap-2 pl-6 mt-6">
+        <DialCheckbox
+          id={FILE_TYPES.SVG}
+          checked={allowedFileTypes.includes(FILE_TYPES.SVG)}
+          label={FILE_TYPES.SVG}
+          onChange={handleCheck}
+        />
+        <DialCheckbox
+          id={FILE_TYPES.PNG}
+          checked={allowedFileTypes.includes(FILE_TYPES.PNG)}
+          label={FILE_TYPES.PNG}
+          onChange={handleCheck}
+        />
+        <DialCheckbox
+          id={FILE_TYPES.TXT}
+          checked={allowedFileTypes.includes(FILE_TYPES.TXT)}
+          label={FILE_TYPES.TXT}
+          onChange={handleCheck}
+        />
+      </div>
+
+      <div className="pl-6">
+        <DialSwitch
+          switchId="allow-context-menu"
+          label="Context menu always enabled"
+          isOn={allowDisabledContextMenu}
+          onChange={(v: boolean) => setAllowDisabledContextMenu(v)}
+        />
+      </div>
+
+      <DialFileManager
+        {...args}
+        allowedFileTypes={allowedFileTypes}
+        gridOptions={{
+          actionLabels: {
+            duplicate: 'Duplicate',
+            download: 'Download',
+            delete: 'Delete',
+            rename: 'Rename',
+          },
+          allowDisabledContextMenu,
+        }}
+        bulkActionsToolbarOptions={{
+          getSelectionLabel: (selectedCount: number) =>
+            `${selectedCount} item(s) selected`,
+          actionLabels: {
+            duplicate: 'Duplicate',
+            download: 'Download',
+            delete: 'Delete',
+          },
+        }}
+        defaultPath="All files/Design/Icons/SVG/24px"
+      />
+    </div>
+  );
+};
+
+export const WithAllowedFileTypes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Only restricted file types are allowed for selection. Use checkboxes above to control allowed types. Use switch to enable context menu on not allowed file types.',
+      },
+    },
+  },
+  render: WithAllowedFileTypesComponent,
 };

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -205,6 +205,7 @@ export interface GridOptions
   visibleColumns?: FileManagerColumnKey[];
   selectionMode?: GridSelectionMode;
   wrapCustomCellRenderers?: boolean;
+  allowDisabledContextMenu?: boolean;
   actionLabels?: {
     [DialFileManagerActions.AddSibling]?: string;
     [DialFileManagerActions.AddChild]?: string;
@@ -643,6 +644,7 @@ export const DialFileManagerView: FC = () => {
     selectionMode,
     wrapCustomCellRenderers,
     visibleColumns = DEFAULT_VISIBLE_COLUMN,
+    allowDisabledContextMenu = false,
     ...forwardedGridOptions
   } = gridOptions ?? {};
 
@@ -1135,9 +1137,22 @@ export const DialFileManagerView: FC = () => {
     [items, gridContextMenu],
   );
 
+  const isRowContextMenuDisabled = useCallback(
+    (
+      row: FileManagerGridRow,
+      allowedFileTypes?: DialFileAcceptType[],
+      maxSelectableFileSize?: number,
+    ) => {
+      return allowDisabledContextMenu
+        ? false
+        : isRowDisabled(row, allowedFileTypes, maxSelectableFileSize);
+    },
+    [allowDisabledContextMenu, isRowDisabled],
+  );
+
   const { actionsColumnDef } = useGridActionsColumn({
     getContextMenuItems: getGridContextMenuItems,
-    isRowDisabled,
+    isRowDisabled: isRowContextMenuDisabled,
     allowedFileTypes: allowedFileTypes,
     buttonClassName: isCompactView ? '' : actionsColumnButtonClassName,
   });

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1314,6 +1314,7 @@ export const DialFileManagerView: FC = () => {
                 onSelectionChange={handleSelectionChange}
                 wrapperBorder={!isDragging && !isDraggingOverWindow}
                 disabledRowIds={disabledGridRowIds}
+                allowDisabledContextMenu={allowDisabledContextMenu}
               />
             )}
           </section>

--- a/src/components/FileManager/hooks/use-grid-actions-column.tsx
+++ b/src/components/FileManager/hooks/use-grid-actions-column.tsx
@@ -60,7 +60,7 @@ export const useGridActionsColumn = ({
           className={mergeClasses('sticky right-0', buttonClassName)}
         >
           <DialIcon
-            className="text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary"
+            className="text-secondary mx-2 flex flex-row gap-2 hover:text-accent-primary cursor-default"
             icon={<IconDotsVertical {...BASE_ICON_PROPS} />}
           />
         </DialDropdown>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -74,6 +74,7 @@ export interface DialGridProps<T extends object = Record<string, unknown>> {
   wrapperBorder?: boolean;
   withoutHeaderBorders?: boolean;
   selectionMode?: GridSelectionMode;
+  allowDisabledContextMenu?: boolean;
 }
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -166,6 +167,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
  * @param [wrapperBorder=true] - Whether to apply a border around the grid container
  * @param [withoutHeaderBorders=false] - Whether to hide the header row borders
  * @param [selectionMode] - Could be GridSelectionMode.MULTIPLE or GridSelectionMode.SINGLE to enable selection column
+ * @param [allowDisabledContextMenu] - Enables context menu actions even if row itself is disabled for selection
  */
 export const DialGrid = <T extends object>({
   columnDefs,
@@ -190,6 +192,7 @@ export const DialGrid = <T extends object>({
   loading = false,
   wrapperBorder = true,
   withoutHeaderBorders = false,
+  allowDisabledContextMenu = false,
   selectionMode,
 }: DialGridProps<T>) => {
   const [rowHeight, setRowHeight] = useState<number>(ROW_HEIGHT);
@@ -220,7 +223,8 @@ export const DialGrid = <T extends object>({
     (p: ICellRendererParams<T, unknown>) => {
       if (p.data) {
         const rowId = getRowId(p.data);
-        const disabled = disabledRowIds?.has(rowId);
+        const disabled =
+          !allowDisabledContextMenu && disabledRowIds?.has(rowId);
         const valueText = p.value == null ? '' : String(p.value);
         const items = getContextMenuItems?.(p.data) ?? [];
 
@@ -243,7 +247,7 @@ export const DialGrid = <T extends object>({
         );
       }
     },
-    [getContextMenuItems, disabledRowIds, getRowId],
+    [getContextMenuItems, disabledRowIds, getRowId, allowDisabledContextMenu],
   );
 
   const isUserSelectionEvent = useCallback(
@@ -387,7 +391,10 @@ export const DialGrid = <T extends object>({
         }
 
         const rowId = p.data ? getRowId(p.data) : null;
-        const disabled = rowId ? disabledRowIds?.has(rowId) : false;
+        const disabled =
+          rowId && !allowDisabledContextMenu
+            ? disabledRowIds?.has(rowId)
+            : false;
 
         return (
           <DialDropdown
@@ -411,6 +418,7 @@ export const DialGrid = <T extends object>({
       getRowId,
       renderDataCell,
       wrapCustomCellRenderers,
+      allowDisabledContextMenu,
     ],
   );
 


### PR DESCRIPTION
**Description and UI changes:**

- add allowDisabledContextMenu flag to gridOptions of FileManager to allow using row actions even if selection is disabled

Issues:

- Issue #555
- Related Chat issue: https://github.com/epam/ai-dial-chat/issues/5980

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [x] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [ ] tests are added