### PR TITLE
feat: add unsupportedFileTypeTooltip and fileTooLargeTooltip in FileManager (Issue #557)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -552,6 +553,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -575,6 +577,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,7 +1201,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
       "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
@@ -1208,7 +1210,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -1235,7 +1236,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
       "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.7.4"
       },
@@ -1248,8 +1248,7 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1610,7 +1609,6 @@
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
       "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "state-local": "^1.0.6"
       }
@@ -2452,6 +2450,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2980,6 +2979,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3054,7 +3054,6 @@
       "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.35.0.tgz",
       "integrity": "sha512-yYXe+gJ56xlZFiXwV9zVoe3FWCGuZ/D7/G4ZIlDtGxSx5CGQK110wrnT29gUj52kEZoxqF7oURTk97GQxELOFQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/codecalm"
@@ -3083,6 +3082,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3240,7 +3240,6 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -3270,7 +3269,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*"
       }
@@ -3280,7 +3278,6 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -3316,7 +3313,6 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -3332,8 +3328,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.2.1",
@@ -3341,6 +3336,7 @@
       "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -3349,14 +3345,14 @@
       "version": "1.26.5",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
       "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3367,6 +3363,7 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3389,8 +3386,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.0",
@@ -3438,6 +3434,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -3667,7 +3664,6 @@
       "resolved": "https://registry.npmjs.org/@uiw/copy-to-clipboard/-/copy-to-clipboard-1.0.20.tgz",
       "integrity": "sha512-IFQhS62CLNon1YgYJTEzXR2N3WVXg7V1FaBRDLMlzU6JY5X6Hr3OPAcw4WNoKcz2XcFD6XCgwEjlsmj+JA0mWA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
@@ -3725,8 +3721,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -3755,6 +3750,7 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -3892,6 +3888,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -4086,6 +4083,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4616,7 +4614,6 @@
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4634,7 +4631,6 @@
       "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
       "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4657,8 +4653,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4704,6 +4699,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4859,7 +4855,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4917,7 +4912,6 @@
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4928,7 +4922,6 @@
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4939,7 +4932,6 @@
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4950,7 +4942,6 @@
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5188,7 +5179,6 @@
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5314,8 +5304,7 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -5468,7 +5457,6 @@
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "character-entities": "^2.0.0"
       },
@@ -5601,7 +5589,6 @@
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -5632,7 +5619,6 @@
       "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
       "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "direction": "cli.js"
       },
@@ -5962,6 +5948,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6026,6 +6013,7 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6087,6 +6075,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6584,7 +6573,6 @@
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -6635,8 +6623,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -7009,8 +6996,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -7228,7 +7214,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
       "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.1.0",
@@ -7247,7 +7232,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -7268,7 +7252,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
       "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7282,7 +7265,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
       "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7296,7 +7278,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7310,7 +7291,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7324,7 +7304,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
       "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -7350,7 +7329,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
       "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -7378,7 +7356,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -7402,7 +7379,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
       "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -7430,7 +7406,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
       "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -7450,7 +7425,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7464,7 +7438,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -7478,7 +7451,6 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
       "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -7541,7 +7513,6 @@
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
       "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -7552,7 +7523,6 @@
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7683,8 +7653,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7706,7 +7675,6 @@
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7717,7 +7685,6 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -7887,7 +7854,6 @@
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7985,7 +7951,6 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8068,7 +8033,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8401,6 +8365,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8850,7 +8815,6 @@
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8961,7 +8925,6 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8982,7 +8945,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -8999,7 +8961,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9012,7 +8973,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
       "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -9037,7 +8997,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -9057,7 +9016,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "ccount": "^2.0.0",
@@ -9075,7 +9033,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.1.0",
@@ -9093,7 +9050,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -9109,7 +9065,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
@@ -9127,7 +9082,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
@@ -9144,7 +9098,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
       "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -9163,7 +9116,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
       "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -9188,7 +9140,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
       "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -9207,7 +9158,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
@@ -9222,7 +9172,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -9244,7 +9193,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -9266,7 +9214,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
@@ -9300,7 +9247,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9336,7 +9282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -9361,7 +9306,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
         "micromark-extension-gfm-footnote": "^2.0.0",
@@ -9382,7 +9326,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-sanitize-uri": "^2.0.0",
@@ -9399,7 +9342,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-core-commonmark": "^2.0.0",
@@ -9420,7 +9362,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -9439,7 +9380,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -9457,7 +9397,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       },
@@ -9471,7 +9410,6 @@
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -9499,7 +9437,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -9521,7 +9458,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -9544,7 +9480,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -9565,7 +9500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -9588,7 +9522,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -9611,7 +9544,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -9632,7 +9564,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -9652,7 +9583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -9674,7 +9604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -9695,7 +9624,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -9715,7 +9643,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -9737,8 +9664,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -9754,8 +9680,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
@@ -9772,7 +9697,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -9792,7 +9716,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       }
@@ -9812,7 +9735,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
@@ -9834,7 +9756,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -9856,8 +9777,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
@@ -9873,8 +9793,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10123,7 +10042,6 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -10366,7 +10284,6 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
@@ -10385,8 +10302,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -10411,8 +10327,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -10596,6 +10511,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10742,6 +10658,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10815,7 +10732,6 @@
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -10884,6 +10800,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10977,6 +10894,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10996,7 +10914,6 @@
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.3.tgz",
       "integrity": "sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -11133,7 +11050,6 @@
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.9.0.tgz",
       "integrity": "sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/prismjs": "^1.0.0",
@@ -11150,7 +11066,6 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
       "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -11159,15 +11074,13 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/refractor/node_modules/hast-util-parse-selector": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
       "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0"
       },
@@ -11181,7 +11094,6 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
       "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -11199,7 +11111,6 @@
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
       "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -11231,7 +11142,6 @@
       "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
       "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "rehype-parse": "^9.0.0",
@@ -11248,7 +11158,6 @@
       "resolved": "https://registry.npmjs.org/rehype-attr/-/rehype-attr-3.0.3.tgz",
       "integrity": "sha512-Up50Xfra8tyxnkJdCzLBIBtxOcB2M1xdeKe1324U06RAvSjYm7ULSeoM+b/nYPQPVd7jsXJ9+39IG1WAJPXONw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "unified": "~11.0.0",
         "unist-util-visit": "~5.0.0"
@@ -11265,7 +11174,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -11281,7 +11189,6 @@
       "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
       "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.0.0",
