### PR TITLE
fix(chat): show disabled cursor and darkened view on disabled grid row (Issue #555)

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -391,10 +391,7 @@ export const DialGrid = <T extends object>({
         }
 
         const rowId = p.data ? getRowId(p.data) : null;
-        const disabled =
-          rowId && !allowDisabledContextMenu
-            ? disabledRowIds?.has(rowId)
-            : false;
+        const disabled = rowId ? disabledRowIds?.has(rowId) : false;
 
         return (
           <DialDropdown
@@ -402,8 +399,11 @@ export const DialGrid = <T extends object>({
             menu={{ items }}
             anchorToMouse
             matchReferenceWidth
-            className="w-full h-full"
-            disabled={disabled}
+            className={classNames(
+              'w-full h-full',
+              disabled && '!cursor-not-allowed opacity-75',
+            )}
+            disabled={disabled && !allowDisabledContextMenu}
           >
             <span className="block min-w-0 max-w-full flex-1">{content}</span>
           </DialDropdown>


### PR DESCRIPTION
**Description and UI changes:**

- darken and set not-allowed cursor for disabled grid row even if context menu is available

Issues:

- Issue #555 

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added