### PR TITLE
fix: [File manager] empty state for destination popup

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -135,6 +135,8 @@ export type DialFileManagerDestinationFolderPopupOptions = Pick<
   | 'onCreateFolderValidate'
   | 'folderCreationValidationMessages'
   | 'disabledPathTooltip'
+  | 'emptyStateTitle'
+  | 'emptyStateDescription'
 > & {
   getCopyHeader?: (itemsCount: number, itemName?: string) => string;
   getMoveHeader?: (itemsCount: number, itemName?: string) => string;


### PR DESCRIPTION
**Description and UI changes:**

added configurable empty state for destination popup

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added