@@ -11300,7 +11207,6 @@
       "resolved": "https://registry.npmjs.org/rehype-ignore/-/rehype-ignore-2.0.3.tgz",
       "integrity": "sha512-IzhP6/u/6sm49sdktuYSmeIuObWB+5yC/5eqVws8BhuGA9kY25/byz6uCy/Ravj6lXUShEd2ofHM5MyAIj86Sg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hast-util-select": "^6.0.0",
         "unified": "^11.0.0",
@@ -11318,7 +11224,6 @@
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
       "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-from-html": "^2.0.0",
@@ -11334,7 +11239,6 @@
       "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-2.0.0.tgz",
       "integrity": "sha512-FeM/9V2N7EvDZVdR2dqhAzlw5YI49m9Tgn7ZrYJeYHIahM6gcXpH0K1y2gNnKanZCydOMluJvX2cB9z3lhY8XQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hast-util-to-string": "^3.0.0",
         "parse-numeric-range": "^1.3.0",
@@ -11349,7 +11253,6 @@
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
@@ -11365,7 +11268,6 @@
       "resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-4.0.4.tgz",
       "integrity": "sha512-L/FO96EOzSA6bzOam4DVu61/PB3AGKcSPXpa53yMIozoxH4qg1+bVZDF8zh1EsuxtSauAhzt5cCnvoplAaSLrw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hast-util-select": "^6.0.0",
         "unified": "^11.0.3",
@@ -11383,7 +11285,6 @@
       "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
       "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "github-slugger": "^2.0.0",
@@ -11401,7 +11302,6 @@
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
       "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
@@ -11417,7 +11317,6 @@
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-gfm": "^3.0.0",
@@ -11436,7 +11335,6 @@
       "resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-1.3.1.tgz",
       "integrity": "sha512-OPNnimcKeozWN1w8KVQEuHOxgN3L4rah8geMOLhA5vN9wITqU4FWD+G26tkEsCGHiOVDbISx+Se5rGZ+D1p0Jg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "unist-util-visit": "^5.0.0"
       },
@@ -11452,7 +11350,6 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -11469,7 +11366,6 @@
       "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
       "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -11487,7 +11383,6 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-to-markdown": "^2.0.0",
@@ -11590,6 +11485,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11772,6 +11668,7 @@
       "integrity": "sha512-XP1EltyLLfuU5FsGVjSz8PcT925oA3rDnJTWOEBHR42k62ZEbKTcZ4gVlFwKi0Ggzi5E8v1K2BplD8ELHwusYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
         "buffer-builder": "^0.2.0",
@@ -12406,7 +12303,6 @@
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12430,8 +12326,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -12460,6 +12355,7 @@
       "integrity": "sha512-heMfJjOfbHvL+wlCAwFZlSxcakyJ5yQDam6e9k2RRArB1veJhRnsjO6lO1hOXjJYrqxfHA/ldIugbBVlCDqfvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -12709,7 +12605,6 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -12823,7 +12718,6 @@
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
       "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "style-to-object": "1.0.14"
       }
@@ -12833,7 +12727,6 @@
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
       "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
@@ -12957,8 +12850,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -12976,6 +12868,7 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13306,7 +13199,6 @@
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13317,7 +13209,6 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13472,6 +13363,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13542,7 +13434,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -13562,7 +13453,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-5.0.1.tgz",
       "integrity": "sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -13574,7 +13464,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -13588,7 +13477,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -13602,7 +13490,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -13616,7 +13503,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -13632,7 +13518,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -13738,7 +13623,6 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -13753,7 +13637,6 @@
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile": "^6.0.0"
@@ -13768,7 +13651,6 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -13784,6 +13666,7 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13924,6 +13807,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -14016,7 +13900,6 @@
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -14467,7 +14350,6 @@
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -1,10 +1,22 @@
 import React, { createRef, type ReactElement } from 'react';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  within,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import { DialFileManager } from './FileManager';
 import { itemsMock } from './__mocks__/files';
 import type { DialFileManagerActionsRef } from '@/models/file-manager';
