### PR TITLE
fix(file-manager): fix search hidden file appearance (Issue #584)

### DIFF
--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -666,4 +666,58 @@ describe('Dial UI Kit :: FileManager', () => {
       });
     });
   });
+
+  test('search does NOT show files from hidden folders when hidden files toggle is off', async () => {
+    renderWithinSizedShell(
+      <DialFileManager
+        items={itemsMock}
+        defaultPath="All files"
+        showHiddenFiles={false}
+        treeOptions={{
+          expandedPaths: new Set([
+            'All files',
+            'All files/Design',
+            'All files/Design/Icons',
+            'All files/Design/Icons/SVG',
+            'All files/Design/Icons/SVG/24px',
+          ]),
+        }}
+        navigationPanelOptions={{ searchable: true }}
+      />,
+    );
+
+    const searchRegion = screen.getByRole('search', { name: 'Search' });
+    const searchInput = within(searchRegion).getByRole('textbox');
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, 'inside-hidden');
+
+    expect((await queryAllInGridByRowText('inside-hidden')).length).toBe(0);
+  });
+
+  test('search DOES show files from hidden folders when hidden files toggle is on', async () => {
+    renderWithinSizedShell(
+      <DialFileManager
+        items={itemsMock}
+        defaultPath="All files"
+        showHiddenFiles={true}
+        treeOptions={{
+          expandedPaths: new Set([
+            'All files',
+            'All files/Design',
+            'All files/Design/Icons',
+            'All files/Design/Icons/SVG',
+            'All files/Design/Icons/SVG/24px',
+          ]),
+        }}
+        navigationPanelOptions={{ searchable: true }}
+      />,
+    );
+
+    const searchRegion = screen.getByRole('search', { name: 'Search' });
+    const searchInput = within(searchRegion).getByRole('textbox');
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, 'inside-hidden');
+
+    expect(await findInGridByRowText('inside-hidden')).toBeInTheDocument();
+  });
 });

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -417,7 +417,10 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       }
 
       if (!areHiddenFilesVisible) {
-        source = source.filter((node) => !isHiddenDotFile(node));
+        source = source.filter((node) => {
+          const segments = node.path.split('/').filter(Boolean);
+          return !segments.some((segment) => segment.startsWith('.'));
+        });
       }
 
       return source.map((node) => ({
@@ -455,7 +458,13 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     }
 
     if (!areHiddenFilesVisible) {
-      source = source.filter((node) => !isHiddenDotFile(node));
+      source = source.filter((node) => {
+        if (query) {
+          const segments = node.path.split('/').filter(Boolean);
+          return !segments.some((segment) => segment.startsWith('.'));
+        }
+        return !isHiddenDotFile(node);
+      });
     }
 
     const mapped: FileManagerGridRow[] = source.map((node) => ({


### PR DESCRIPTION
**Description and UI changes:**

File from hidden folder should be displayed in search results only when Hidden files toggle is switched on

Issues:

- Issue #584 

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added