### PR TITLE
fix: reset conflict state after close popup and filters for grid

### DIFF
--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -82,7 +82,7 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
     ) : (
       <span
         className={mergeClasses(
-          'flex-1 min-w-0 max-w-full truncate cursor-pointer',
+          'flex-1 min-w-0 max-w-full truncate cursor-pointer max-w-[300px]',
           labelClassName,
         )}
         aria-label="breadcrumb-item-content"

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1286,6 +1286,14 @@ export const DialFileManagerView: FC = () => {
                   headerHeight: COMPACT_VIEW_HEADER_HEIGHT,
                   rowHeight: COMPACT_VIEW_HEADER_HEIGHT,
                   rowClass: 'group/grid-row',
+                  defaultColDef: {
+                    ...forwardedGridOptions.additionalGridOptions
+                      ?.defaultColDef,
+                    floatingFilter: navigationPanelOptions?.searchable
+                      ? false
+                      : forwardedGridOptions.additionalGridOptions
+                          ?.defaultColDef?.floatingFilter,
+                  },
                   ...(isCompactView
                     ? {
                         getRowHeight: (params) =>

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -162,12 +162,11 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
     strategyLabels?.[DialFileManagerConflictStrategies.DecideForEach] ??
     'Decide for each';
 
-  const [singleFileMode, setSingleFileMode] =
-    useState<DialFileManagerConflictActions>(
-      DialFileManagerConflictActions.Replace,
-    );
+  const [singleFileMode, setSingleFileMode] = useState(
+    DialFileManagerConflictActions.Replace,
+  );
 
-  const [strategy, setStrategy] = useState<DialFileManagerConflictStrategies>(
+  const [strategy, setStrategy] = useState(
     DialFileManagerConflictStrategies.ReplaceAll,
   );
   const [fileDecisions, setFileDecisions] = useState<
@@ -385,6 +384,8 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
   );
 
   const resetState = useCallback(() => {
+    setSingleFileMode(DialFileManagerConflictActions.Replace);
+    setStrategy(DialFileManagerConflictStrategies.ReplaceAll);
     setFileDecisions(
       new Map(
         conflictingFiles.map((file) => [


### PR DESCRIPTION
**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added