+import {
+  DialFileNodeType,
+  DialFileResourceType,
+  DialFilePermission,
+  type DialFile,
+} from '@/models/file';
 
 interface GridRowLike {
   name?: string;
@@ -27,16 +39,23 @@ interface MockAdditionalGridOptions<Row extends GridRowLike> {
 
 interface MockDialGridProps<Row extends GridRowLike> {
   rowData?: Row[];
-  getRowId?: (row: Row, index: number) => string;
+  getRowId?: (row: Row) => string;
   columnDefs?: MockColumnDef[];
   className?: string;
   additionalGridOptions?: MockAdditionalGridOptions<Row>;
+  disabledRowIds?: Set<string>;
 }
 
 vi.mock('@/components/Grid/Grid', () => {
   function DialGrid<Row extends GridRowLike>(props: MockDialGridProps<Row>) {
-    const { rowData, getRowId, columnDefs, className, additionalGridOptions } =
-      props;
+    const {
+      rowData,
+      getRowId,
+      columnDefs,
+      className,
+      additionalGridOptions,
+      disabledRowIds,
+    } = props;
 
     const rowsArray: Row[] = rowData ?? [];
     const getId =
@@ -58,8 +77,18 @@ vi.mock('@/components/Grid/Grid', () => {
     const rows = rowsArray.map((row, index) => {
       const key = getId(row, index);
       const label = row.name ?? row.path ?? String(index);
+      const isDisabled = disabledRowIds?.has(key) ?? false;
+
       return (
-        <tr key={key} className="ag-row" onClick={() => handleRowClick(row)}>
+        <tr
+          key={key}
+          className="ag-row"
+          data-disabled={isDisabled || undefined}
+          ref={(el: HTMLTableRowElement | null) => {
+            if (el) el.setAttribute('row-id', key);
+          }}
+          onClick={() => handleRowClick(row)}
+        >
           <td>{label}</td>
         </tr>
       );
@@ -89,6 +118,43 @@ vi.mock('@/components/Grid/Grid', () => {
 
   return { DialGrid };
 });
+
+vi.mock('@/components/Tooltip/TooltipContainer', () => ({
+  DialTooltipContainer: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    placement?: string;
+  }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Tooltip/TooltipTrigger', () => ({
+  DialTooltipTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Tooltip/TooltipContent', () => ({
+  DialTooltipContent: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div
+      role="tooltip"
+      data-testid="disabled-row-tooltip"
+      className={className}
+    >
+      {children}
+    </div>
+  ),
+}));
 
 const renderWithinSizedShell = (ui: ReactElement) =>
   render(<div style={{ height: 640, width: 1100 }}>{ui}</div>);
@@ -144,6 +210,80 @@ const queryAllInGridByRowText = async (
   return Array.from(rows).filter((row) =>
     matcher((row.textContent ?? '').trim()),
   );
+};
+
+const disabledRowItems: DialFile[] = [
+  {
+    id: 'dr-root',
+    name: 'Files',
+    path: 'Files',
+    parentPath: '',
+    nodeType: DialFileNodeType.FOLDER,
+    folderId: 'dr-root',
+    updatedAt: '2025-01-01',
+    items: [
+      {
+        id: 'dr-svg',
+        name: 'icon.svg',
+        path: 'Files/icon.svg',
+        parentPath: 'Files',
+        nodeType: DialFileNodeType.ITEM,
+        resourceType: DialFileResourceType.FILE,
+        extension: 'svg',
+        contentType: 'image/svg+xml',
+        folderId: 'dr-root',
+        updatedAt: '2025-01-01',
+        contentLength: 1024,
+        permissions: [DialFilePermission.READ],
+      },
+      {
+        id: 'dr-pdf',
+        name: 'report.pdf',
+        path: 'Files/report.pdf',
+        parentPath: 'Files',
+        nodeType: DialFileNodeType.ITEM,
+        resourceType: DialFileResourceType.FILE,
+        extension: 'pdf',
+        contentType: 'application/pdf',
+        folderId: 'dr-root',
+        updatedAt: '2025-01-01',
+        contentLength: 1024,
+        permissions: [DialFilePermission.READ],
+      },
+      {
+        id: 'dr-big',
+        name: 'large.svg',
+        path: 'Files/large.svg',
+        parentPath: 'Files',
+        nodeType: DialFileNodeType.ITEM,
+        resourceType: DialFileResourceType.FILE,
+        extension: 'svg',
+        contentType: 'image/svg+xml',
+        folderId: 'dr-root',
+        updatedAt: '2025-01-01',
+        contentLength: 10 * 1024 * 1024, // 10 MB
+        permissions: [DialFilePermission.READ],
+      },
+    ],
+  },
+];
+
+const hoverDisabledRow = async (rowText: string) => {
+  const row = await findInGridByRowText(rowText);
+  const cell = row.querySelector('td')!;
+  fireEvent.mouseMove(cell);
+};
+
+const leaveGrid = () => {
+  const gridSection = screen.getByRole('region', {
+    name: 'File Manager Grid View',
+  });
+  fireEvent.mouseLeave(gridSection);
+};
+
+const expectNoDisabledTooltip = () => {
+  expect(screen.queryByText(/Unsupported file type/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/File is too large/)).not.toBeInTheDocument();
 };
 
 describe('Dial UI Kit :: FileManager', () => {
@@ -239,8 +379,8 @@ describe('Dial UI Kit :: FileManager', () => {
     );
 
     const grid = await waitForGridTable();
-    const teaboxesInsideGrid = within(grid).queryAllByRole('textbox');
-    expect(teaboxesInsideGrid.length).toBe(0);
+    const textboxesInsideGrid = within(grid).queryAllByRole('textbox');
+    expect(textboxesInsideGrid.length).toBe(0);
   });
 
   test('actionsRef.createFolder adds a new row to the grid', async () => {
@@ -317,5 +457,213 @@ describe('Dial UI Kit :: FileManager', () => {
     expect(
       screen.queryByText('Upload or drag and drop files'),
     ).not.toBeInTheDocument();
+  });
+
+  describe('disabled-row tooltips', () => {
+    test('unsupported file type shows tooltip on hover', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Unsupported file type. Supported types: image/svg+xml.',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('file exceeding maxSelectableFileSize shows size tooltip', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          maxSelectableFileSize={5 * 1024 * 1024}
+        />,
+      );
+
+      await hoverDisabledRow('large.svg');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/File is too large\. Maximum size: .+/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('accepted file does NOT show disabled tooltip', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+          maxSelectableFileSize={5 * 1024 * 1024}
+        />,
+      );
+
+      await hoverDisabledRow('icon.svg');
+
+      await waitFor(() => {
+        expectNoDisabledTooltip();
+      });
+    });
+
+    test('custom getDisabledTooltip overrides default text', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+          getDisabledTooltip={(file) =>
+            file.contentType === 'application/pdf'
+              ? 'PDF files are not allowed'
+              : undefined
+          }
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('PDF files are not allowed'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('custom unsupportedFileTypeTooltip overrides default', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+          unsupportedFileTypeTooltip="Wrong file type"
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(screen.getByText('Wrong file type')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/Unsupported file type\. Supported types/),
+      ).not.toBeInTheDocument();
+    });
+
+    test('custom fileTooLargeTooltip overrides default', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          maxSelectableFileSize={5 * 1024 * 1024}
+          fileTooLargeTooltip="File exceeds limit"
+        />,
+      );
+
+      await hoverDisabledRow('large.svg');
+
+      await waitFor(() => {
+        expect(screen.getByText('File exceeds limit')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/File is too large\. Maximum size/),
+      ).not.toBeInTheDocument();
+    });
+
+    test('tooltip disappears when mouse leaves grid', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Unsupported file type. Supported types: image/svg+xml.',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      leaveGrid();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Unsupported file type. Supported types: image/svg+xml.',
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('tooltip disappears on scroll', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Unsupported file type. Supported types: image/svg+xml.',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.scroll(window);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Unsupported file type. Supported types: image/svg+xml.',
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('switching from one disabled row to another updates tooltip', async () => {
+      renderWithinSizedShell(
+        <DialFileManager
+          items={disabledRowItems}
+          path="Files"
+          allowedFileTypes={['image/svg+xml']}
+          maxSelectableFileSize={5 * 1024 * 1024}
+          unsupportedFileTypeTooltip="Wrong type"
+          fileTooLargeTooltip="Too large"
+        />,
+      );
+
+      await hoverDisabledRow('report.pdf');
+
+      await waitFor(() => {
+        expect(screen.getByText('Wrong type')).toBeInTheDocument();
+      });
+
+      await hoverDisabledRow('large.svg');
+
+      await waitFor(() => {
+        expect(screen.getByText('Too large')).toBeInTheDocument();
+        expect(screen.queryByText('Wrong type')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -77,7 +77,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+  args: {},
+};
 
 export const PreselectedNode: Story = {
   args: {
@@ -139,6 +141,46 @@ export const WithFilesInTree: Story = {
   args: {
     treeOptions: {
       showFiles: true,
+    },
+  },
+};
+
+type WithDisabledTooltipArgs = DialFileManagerProps;
+
+const WithDisabledTooltipComponent = (args: WithDisabledTooltipArgs) => (
+  <DialFileManager {...args} />
+);
+
+export const WithDisabledTooltip: StoryObj<WithDisabledTooltipArgs> = {
+  render: WithDisabledTooltipComponent,
+  args: {
+    allowedFileTypes: ['.pdf'],
+    maxSelectableFileSize: 1024 * 1024, // 1MB
+  },
+  argTypes: {
+    unsupportedFileTypeTooltip: {
+      control: { type: 'text' },
+      description: 'Tooltip text shown for unsupported file types',
+    },
+    fileTooLargeTooltip: {
+      control: { type: 'text' },
+      description: 'Tooltip text shown for files exceeding size limit',
+    },
+    allowedFileTypes: {
+      control: 'object',
+      description: 'Allowed file extensions (e.g. [".svg", ".png"])',
+    },
+    maxSelectableFileSize: {
+      control: { type: 'number' },
+      description: 'Maximum selectable file size in bytes',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Adjust constraints and tooltip texts in the Controls panel. Hover over any greyed-out file to see the row-level tooltip centered at the bottom.',
+      },
     },
   },
 };

--- a/src/components/FileManager/FileManager.stories.tsx
+++ b/src/components/FileManager/FileManager.stories.tsx
@@ -184,7 +184,7 @@ export const WithDisabledTooltip: StoryObj<WithDisabledTooltipArgs> = {
     docs: {
       description: {
         story:
-          'Adjust constraints and tooltip texts in the Controls panel. Hover over any greyed-out file to see the row-level tooltip centered at the bottom.',
+          'Adjust constraints and tooltip texts in the Controls panel. Hover over any greyed-out file to see the row-level tooltip displayed above the row.',
       },
     },
   },

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -9,6 +9,7 @@ import {
   type Ref,
   useImperativeHandle,
   type RefObject,
+  useEffect,
 } from 'react';
 import type { CellClickedEvent, ColDef, GridApi } from 'ag-grid-community';
 import {
@@ -28,7 +29,7 @@ import {
   actionsColumnButtonClassName,
   DEFAULT_VISIBLE_COLUMN,
 } from './constants';
-import { findNodeByPath, isFileAccepted } from './utils';
+import { findNodeByPath, isFileAccepted, formatBytes } from './utils';
 import { DialCollapsibleSidebar } from '@/components/CollapsibleSidebar/CollapsibleSidebar';
 import type { DialFile, DialRootFolder } from '@/models/file';
 import { DialFileNodeType, DialFilePermission } from '@/models/file';
@@ -91,7 +92,6 @@ import {
   DialFileManagerActions,
   FileManagerRenameTriggerView,
 } from '@/types/file-manager';
-import type { FolderCreationValidationMessages } from '@/components/FileManager/hooks/use-folder-creation';
 import {
   ConflictResolutionPopup,
   type ConflictResolutionPopupProps,
@@ -111,6 +111,9 @@ import {
   type FileManagerGridContext,
 } from './hooks/use-file-manager-columns';
 import { GridSelectionMode } from '@/models/selection-mode.ts';
+import { DialTooltipContainer } from '@/components/Tooltip/TooltipContainer';
+import { DialTooltipTrigger } from '@/components/Tooltip/TooltipTrigger';
+import { DialTooltipContent } from '@/components/Tooltip/TooltipContent';
 
 type GridRow = FileManagerGridRow;
 
@@ -320,7 +323,10 @@ export interface DialFileManagerProps {
     name: string,
     parentFolder: DialFile,
   ) => string | null;
-  folderCreationValidationMessages?: FolderCreationValidationMessages;
+  folderCreationValidationMessages?: CreateFolderValidationMessages;
+  getDisabledTooltip?: (row: DialFile) => string | undefined;
+  fileTooLargeTooltip?: string;
+  unsupportedFileTypeTooltip?: string;
 
   onUploadFiles?: (
     files: DialUploadFileItem[],
@@ -464,6 +470,8 @@ export interface DialFileManagerProps {
  * @param [emptyStateDescription] - Optional description text displayed below the empty state title.
  *
  * @param [sharedWithMeIds] - Optional list of file IDs that are shared with the current user.
+ * @param [unsupportedFileTypeTooltip] - Optional tooltip text displayed when an unsupported file type is selected.
+ * @param [fileTooLargeTooltip] - Optional tooltip text displayed when a file is too large.
  */
 export const DialFileManager: FC<DialFileManagerProps> = (props) => {
   return (
@@ -607,7 +615,11 @@ export const DialFileManagerView: FC = () => {
     onPreview,
     previewExtensions,
     isRenameFileAvailable,
+    getDisabledTooltip,
+    fileTooLargeTooltip,
+    unsupportedFileTypeTooltip,
   } = useFileManagerContext();
+
   const {
     width = sidebarWidth,
     header = sidebarTitleDefault,
@@ -658,26 +670,128 @@ export const DialFileManagerView: FC = () => {
       : visibleColumns;
   }, [isSearchMode, visibleColumns]);
 
-  const isRowDisabled = useCallback(
+  const getRowDisabledTooltip = useCallback(
     (
       row: FileManagerGridRow,
       allowedFileTypes?: DialFileAcceptType[],
       maxSelectableFileSize?: number,
     ) => {
+      if (row.nodeType === DialFileNodeType.FOLDER) return undefined;
+
       const isFileSizeAccepted =
-        row.nodeType === DialFileNodeType.FOLDER ||
         !row.contentLength ||
-        typeof maxSelectableFileSize !== 'number' ||
+        maxSelectableFileSize == null ||
         row.contentLength <= maxSelectableFileSize;
       const isFileTypeAccepted =
-        row.nodeType === DialFileNodeType.FOLDER ||
         !row.contentType ||
         isFileAccepted(allowedFileTypes, row.contentType, row.name);
 
-      return !isFileTypeAccepted || !isFileSizeAccepted;
+      if (!isFileTypeAccepted) {
+        return (
+          unsupportedFileTypeTooltip ??
+          `Unsupported file type. Supported types: ${allowedFileTypes?.join(', ')}.`
+        );
+      }
+      if (!isFileSizeAccepted) {
+        return (
+          fileTooLargeTooltip ??
+          `File is too large. Maximum size: ${formatBytes(maxSelectableFileSize!)}.`
+        );
+      }
+      return undefined;
     },
-    [],
+    [fileTooLargeTooltip, unsupportedFileTypeTooltip],
   );
+
+  const isRowDisabled = useCallback(
+    (row: FileManagerGridRow) => {
+      if (getDisabledTooltip && getDisabledTooltip(row as DialFile)) {
+        return true;
+      }
+      return !!getRowDisabledTooltip(
+        row,
+        allowedFileTypes,
+        maxSelectableFileSize,
+      );
+    },
+    [
+      getDisabledTooltip,
+      getRowDisabledTooltip,
+      allowedFileTypes,
+      maxSelectableFileSize,
+    ],
+  );
+
+  const disabledGridRowIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of gridRows) {
+      if (isRowDisabled(row)) {
+        ids.add(row.path);
+      }
+    }
+    return ids;
+  }, [gridRows, isRowDisabled]);
+
+  const [hoveredRowId, setHoveredRowId] = useState<string | null>(null);
+  const [hoveredRowRect, setHoveredRowRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHoveredRowId((prev) => (prev ? null : prev));
+    };
+    window.addEventListener('scroll', handleScroll, true);
+    return () => window.removeEventListener('scroll', handleScroll, true);
+  }, []);
+
+  const handleGridViewportMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      const rowTarget = (e.target as HTMLElement).closest(
+        '.ag-row',
+      ) as HTMLElement | null;
+      if (!rowTarget) {
+        if (hoveredRowId) setHoveredRowId(null);
+        return;
+      }
+      const rowId = rowTarget.getAttribute('row-id');
+      if (rowId && disabledGridRowIds.has(rowId)) {
+        if (hoveredRowId !== rowId) {
+          setHoveredRowId(rowId);
+          setHoveredRowRect(rowTarget.getBoundingClientRect());
+        }
+      } else {
+        if (hoveredRowId) setHoveredRowId(null);
+      }
+    },
+    [hoveredRowId, disabledGridRowIds],
+  );
+
+  const handleGridViewportMouseLeave = useCallback(() => {
+    setHoveredRowId(null);
+  }, []);
+
+  const hoveredRowFile = useMemo(() => {
+    if (!hoveredRowId) return undefined;
+    const file = gridRows.find((r) => r.path === hoveredRowId);
+    return file ? (file as unknown as DialFile) : undefined;
+  }, [hoveredRowId, gridRows]);
+
+  const hoveredRowTooltipContent = useMemo(() => {
+    if (!hoveredRowFile) return undefined;
+    if (getDisabledTooltip) {
+      return getDisabledTooltip(hoveredRowFile);
+    }
+    return getRowDisabledTooltip(
+      hoveredRowFile as unknown as FileManagerGridRow,
+      allowedFileTypes,
+      maxSelectableFileSize,
+    );
+  }, [
+    hoveredRowFile,
+    getDisabledTooltip,
+    getRowDisabledTooltip,
+    allowedFileTypes,
+    maxSelectableFileSize,
+  ]);
 
   const getTreeContextMenuItems = useCallback(
     (file: DialFile): DropdownItem[] => {
@@ -919,16 +1033,6 @@ export const DialFileManagerView: FC = () => {
     selectedFiles.forEach((_file, id) => data.add(id));
     return data;
   }, [selectedFiles]);
-
-  const disabledGridRowIds = useMemo(() => {
-    const ids = new Set<string>();
-    gridRows
-      .filter((row) =>
-        isRowDisabled(row, allowedFileTypes, maxSelectableFileSize),
-      )
-      .forEach((row) => ids.add(row.path));
-    return ids;
-  }, [allowedFileTypes, maxSelectableFileSize, gridRows, isRowDisabled]);
 
   const handleSelectionChange = useCallback(
     (selectedRowsIds: Set<string>, selectedRows: GridRow[]) => {
@@ -1234,6 +1338,8 @@ export const DialFileManagerView: FC = () => {
             role="region"
             aria-label="File Manager Grid View"
             className={mergeClasses(gridBaseClassName)}
+            onMouseMove={handleGridViewportMouseMove}
+            onMouseLeave={handleGridViewportMouseLeave}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
@@ -1264,6 +1370,10 @@ export const DialFileManagerView: FC = () => {
                 wrapCustomCellRenderers={wrapCustomCellRenderers}
                 additionalGridOptions={{
                   ...forwardedGridOptions.additionalGridOptions,
+                  defaultColDef: {
+                    ...forwardedGridOptions.additionalGridOptions
+                      ?.defaultColDef,
+                  },
                   onCellClicked: cellClickHandler,
                   headerHeight: COMPACT_VIEW_HEADER_HEIGHT,
                   rowHeight: COMPACT_VIEW_HEADER_HEIGHT,
@@ -1290,6 +1400,7 @@ export const DialFileManagerView: FC = () => {
                     newFolderTempId,
                     sharedByMePaths,
                     selectedPaths,
+                    disabledRowIds: disabledGridRowIds,
                   } as FileManagerGridContext,
                 }}
                 selectedRowIds={selectedGridRowsIds}
@@ -1297,6 +1408,24 @@ export const DialFileManagerView: FC = () => {
                 wrapperBorder={!isDragging && !isDraggingOverWindow}
                 disabledRowIds={disabledGridRowIds}
               />
+            )}
+            {hoveredRowTooltipContent && hoveredRowRect && (
+              <DialTooltipContainer open={true} placement="top">
+                <DialTooltipTrigger asChild>
+                  <div
+                    className="fixed pointer-events-none z-[-1]"
+                    style={{
+                      top: hoveredRowRect.top,
+                      left: hoveredRowRect.left,
+                      width: hoveredRowRect.width,
+                      height: hoveredRowRect.height,
+                    }}
+                  />
+                </DialTooltipTrigger>
+                <DialTooltipContent className="max-w-[300px] rounded border border-ui-outline-primary bg-ui-popover px-3 py-1.5 text-center text-primary shadow-md fill-ui-popover">
+                  {hoveredRowTooltipContent}
+                </DialTooltipContent>
+              </DialTooltipContainer>
             )}
           </section>
         </div>

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -692,10 +692,12 @@ export const DialFileManagerView: FC = () => {
         isFileAccepted(allowedFileTypes, row.contentType, row.name);
 
       if (!isFileTypeAccepted) {
-        return (
-          unsupportedFileTypeTooltip ??
-          `Unsupported file type. Supported types: ${allowedFileTypes?.join(', ')}.`
-        );
+        const hasAllowedTypes =
+          Array.isArray(allowedFileTypes) && allowedFileTypes.length > 0;
+        const defaultUnsupportedMessage = hasAllowedTypes
+          ? `Unsupported file type. Supported types: ${allowedFileTypes.join(', ')}.`
+          : 'Unsupported file type.';
+        return unsupportedFileTypeTooltip ?? defaultUnsupportedMessage;
       }
       if (!isFileSizeAccepted) {
         return (
@@ -709,40 +711,37 @@ export const DialFileManagerView: FC = () => {
   );
 
   const isRowDisabled = useCallback(
-    (row: FileManagerGridRow) => {
-      if (getDisabledTooltip && getDisabledTooltip(row as DialFile)) {
-        return true;
-      }
+    (
+      row: FileManagerGridRow,
+      allowedFileTypes?: DialFileAcceptType[],
+      maxSelectableFileSize?: number,
+    ) => {
       return !!getRowDisabledTooltip(
         row,
         allowedFileTypes,
         maxSelectableFileSize,
       );
     },
-    [
-      getDisabledTooltip,
-      getRowDisabledTooltip,
-      allowedFileTypes,
-      maxSelectableFileSize,
-    ],
+    [getRowDisabledTooltip],
   );
 
   const disabledGridRowIds = useMemo(() => {
     const ids = new Set<string>();
     for (const row of gridRows) {
-      if (isRowDisabled(row)) {
+      if (isRowDisabled(row, allowedFileTypes, maxSelectableFileSize)) {
         ids.add(row.path);
       }
     }
     return ids;
-  }, [gridRows, isRowDisabled]);
+  }, [allowedFileTypes, maxSelectableFileSize, gridRows, isRowDisabled]);
 
   const [hoveredRowId, setHoveredRowId] = useState<string | null>(null);
   const [hoveredRowRect, setHoveredRowRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
     const handleScroll = () => {
-      setHoveredRowId((prev) => (prev ? null : prev));
+      setHoveredRowId(null);
+      setHoveredRowRect(null);
     };
     window.addEventListener('scroll', handleScroll, true);
     return () => window.removeEventListener('scroll', handleScroll, true);
@@ -772,6 +771,7 @@ export const DialFileManagerView: FC = () => {
 
   const handleGridViewportMouseLeave = useCallback(() => {
     setHoveredRowId(null);
+    setHoveredRowRect(null);
   }, []);
 
   const hoveredRowFile = useMemo(() => {

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -326,7 +326,7 @@ export interface DialFileManagerProps {
     parentFolder: DialFile,
   ) => string | null;
   folderCreationValidationMessages?: CreateFolderValidationMessages;
-  getDisabledTooltip?: (row: DialFile) => string | undefined;
+  getDisabledTooltip?: (row: FileManagerGridRow) => string | undefined;
   fileTooLargeTooltip?: string;
   unsupportedFileTypeTooltip?: string;
 
@@ -677,27 +677,28 @@ export const DialFileManagerView: FC = () => {
 
   const getRowDisabledTooltip = useCallback(
     (
-      row: FileManagerGridRow,
+      file: FileManagerGridRow,
       allowedFileTypes?: DialFileAcceptType[],
       maxSelectableFileSize?: number,
     ) => {
-      if (row.nodeType === DialFileNodeType.FOLDER) return undefined;
+      if (file.nodeType === DialFileNodeType.FOLDER) return undefined;
 
       const isFileSizeAccepted =
-        !row.contentLength ||
+        !file.contentLength ||
         maxSelectableFileSize == null ||
-        row.contentLength <= maxSelectableFileSize;
+        file.contentLength <= maxSelectableFileSize;
+
       const isFileTypeAccepted =
-        !row.contentType ||
-        isFileAccepted(allowedFileTypes, row.contentType, row.name);
+        !file.contentType ||
+        isFileAccepted(allowedFileTypes, file.contentType, file.name);
 
       if (!isFileTypeAccepted) {
-        const hasAllowedTypes =
-          Array.isArray(allowedFileTypes) && allowedFileTypes.length > 0;
-        const defaultUnsupportedMessage = hasAllowedTypes
-          ? `Unsupported file type. Supported types: ${allowedFileTypes.join(', ')}.`
-          : 'Unsupported file type.';
-        return unsupportedFileTypeTooltip ?? defaultUnsupportedMessage;
+        return (
+          unsupportedFileTypeTooltip ??
+          (allowedFileTypes?.length
+            ? `Unsupported file type. Supported types: ${allowedFileTypes.join(', ')}.`
+            : 'Unsupported file type.')
+        );
       }
       if (!isFileSizeAccepted) {
         return (
@@ -776,17 +777,18 @@ export const DialFileManagerView: FC = () => {
 
   const hoveredRowFile = useMemo(() => {
     if (!hoveredRowId) return undefined;
-    const file = gridRows.find((r) => r.path === hoveredRowId);
-    return file ? (file as unknown as DialFile) : undefined;
+    return gridRows.find((r) => r.path === hoveredRowId);
   }, [hoveredRowId, gridRows]);
 
   const hoveredRowTooltipContent = useMemo(() => {
     if (!hoveredRowFile) return undefined;
-    if (getDisabledTooltip) {
+
+    if (getDisabledTooltip && hoveredRowFile.folderId) {
       return getDisabledTooltip(hoveredRowFile);
     }
+
     return getRowDisabledTooltip(
-      hoveredRowFile as unknown as FileManagerGridRow,
+      hoveredRowFile,
       allowedFileTypes,
       maxSelectableFileSize,
     );

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -208,7 +208,7 @@ export interface FileManagerContextValue {
     currentPath?: string,
     currentFolder?: DialFile,
   ) => void;
-  getDisabledTooltip?: (row: DialFile) => string | undefined;
+  getDisabledTooltip?: (row: FileManagerGridRow) => string | undefined;
   fileTooLargeTooltip?: string;
   unsupportedFileTypeTooltip?: string;
 }

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -42,6 +42,7 @@ export interface FileManagerGridRow {
   owner?: string;
   contentType?: string;
   contentLength?: number;
+  folderId?: string;
 }
 
 export interface FileManagerContextValue {
@@ -206,6 +207,9 @@ export interface FileManagerContextValue {
     currentPath?: string,
     currentFolder?: DialFile,
   ) => void;
+  getDisabledTooltip?: (row: DialFile) => string | undefined;
+  fileTooLargeTooltip?: string;
+  unsupportedFileTypeTooltip?: string;
 }
 
 export const FileManagerContext = createContext<

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -113,6 +113,9 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   clearSearchResults,
   allowedFileTypes,
   maxSelectableFileSize,
+  getDisabledTooltip,
+  fileTooLargeTooltip,
+  unsupportedFileTypeTooltip,
 
   emptyStateIcon,
   emptyStateTitle,
@@ -141,14 +144,14 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     const map = new Map<string, DialFile>();
 
     effectiveSelectedPaths.forEach((path) => {
-      const file = findNodeByPath(items, path);
-      if (file) {
-        map.set(path, file);
+      const node = findNodeByPath(items, path);
+      if (node && node.nodeType === DialFileNodeType.ITEM) {
+        map.set(path, node);
       }
     });
 
     return map;
-  }, [effectiveSelectedPaths, items]);
+  }, [items, effectiveSelectedPaths]);
 
   const { currentPath, setCurrentPath, handlePathChange } = useCurrentPath({
     path,
@@ -408,6 +411,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
         extension: node.extension,
         isTemporary: false,
         owner: node.owner,
+        folderId: node.folderId,
       }));
     }
 
@@ -446,6 +450,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       owner: node.owner,
       contentType: node.contentType,
       contentLength: node.contentLength,
+      folderId: node.folderId,
     }));
 
     if (isCreatingFolder && newFolderTempId && !query) {
@@ -702,6 +707,9 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     isRenameFileAvailable,
     customUploadFileAction,
     customBreakpointRef,
+    getDisabledTooltip,
+    fileTooLargeTooltip,
+    unsupportedFileTypeTooltip,
   };
 
   return (

--- a/src/components/FileManager/components/DialFileManagerItemSummaryCell/DialFileManagerItemSummaryCell.tsx
+++ b/src/components/FileManager/components/DialFileManagerItemSummaryCell/DialFileManagerItemSummaryCell.tsx
@@ -17,6 +17,7 @@ interface DialFileManagerItemSummaryCellProps {
   dateLocale?: Intl.LocalesArgument;
   dateOptions?: Intl.DateTimeFormatOptions;
   sharedIndicatorClassName?: string;
+  hideTooltip?: boolean;
 }
 
 /**
@@ -74,6 +75,7 @@ export const DialFileManagerItemSummaryCell: FC<
   dateOptions,
   shared,
   sharedIndicatorClassName,
+  hideTooltip = false,
 }) => {
   return (
     <div className="flex">
@@ -89,6 +91,7 @@ export const DialFileManagerItemSummaryCell: FC<
           shared={shared}
           iconSize={BASE_FILE_MANAGER_ICON_SIZE}
           sharedIndicatorClassName={sharedIndicatorClassName}
+          hideTooltip={hideTooltip}
           details={
             <div className="flex items-center gap-1 dial-tiny text-secondary">
               <span>
@@ -104,6 +107,7 @@ export const DialFileManagerItemSummaryCell: FC<
                     locale={dateLocale?.toString()}
                     options={dateOptions}
                     className="dial-tiny text-secondary"
+                    hideTooltip={hideTooltip}
                   />
                 </span>
               ) : null}

--- a/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.tsx
+++ b/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.tsx
@@ -23,6 +23,7 @@ export interface DialFileManagerItemNameProps
   validate?: (value: string) => string | null;
   onSave?: (value: string) => void;
   onCancel?: () => void;
+  hideTooltip?: boolean;
 }
 
 /**
@@ -73,6 +74,7 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
   inputContainerClassName,
   sharedIndicatorClassName,
   sharedIndicatorTooltip,
+  hideTooltip = false,
   ...restProps
 }) => {
   const { value, invalid, invalidMessage, onChange, inputRef } =
@@ -94,6 +96,7 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
           iconSize={iconSize}
           className="max-w-[428px] truncate"
           sharedIndicatorClassName={sharedIndicatorClassName}
+          hideTooltip={hideTooltip}
         />
       );
     }
@@ -105,6 +108,7 @@ export const DialFileManagerItemName: FC<DialFileManagerItemNameProps> = ({
         shared={shared}
         iconSize={iconSize}
         sharedIndicatorClassName={sharedIndicatorClassName}
+        hideTooltip={hideTooltip}
       />
     );
   }

--- a/src/components/FileManager/hooks/use-file-manager-columns.tsx
+++ b/src/components/FileManager/hooks/use-file-manager-columns.tsx
@@ -20,6 +20,7 @@ export interface FileManagerGridContext {
   renameTriggerView: FileManagerRenameTriggerView;
   sharedByMePaths?: Set<string>;
   selectedPaths?: Set<string>;
+  disabledRowIds?: Set<string>;
 
   cancelFolderCreation: () => void;
   saveFolderCreation: (name: string) => Promise<void>;
@@ -102,12 +103,22 @@ export function useFileManagerColumns({
         headerName: 'Path',
         flex: 1,
         minWidth: 200,
-        cellRenderer: (params: { data: GridRow }) => {
+        cellRenderer: (params: {
+          data: GridRow;
+          context: FileManagerGridContext;
+        }) => {
+          const isDisabled =
+            params.context?.disabledRowIds?.has(params.data.path) ?? false;
           if (!rootItemPath || !rootItemLabel) {
-            return <DialEllipsisTooltip text={params.data.path} />;
+            return (
+              <DialEllipsisTooltip
+                text={params.data.path}
+                hideTooltip={isDisabled}
+              />
+            );
           }
           const path = params.data.path.replace(rootItemPath, rootItemLabel);
-          return <DialEllipsisTooltip text={path} />;
+          return <DialEllipsisTooltip text={path} hideTooltip={isDisabled} />;
         },
       },
       UPDATED_AT_COLUMN('Modified Date')(dateLocale, dateOptions),

--- a/src/components/FileName/FileName.tsx
+++ b/src/components/FileName/FileName.tsx
@@ -15,6 +15,7 @@ export interface DialFileNameProps {
   details?: ReactNode;
   sharedIndicatorClassName?: string;
   sharedIndicatorTooltip?: ReactNode;
+  hideTooltip?: boolean;
 }
 
 /**
@@ -53,6 +54,7 @@ export const DialFileName: FC<DialFileNameProps> = ({
   sharedIndicatorClassName,
   sharedIndicatorTooltip,
   fileExtension,
+  hideTooltip = false,
 }) => {
   const extension = name.includes('.')
     ? name.split('.').pop()
@@ -85,6 +87,7 @@ export const DialFileName: FC<DialFileNameProps> = ({
           className="text-primary dial-small flex-1 min-w-0"
           text={name}
           id="name"
+          hideTooltip={hideTooltip}
         />
         {details}
       </div>

--- a/src/components/FolderName/FolderName.tsx
+++ b/src/components/FolderName/FolderName.tsx
@@ -15,6 +15,7 @@ export interface DialFolderNameProps {
   className?: string;
   sharedIndicatorClassName?: string;
   sharedIndicatorTooltip?: ReactNode;
+  hideTooltip?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export const DialFolderName: FC<DialFolderNameProps> = ({
   iconSize = BASE_ICON_SIZE,
   sharedIndicatorClassName,
   sharedIndicatorTooltip,
+  hideTooltip = false,
 }) => {
   const getIcon = () => {
     if (loading) {
@@ -72,6 +74,7 @@ export const DialFolderName: FC<DialFolderNameProps> = ({
         className="text-primary dial-small flex-1 min-w-0"
         text={name}
         id="name"
+        hideTooltip={hideTooltip}
       />
     </div>
   );

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -223,8 +223,9 @@ export const DialGrid = <T extends object>({
     (p: ICellRendererParams<T, unknown>) => {
       if (p.data) {
         const rowId = getRowId(p.data);
-        const disabled =
-          !allowDisabledContextMenu && disabledRowIds?.has(rowId);
+        const isRowDisabled = disabledRowIds?.has(rowId) ?? false;
+        const isContextMenuDisabled =
+          isRowDisabled && !allowDisabledContextMenu;
         const valueText = p.value == null ? '' : String(p.value);
         const items = getContextMenuItems?.(p.data) ?? [];
 
@@ -235,13 +236,13 @@ export const DialGrid = <T extends object>({
             anchorToMouse
             matchReferenceWidth
             className="w-full"
-            disabled={disabled}
+            disabled={isContextMenuDisabled}
           >
             <span className="block min-w-0 h-full max-w-full">
               <DialEllipsisTooltip
                 text={valueText}
                 className="max-w-full h-full"
-                hideTooltip={disabled}
+                hideTooltip={isRowDisabled}
               />
             </span>
           </DialDropdown>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -237,6 +237,7 @@ export const DialGrid = <T extends object>({
               <DialEllipsisTooltip
                 text={valueText}
                 className="max-w-full h-full"
+                hideTooltip={disabled}
               />
             </span>
           </DialDropdown>

--- a/src/components/Grid/renderers/DateCellRenderer.tsx
+++ b/src/components/Grid/renderers/DateCellRenderer.tsx
@@ -19,6 +19,7 @@ export interface DialDateCellRendererProps
   options?: Intl.DateTimeFormatOptions;
   emptyPlaceholder?: string;
   className?: string;
+  hideTooltip?: boolean;
 }
 
 /**
@@ -48,6 +49,7 @@ export const DialDateCellRenderer: FC<DialDateCellRendererProps> = ({
   options = DEFAULT_DATE_FORMAT_OPTIONS,
   emptyPlaceholder,
   className,
+  hideTooltip = false,
 }) => {
   const date = convertToDate(value);
 
@@ -67,7 +69,7 @@ export const DialDateCellRenderer: FC<DialDateCellRendererProps> = ({
         iso ? <time dateTime={iso}>{content}</time> : <span>{content}</span>
       }
       className={classNames(dateCellBaseClassName, className)}
-      hideTooltip={false}
+      hideTooltip={hideTooltip}
     />
   );
 };

--- a/src/constants/file-grid-columns.tsx
+++ b/src/constants/file-grid-columns.tsx
@@ -135,6 +135,7 @@ export const NAME_COLUMN =
               updatedAt={params.data.updatedAt}
               dateLocale={dateLocale}
               dateOptions={dateOptions}
+              hideTooltip={isDisabled}
             />
           );
         }

--- a/src/constants/file-grid-columns.tsx
+++ b/src/constants/file-grid-columns.tsx
@@ -2,7 +2,10 @@ import { mergeClasses } from '@/utils/merge-classes';
 import { DialFileNodeType } from '@/models/file';
 import { DialFileName } from '@/components/FileName/FileName';
 import { DialFolderName } from '@/components/FolderName/FolderName';
-import { DialDateCellRenderer } from '@/components/Grid/renderers/DateCellRenderer';
+import {
+  DialDateCellRenderer,
+  type DialDateCellRendererProps,
+} from '@/components/Grid/renderers/DateCellRenderer';
 import { FileManagerRenameTriggerView } from '@/types/file-manager';
 import { DialFileManagerItemName } from '@/components/FileManager/components/FileManagerItemName/FileManagerItemName';
 import { DialItemType } from '@/types/item';
@@ -46,10 +49,12 @@ export const NAME_COLUMN =
           newFolderTempId,
           sharedByMePaths,
           selectedPaths,
+          disabledRowIds,
         } = params.context;
 
         const isSharedByMe = sharedByMePaths?.has(params.data.path);
         const isSelected = selectedPaths?.has(params.data.path);
+        const isDisabled = disabledRowIds?.has(params.data.path) ?? false;
 
         const sharedIndicatorClassName = mergeClasses([
           'group-hover/grid-row:bg-accent-primary-alpha',
@@ -140,6 +145,7 @@ export const NAME_COLUMN =
             shared={isSharedByMe}
             sharedIndicatorClassName={sharedIndicatorClassName}
             iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+            hideTooltip={isDisabled}
           />
         ) : (
           <DialFileName
@@ -147,6 +153,7 @@ export const NAME_COLUMN =
             shared={isSharedByMe}
             sharedIndicatorClassName={sharedIndicatorClassName}
             iconSize={BASE_FILE_MANAGER_ICON_SIZE}
+            hideTooltip={isDisabled}
           />
         );
       },
@@ -164,7 +171,11 @@ export const UPDATED_AT_COLUMN =
     headerName: headerName,
     width: 168,
     suppressSizeToFit: true,
-    cellRenderer: DialDateCellRenderer,
+    cellRenderer: (params: DialDateCellRendererProps) => {
+      const isDisabled =
+        params.context?.disabledRowIds?.has(params.data?.path) ?? false;
+      return <DialDateCellRenderer {...params} hideTooltip={isDisabled} />;
+    },
     cellRendererParams: {
       locale: dateLocale,
       options: dateOptions,


### PR DESCRIPTION
**Description and UI changes:**

Need to add a tooltip for files that do not meet size or type restrictions

Issues:

- Issue #557

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added