### PR TITLE
fix(file-manager): reset search results when creating folder or uploading files (Issue #589)

### DIFF
--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -824,5 +824,22 @@ describe('Dial UI Kit :: FileManager', () => {
       });
       expect((await queryAllInGridByRowText('SVG')).length).toBe(0);
     });
+
+    test('drag and drop clears the search text and results', async () => {
+      renderWithNewActions();
+      const searchInput = await typeSearchAndVerify();
+
+      fireEvent.drop(getGridRegion(), {
+        dataTransfer: {
+          files: [new File([''], 'test.txt', { type: 'text/plain' })],
+          types: ['Files'],
+        },
+      });
+
+      await waitFor(() => {
+        expect(searchInput).toHaveValue('');
+      });
+      expect((await queryAllInGridByRowText('SVG')).length).toBe(0);
+    });
   });
 });

--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -17,6 +17,7 @@ import {
   DialFilePermission,
   type DialFile,
 } from '@/models/file';
+import type { DropdownItem } from '@/models/dropdown';
 
 interface GridRowLike {
   name?: string;
@@ -152,6 +153,36 @@ vi.mock('@/components/Tooltip/TooltipContent', () => ({
       className={className}
     >
       {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ButtonDropdown/ButtonDropdown', () => ({
+  DialButtonDropdown: ({
+    label,
+    items,
+    disabled,
+  }: {
+    label?: string;
+    items: DropdownItem[];
+    disabled?: boolean;
+  }) => (
+    <div data-testid="mock-button-dropdown">
+      <button disabled={disabled}>{label}</button>
+      {items.map((item) => (
+        <button
+          key={item.key}
+          data-testid={`action-${item.key}`}
+          onClick={() =>
+            item.onClick?.({
+              key: item.key,
+              domEvent: {} as React.MouseEvent,
+            })
+          }
+        >
+          {item.label}
+        </button>
+      ))}
     </div>
   ),
 }));
@@ -721,48 +752,77 @@ describe('Dial UI Kit :: FileManager', () => {
     expect(await findInGridByRowText('inside-hidden')).toBeInTheDocument();
   });
 
-  test('New actions (New Folder) clear the search text and results', async () => {
-    renderWithinSizedShell(
-      <DialFileManager
-        items={itemsMock}
-        defaultPath="All files"
-        navigationPanelOptions={{ searchable: true }}
-        toolbarOptions={{
-          newActions: {
-            newFolder: { label: 'New Folder' },
-            uploadFiles: { label: 'Upload Files' },
-            uploadArchive: { label: 'Upload Archive' },
-          },
-        }}
-        treeOptions={{
-          expandedPaths: new Set([
-            'All files',
-            'All files/Design',
-            'All files/Design/Icons',
-            'All files/Design/Icons/SVG',
-          ]),
-        }}
-      />,
-    );
+  describe('New actions clear search', () => {
+    const renderWithNewActions = () =>
+      renderWithinSizedShell(
+        <DialFileManager
+          items={itemsMock}
+          defaultPath="All files"
+          navigationPanelOptions={{ searchable: true }}
+          toolbarOptions={{
+            newActions: {
+              newFolder: { label: 'New Folder' },
+              uploadFiles: { label: 'Upload Files' },
+              uploadArchive: { label: 'Upload Archive' },
+            },
+          }}
+          treeOptions={{
+            expandedPaths: new Set([
+              'All files',
+              'All files/Design',
+              'All files/Design/Icons',
+              'All files/Design/Icons/SVG',
+            ]),
+            showFiles: true,
+          }}
+        />,
+      );
 
-    const searchRegion = screen.getByRole('search', { name: 'Search' });
-    const searchInput = within(searchRegion).getByRole('textbox');
-    await userEvent.clear(searchInput);
-    await userEvent.type(searchInput, 'svg');
+    const typeSearchAndVerify = async () => {
+      const searchRegion = screen.getByRole('search', { name: 'Search' });
+      const searchInput = within(searchRegion).getByRole('textbox');
+      await userEvent.clear(searchInput);
+      await userEvent.type(searchInput, 'svg');
 
-    expect(await findInGridByRowText('SVG')).toBeInTheDocument();
-    expect(searchInput).toHaveValue('svg');
+      expect(await findInGridByRowText('SVG')).toBeInTheDocument();
+      expect(searchInput).toHaveValue('svg');
+      return searchInput;
+    };
 
-    const newButton = screen.getByRole('button', { name: 'New' });
-    await userEvent.click(newButton);
+    test('New Folder clears the search text and results', async () => {
+      renderWithNewActions();
+      const searchInput = await typeSearchAndVerify();
 
-    const newFolderMenuAction = await screen.findByRole('menuitem', {
-      name: 'New Folder',
+      await userEvent.click(screen.getByTestId('action-new-folder'));
+
+      await waitFor(() => {
+        expect(searchInput).toHaveValue('');
+      });
+      expect((await queryAllInGridByRowText('SVG')).length).toBe(0);
     });
-    await userEvent.click(newFolderMenuAction);
 
-    await waitFor(() => {
-      expect(searchInput).toHaveValue('');
+    test('Upload Files clears the search text and results', async () => {
+      renderWithNewActions();
+      const searchInput = await typeSearchAndVerify();
+
+      await userEvent.click(screen.getByTestId('action-upload-file'));
+
+      await waitFor(() => {
+        expect(searchInput).toHaveValue('');
+      });
+      expect((await queryAllInGridByRowText('SVG')).length).toBe(0);
+    });
+
+    test('Upload Archive clears the search text and results', async () => {
+      renderWithNewActions();
+      const searchInput = await typeSearchAndVerify();
+
+      await userEvent.click(screen.getByTestId('action-upload-archive'));
+
+      await waitFor(() => {
+        expect(searchInput).toHaveValue('');
+      });
+      expect((await queryAllInGridByRowText('SVG')).length).toBe(0);
     });
   });
 });

--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -720,4 +720,49 @@ describe('Dial UI Kit :: FileManager', () => {
 
     expect(await findInGridByRowText('inside-hidden')).toBeInTheDocument();
   });
+
+  test('New actions (New Folder) clear the search text and results', async () => {
+    renderWithinSizedShell(
+      <DialFileManager
+        items={itemsMock}
+        defaultPath="All files"
+        navigationPanelOptions={{ searchable: true }}
+        toolbarOptions={{
+          newActions: {
+            newFolder: { label: 'New Folder' },
+            uploadFiles: { label: 'Upload Files' },
+            uploadArchive: { label: 'Upload Archive' },
+          },
+        }}
+        treeOptions={{
+          expandedPaths: new Set([
+            'All files',
+            'All files/Design',
+            'All files/Design/Icons',
+            'All files/Design/Icons/SVG',
+          ]),
+        }}
+      />,
+    );
+
+    const searchRegion = screen.getByRole('search', { name: 'Search' });
+    const searchInput = within(searchRegion).getByRole('textbox');
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, 'svg');
+
+    expect(await findInGridByRowText('SVG')).toBeInTheDocument();
+    expect(searchInput).toHaveValue('svg');
+
+    const newButton = screen.getByRole('button', { name: 'New' });
+    await userEvent.click(newButton);
+
+    const newFolderMenuAction = await screen.findByRole('menuitem', {
+      name: 'New Folder',
+    });
+    await userEvent.click(newFolderMenuAction);
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('');
+    });
+  });
 });

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -341,11 +341,12 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
 
   const handleDrop = useCallback(
     (e: DragEvent) => {
+      handleSearchClear();
       const destinationFolder = currentPath ?? '';
       const existingFiles = currentFolder?.items ?? [];
       handleFileDropBase(e, destinationFolder, existingFiles);
     },
-    [currentPath, currentFolder, handleFileDropBase],
+    [currentPath, currentFolder, handleFileDropBase, handleSearchClear],
   );
 
   const openFileDialog = useCallback(() => {

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -233,6 +233,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     effectiveSearchValue,
     setSearchValue,
     handleSearchChange,
+    handleSearchClear,
     searchResultsRows,
   } = useFileSearch({
     onSearchFiles,
@@ -348,24 +349,33 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   );
 
   const openFileDialog = useCallback(() => {
+    handleSearchClear();
     const destinationFolder = currentPath ?? '';
     const existingFiles = currentFolder?.items ?? [];
     openFileDialogBase(destinationFolder, existingFiles);
-  }, [currentPath, currentFolder, openFileDialogBase]);
+  }, [currentPath, currentFolder, openFileDialogBase, handleSearchClear]);
 
   const openArchiveUpload = useCallback(() => {
+    handleSearchClear();
     const destinationFolder = currentPath ?? '';
     const existingFiles = currentFolder?.items ?? [];
     openArchiveDialog(destinationFolder, existingFiles);
-  }, [currentPath, currentFolder, openArchiveDialog]);
+  }, [currentPath, currentFolder, openArchiveDialog, handleSearchClear]);
 
   const customUploadFile = useCallback(() => {
+    handleSearchClear();
     customUploadFileAction?.(currentPath, currentFolder);
-  }, [customUploadFileAction, currentPath, currentFolder]);
+  }, [customUploadFileAction, currentPath, currentFolder, handleSearchClear]);
 
   const customCreateNewItem = useCallback(() => {
+    handleSearchClear();
     customCreateNewItemAction?.(currentPath, currentFolder);
-  }, [customCreateNewItemAction, currentPath, currentFolder]);
+  }, [
+    customCreateNewItemAction,
+    currentPath,
+    currentFolder,
+    handleSearchClear,
+  ]);
 
   const customDuplicateHandle = useCallback(
     (items: DialFile[]) => {
@@ -377,7 +387,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   const {
     isCreatingFolder,
     newFolderTempId,
-    startFolderCreation,
+    startFolderCreation: startFolderCreationBase,
     cancelFolderCreation,
     saveFolderCreation,
     validateFolderName,
@@ -387,6 +397,11 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     onValidateFolderName: onCreateFolderValidate,
     validationMessages: folderCreationValidationMessages,
   });
+
+  const startFolderCreation = useCallback(() => {
+    handleSearchClear();
+    startFolderCreationBase();
+  }, [handleSearchClear, startFolderCreationBase]);
 
   const { newActions, isNewButtonVisible, isNewButtonDisabled } = useNewActions(
     {


### PR DESCRIPTION
**Description and UI changes:**

Need to eliminate search results and text from search field when user click on New/New folder, New/Upload file, New/Upload archive

Issues:

- Issue #589 

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added