### PR TITLE
feat(file-manager): add `hiddenItemWarning` to the name validation function on create folder

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -466,7 +466,7 @@ export interface DialFileManagerProps {
  * @param [onAddChild] - Callback fired when when a new folder is added as a child to the selected folder
  *
  * @param [onRenameValidate] - Optional callback to validate a file or folder name during renaming. Should return an error message string if the name is invalid, or null if it's valid.
- * @param [renameValidationMessages] - Optional custom validation messages for renaming files and folders. Note that you need to add `warning__` prefix to the `hiddenItemWarning` message to display it as a warning with the warning icon.
+ * @param [renameValidationMessages] - Optional custom validation messages for renaming files and folders. Note that you need to add `${AlertVariant.Warning}__` prefix to the `hiddenItemWarning` message to display it as a warning with the warning icon.
  * @param [forbiddenSymbolsRegExp] - Optional RegExp will be used in the validation for the files and folders names. The "g" and "y" flags are not allowed in this RegExp and will be ignored.
  * @param [forbiddenSymbolsTooltip] - Optional tooltip displayed when a file or folder name contains forbidden characters
  *

--- a/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
+++ b/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
@@ -126,7 +126,7 @@ export const DialFileManagerItemNameInput: FC<
           ) : (
             <IconAlertTriangleFilled
               {...BASE_ICON_PROPS}
-              className="text-warning"
+              className="text-warning-icon"
               aria-label="warning"
             />
           ))}

--- a/src/components/FileManager/errors.ts
+++ b/src/components/FileManager/errors.ts
@@ -1,0 +1,5 @@
+import { AlertVariant } from '@/types/alert';
+
+export const DEFAULT_WARNINGS = {
+  hiddenItemWarning: `${AlertVariant.Warning}__A dot at the start of the name will make the item hidden`,
+};

--- a/src/components/FileManager/hooks/__tests__/use-item-renaming.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-item-renaming.spec.tsx
@@ -4,6 +4,7 @@ import { useItemRenaming } from '@/components/FileManager/hooks/use-item-renamin
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type { DialCopiedItem } from '@/models/file-manager';
+import { AlertVariant } from '@/types/alert';
 
 function buildTree(): DialFile[] {
   return [
@@ -530,7 +531,7 @@ describe('useItemRenaming hook', () => {
       const folderA = items[0].items![0]; // /root/A
       const error = result.current.renameValidateHandler('.hidden', folderA);
       expect(error).toBe(
-        'warning__A dot at the start of the name will make the item hidden',
+        `${AlertVariant.Warning}__A dot at the start of the name will make the item hidden`,
       );
     });
 

--- a/src/components/FileManager/hooks/use-folder-creation.tsx
+++ b/src/components/FileManager/hooks/use-folder-creation.tsx
@@ -3,10 +3,12 @@ import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type { DialUploadFileItem } from '@/models/file-manager';
 import { FOLDER_PLACEHOLDER_FILE_NAME } from '@/components/FileManager/constants';
+import { DEFAULT_WARNINGS } from '@/components/FileManager/errors';
 
 export interface FolderCreationValidationMessages {
   emptyName?: string;
   duplicateName?: string;
+  hiddenItemWarning?: string;
 }
 
 export interface UseFolderCreationProps {
@@ -36,6 +38,7 @@ const DEFAULT_VALIDATION_MESSAGES: Required<FolderCreationValidationMessages> =
   {
     emptyName: 'Folder name cannot be empty',
     duplicateName: 'A folder with this name already exists',
+    hiddenItemWarning: DEFAULT_WARNINGS.hiddenItemWarning,
   };
 
 export const useFolderCreation = ({
@@ -84,6 +87,10 @@ export const useFolderCreation = ({
 
       if (!trimmedName) {
         return messages.emptyName;
+      }
+
+      if (trimmedName.startsWith('.')) {
+        return messages.hiddenItemWarning;
       }
 
       if (currentFolder) {

--- a/src/components/FileManager/hooks/use-item-renaming.tsx
+++ b/src/components/FileManager/hooks/use-item-renaming.tsx
@@ -3,6 +3,7 @@ import type { DialCopiedItem } from '@/models/file-manager';
 import { useCallback, useState, useMemo } from 'react';
 import { findNodeByPath } from '@/components/FileManager/utils';
 import { DialFileNodeType } from '@/models/file';
+import { DEFAULT_WARNINGS } from '@/components/FileManager/errors';
 
 export interface RenameValidationMessages {
   emptyName?: string;
@@ -13,8 +14,7 @@ export interface RenameValidationMessages {
 const DEFAULT_VALIDATION_MESSAGES: Required<RenameValidationMessages> = {
   emptyName: 'Name cannot be empty',
   duplicateName: 'An item with this name already exists',
-  hiddenItemWarning:
-    'warning__A dot at the start of the name will make the item hidden',
+  hiddenItemWarning: DEFAULT_WARNINGS.hiddenItemWarning,
 };
 
 function trimTrailingSlashes(path: string): string {


### PR DESCRIPTION
**Description and UI changes:**

- Add `hiddenItemWarning` to the name validation function on create folder.


**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added