### PR TITLE
feat: [LoadAreaField] added props for custom button 

### DIFF
--- a/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.spec.tsx
@@ -39,6 +39,35 @@ describe('Dial UI Kit :: DialLoadFileAreaField', () => {
     expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
   });
 
+  test('Should render additional buttons near default actions', () => {
+    render(
+      <DialLoadFileAreaField
+        fieldTitle="Files"
+        elementId="file-input"
+        emptyTextFirstLine="empty"
+        emptyButtonLabel="Browse"
+        files={[new File([''], 'file1.png', { type: 'image/png' })]}
+        onChange={vi.fn()}
+        acceptTypes="image/png"
+        deleteAllButtonLabel="Delete All"
+        addButtonLabel="Add"
+        additionalActionButtons={
+          <button type="button" aria-label="extra-action">
+            Extra Action
+          </button>
+        }
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Delete All' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'extra-action' }),
+    ).toBeInTheDocument();
+  });
+
   test('Should call onChangeFile([]) when delete-all button is clicked', () => {
     const onChangeFile = vi.fn();
     render(

--- a/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
@@ -9,8 +9,10 @@ import {
   IconFileTypePdf,
   IconFileText,
   IconFileTypeSvg,
+  IconUpload,
 } from '@tabler/icons-react';
 import { BASE_ICON_PROPS } from '@/constants/icon';
+import { DialPrimaryButton } from '@/components/Button/ButtonWrappers';
 
 const meta: Meta<typeof DialLoadFileAreaField> = {
   title: 'Form/LoadFileAreaField',
@@ -51,6 +53,11 @@ const meta: Meta<typeof DialLoadFileAreaField> = {
       description: 'Label for delete-all button',
     },
     addButtonLabel: { control: 'text', description: 'Label for add button' },
+    additionalActionButtons: {
+      control: false,
+      description:
+        'Optional custom buttons or content rendered near the default action buttons',
+    },
     fileFormatError: {
       control: 'text',
       description: 'Displayed when an unsupported file is uploaded',
@@ -168,6 +175,31 @@ export const WithDynamicIcons: Story = {
     ];
 
     return <InteractiveLoadFileAreaField {...args} files={mockFiles} />;
+  },
+  args: {
+    ...Empty.args,
+  },
+};
+
+export const WithAdditionalButtons: Story = {
+  render: (args) => {
+    const mockFiles = [
+      new File(['text'], 'report.pdf', { type: 'application/pdf' }),
+      new File(['data'], 'notes.txt', { type: 'text/plain' }),
+    ];
+
+    return (
+      <InteractiveLoadFileAreaField
+        {...args}
+        files={mockFiles}
+        additionalActionButtons={
+          <DialPrimaryButton
+            label="Upload selected"
+            iconBefore={<IconUpload {...BASE_ICON_PROPS} />}
+          />
+        }
+      />
+    );
   },
   args: {
     ...Empty.args,

--- a/src/components/LoadFileArea/LoadFileAreaField.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.tsx
@@ -6,7 +6,13 @@ import { DialLabel } from '@/components/Label/Label';
 import { BASE_ICON_PROPS } from '@/constants/icon';
 import { ButtonAppearance } from '@/types/button';
 import { IconPlus, IconTrashX } from '@tabler/icons-react';
-import { type ChangeEvent, type FC, useCallback, useRef } from 'react';
+import {
+  type ChangeEvent,
+  type FC,
+  type ReactNode,
+  useCallback,
+  useRef,
+} from 'react';
 import { DialLoadFileArea, type DialLoadFileAreaProps } from './LoadFileArea';
 
 export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
@@ -14,6 +20,7 @@ export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
   elementId: string;
   deleteAllButtonLabel?: string;
   addButtonLabel?: string;
+  additionalActionButtons?: ReactNode;
 }
 
 /**
@@ -56,6 +63,7 @@ export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
  * @param {string} [props.acceptTypes] - Comma-separated list of allowed MIME types or file extensions.
  * @param {string} [props.deleteAllButtonLabel] - Label for the "Delete All" button shown when files exist.
  * @param {string} [props.addButtonLabel] - Label for the "Add" button used to select additional files.
+ * @param {ReactNode} [props.additionalActionButtons] - Optional custom buttons/content rendered next to default action buttons.
  * @param {object} [props.props] - Additional props passed to the underlying `DialLoadFileArea`.
  *
  * @returns {JSX.Element} A file upload field with label, action buttons, and a drag-and-drop area.
@@ -74,6 +82,7 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
   acceptTypes,
   deleteAllButtonLabel,
   addButtonLabel,
+  additionalActionButtons,
   ...props
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -150,6 +159,7 @@ export const DialLoadFileAreaField: FC<DialLoadFileAreaFieldProps> = ({
                 onClick={onAddFiles}
               />
             )}
+            {additionalActionButtons}
           </div>
         )}
       </div>


### PR DESCRIPTION
**Description and UI changes:**

<img width="1056" height="247" alt="image" src="https://github.com/user-attachments/assets/6dc4b227-9c14-404f-8b46-5ee9a4e895c3" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added