### PR TITLE
fix(file-manager): fix NOT_ALLOWED_SYMBOLS constant

### DIFF
--- a/src/components/FileManager/__mocks__/files.ts
+++ b/src/components/FileManager/__mocks__/files.ts
@@ -806,8 +806,8 @@ export const itemsMock: DialFile[] = [
           },
           {
             id: 'test-forbidden-symbols-hidden',
-            name: '.no"tes%s_test',
-            path: 'All files/Folder%%End/.no"tes%s_test',
+            name: '.notes\\s_test',
+            path: 'All files/Folder%%End/.notes\\s_test',
             parentPath: 'All files/Folder%%End',
             nodeType: DialFileNodeType.ITEM,
             resourceType: DialFileResourceType.FILE,

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-useless-escape
-export const NOT_ALLOWED_SYMBOLS = ':;,=/{}%&\"';
+export const NOT_ALLOWED_SYMBOLS = ':;,=/{}%&\\"';
 export const NOT_ALLOWED_SPACES = '(\r\n|\n|\r|\t)|[\x00-\x1F]';
 const NOT_ALLOWED_SYMBOLS_CHARACTER_CLASS = `[${NOT_ALLOWED_SYMBOLS.replace(/\\/g, '\\\\')}]`;
 export const NOT_ALLOWED_SYMBOLS_REGEXP = new RegExp(


### PR DESCRIPTION
**Description and UI changes:**

- Fix NOT_ALLOWED_SYMBOLS constant.


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added