### PR TITLE
feat: Add MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "ai-dial-ui-kit": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./dist/mcp-server.cjs"],
+      "env": {}
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The AI DIAL UI Kit is an production-ready React component library designed to st
 - [🚀 Usage in Projects](#-usage-in-projects)
   - [Next.js Integration](#nextjs-integration)
   - [Tree Shaking](#tree-shaking)
+- [🤖 AI Agent MCP Server](#-ai-agent-mcp-server)
 - [🤝 Contributing](#-contributing)
 - [🔒 Security](#-security)
 - [📄 License](#-license)
@@ -268,6 +269,12 @@ import '@epam/ai-dial-ui-kit/styles.css'; // Import styles separately
 // ❌ Avoid - Imports entire library
 import * as UIKit from '@epam/ai-dial-ui-kit';
 ```
+
+## 🤖 AI Agent MCP Server
+
+The AI DIAL UI Kit includes a built-in **MCP (Model Context Protocol) server** that enables AI agents to discover components, types, hooks, and utilities programmatically. This allows AI assistants to generate accurate, type-safe component code without hallucination.
+
+For setup, configuration, and detailed resources, see the [MCP Server Guide](./src/mcp/README.md).
 
 ## 🤝 Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,15 @@
         "react-dnd-html5-backend": "^16.0.1",
         "tailwind-merge": "^3.3.1"
       },
+      "bin": {
+        "ai-dial-ui-kit-mcp": "dist/mcp-server.cjs"
+      },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.3",
         "@eslint/compat": "^1.3.1",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.31.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@storybook/addon-a11y": "^10.2.17",
         "@storybook/addon-docs": "^10.2.17",
         "@storybook/addon-vitest": "^10.2.17",
@@ -36,6 +40,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.2.0",
+        "esbuild": "^0.25.9",
         "eslint": "^9.30.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "2.32.0",
@@ -72,6 +77,7 @@
       },
       "peerDependencies": {
         "@floating-ui/react": "^0.27.16",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@monaco-editor/react": "^4.7.0",
         "@tabler/icons-react": "^3.36.1",
         "@uiw/react-markdown-preview": "^5.1.5",
@@ -80,6 +86,11 @@
         "monaco-editor": "^0.52.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1253,6 +1264,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1670,6 +1694,71 @@
       }
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
@@ -4151,6 +4240,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4724,6 +4827,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4809,6 +4954,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -5322,12 +5477,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -5644,6 +5861,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5783,6 +6010,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.200",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
@@ -5805,6 +6039,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/entities": {
@@ -6077,6 +6321,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6678,12 +6929,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -6693,6 +6977,69 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/exsolve": {
@@ -6847,6 +7194,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -6901,6 +7270,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -6913,6 +7292,16 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -7600,6 +7989,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -7640,6 +8039,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -7763,6 +8183,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -7783,6 +8210,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8167,6 +8614,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8460,6 +8914,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8552,6 +9016,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9359,6 +9830,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9987,6 +10481,33 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -10155,6 +10676,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -10354,6 +10885,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -10510,6 +11064,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -10557,6 +11121,17 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10636,6 +11211,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -10905,6 +11490,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10913,6 +11512,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -10952,6 +11567,49 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/re-resizable": {
       "version": "6.11.2",
@@ -11723,6 +12381,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -12238,6 +12913,53 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -12286,6 +13008,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -12526,6 +13255,16 @@
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -13349,6 +14088,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -13500,6 +14249,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -13766,6 +14530,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unplugin": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
@@ -13846,6 +14620,16 @@
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -14417,6 +15201,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -14577,6 +15368,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
       "default": "./dist/index.css"
     }
   },
+  "bin": {
+    "ai-dial-ui-kit-mcp": "./dist/mcp-server.cjs"
+  },
   "files": [
     "dist"
   ],
@@ -32,8 +35,10 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build && npm run build:css",
+    "build": "vite build && npm run build:css && npm run build:manifest && npm run build:mcp",
     "build:css": "tailwindcss -m -i ./src/styles/tailwind-entry.scss -o ./dist/index.css",
+    "build:manifest": "tsx src/mcp/generate-manifest.ts",
+    "build:mcp": "node tools/build-mcp.mjs",
     "lint": "eslint . --ext ts,tsx --fix --report-unused-disable-directives --max-warnings 0",
     "lint:check": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "typecheck": "tsc --noEmit",
@@ -59,7 +64,7 @@
     ]
   },
   "overrides": {
-    "esbuild": "0.25.9",
+    "esbuild": "^0.25.9",
     "lodash": "4.18.1"
   },
   "dependencies": {
@@ -72,6 +77,7 @@
   },
   "peerDependencies": {
     "@floating-ui/react": "^0.27.16",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@monaco-editor/react": "^4.7.0",
     "@tabler/icons-react": "^3.36.1",
     "@uiw/react-markdown-preview": "^5.1.5",
@@ -81,11 +87,17 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@eslint/compat": "^1.3.1",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.31.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@storybook/addon-a11y": "^10.2.17",
     "@storybook/addon-docs": "^10.2.17",
     "@storybook/addon-vitest": "^10.2.17",
@@ -101,6 +113,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.2.0",
+    "esbuild": "^0.25.9",
     "eslint": "^9.30.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "2.32.0",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -29,6 +29,7 @@ export interface DialAlertProps extends HTMLAttributes<HTMLDivElement> {
 
 /**
  * A contextual feedback component for displaying important messages.
+ * aliases: Notification|StatusBanner
  *
  * Renders a colored container with an icon, message text, and an optional
  * close button.

--- a/src/components/AutocompleteInput/AutocompleteInputValue.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputValue.tsx
@@ -12,6 +12,8 @@ export interface DialAutocompleteInputValueProps {
 
 /**
  * A component that displays a list of selected items in a customizable, styled list. Each item is
+ * aliases: SelectedList|ItemDisplay
+ *
  * rendered as a button wrapped in a tooltip, allowing for truncation and additional context when
  * hovered. The component is flexible and supports custom CSS classes for styling the list and
  * individual list items.

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -34,6 +34,7 @@ export interface DialBreadcrumbProps {
 
 /**
  * Breadcrumb navigation component with horizontal scroll on overflow.
+ * aliases: NavigationPath|BreadcrumbTrail
  *
  * Use either the `pathItems` prop or compose with `<DialBreadcrumbItem/>` as children.
  * The last item is treated as the current page.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -36,6 +36,7 @@ export interface DialButtonProps
 
 /**
  * A Button component with flexible icon and text positioning
+ * aliases: ActionButton|CallToAction
  *
  * @example
  * ```tsx

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -13,6 +13,7 @@ export interface DialButtonDropdownProps
 
 /**
  * A Button dropdown component based on DialDropdown component
+ * aliases: SplitButton|MenuButton
  *
  * @example
  * ```tsx

--- a/src/components/CaptionText/CaptionText.tsx
+++ b/src/components/CaptionText/CaptionText.tsx
@@ -9,6 +9,7 @@ export interface DialCaptionTextProps extends HTMLAttributes<HTMLSpanElement> {
 
 /**
  * A component for displaying error messages with consistent styling
+ * aliases: HelperText|ValidationText
  *
  * @example
  * ```tsx

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -25,6 +25,7 @@ export interface DialCheckboxProps
 
 /**
  * A Checkbox component with styling options
+ * aliases: ToggleCheckbox|MultiSelectOption
  *
  * @example
  * ```tsx

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -13,6 +13,7 @@ export interface DialCloseButtonProps {
 }
 /**
  * A Close button component with a customizable icon and accessible label.
+ * aliases: DismissButton|ExitButton
  *
  * @example
  * ```tsx

--- a/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -30,6 +30,8 @@ const CLOSED_WIDTH = 48;
 
 /**
  * A collapsible horizontal bar component that allows toggling between an expanded and collapsed state.
+ * aliases: ToggleSidebar|CollapsiblePanel
+ *
  * It supports customizable width, title, icons, additional buttons, and flexible styling options.
  *
  * @example

--- a/src/components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -31,6 +31,7 @@ export interface DialConfirmationPopupProps extends DialPopupProps {
 
 /**
  * A confirmation dialog built with DialPopup and DialButton.
+ * aliases: ConfirmDialog|WarningDialog
  *
  * Provides an accessible modal with a title, optional description or custom content,
  * and a footer with Cancel / Confirm actions.

--- a/src/components/DraggableItem/DraggableItem.tsx
+++ b/src/components/DraggableItem/DraggableItem.tsx
@@ -21,6 +21,7 @@ export interface DialDraggableItemProps {
 
 /**
  * A lightweight wrapper that makes its children sortable via drag-and-drop.
+ * aliases: SortableItem|DragHandle
  *
  * Renders a row with a grab handle (left) and the provided content (right).
  * Integrates with `react-dnd` using a simple "column" drag type and delegates

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -78,6 +78,8 @@ export interface DialDropdownProps {
 /**
  *
  * Renders the given trigger (`children`) and a floating contextual menu overlay.
+ * aliases: ContextMenu|PopupMenu
+ *
  * Supports click/hover/contextMenu triggers, controlled/uncontrolled open, and an optional
  * close button inside the overlay. Placement is taken directly from Floating UI; when
  * `placement` is **undefined** (default), automatic placement is handled by `autoPlacement`.

--- a/src/components/EllipsisTooltip/EllipsisTooltip.tsx
+++ b/src/components/EllipsisTooltip/EllipsisTooltip.tsx
@@ -19,6 +19,8 @@ export interface DialEllipsisTooltipProps extends DialTooltipContainerOptions {
 
 /**
  * Single-line text with CSS ellipsis that shows a tooltip **only when actually truncated**.
+ * aliases: TruncatedText|TruncationTooltip
+ *
  * If the text fits, tooltip content is empty and the popup stays hidden.
  *
  * Important: width must be finite for truncation.

--- a/src/components/FileIcon/FileIcon.tsx
+++ b/src/components/FileIcon/FileIcon.tsx
@@ -18,6 +18,7 @@ export interface DialFileIconProps {
 
 /**
  * Renders a file-type icon based on a file extension.
+ * aliases: ExtensionIcon|TypeIcon
  *
  * Uses DialIcon to provide consistent icon wrapper styling.
  *

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -398,6 +398,7 @@ export interface DialFileManagerProps {
 
 /**
  * File Manager layout with a collapsible folders tree, breadcrumb/search header, and a data grid.
+ * aliases: FileExplorer|FileBrowser
  *
  * Features:
  * - Global `path` drives both the breadcrumb trail and the visible folder in the grid.

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -51,6 +51,7 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
 
 /**
  * DestinationFolderPopup
+ * aliases: FolderSelector|PathChooser
  *
  * A popup dialog for selecting a destination folder when copying or moving files.
  * Displays a File Manager interface with a footer containing action buttons and

--- a/src/components/FileName/FileName.tsx
+++ b/src/components/FileName/FileName.tsx
@@ -22,6 +22,8 @@ export interface DialFileNameProps {
 
 /**
  * Component to display a file name with a file icon and shared indicator.
+ * aliases: FileDisplay|NameDisplay
+ *
  * Handles long names with ellipsis and tooltip.
  *
  * If `details` is provided (e.g., file size, date), the component switches to

--- a/src/components/FolderName/FolderName.tsx
+++ b/src/components/FolderName/FolderName.tsx
@@ -23,6 +23,8 @@ export interface DialFolderNameProps {
 
 /**
  * Component to display a folder name with a folder icon and shared indicator.
+ * aliases: FolderDisplay|DirectoryName
+ *
  * Handles long names with ellipsis and tooltip.
  *
  * @example

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -24,6 +24,7 @@ export interface DialFormItemProps extends DialFormItemBaseProps {
 
 /**
  * A layout wrapper for form controls with label, helper text and error message.
+ * aliases: FieldWrapper|FormControl
  *
  * Uses `DialLabel` for the label and `DialErrorText` for consistent error styling.
  * Wires accessibility with:

--- a/src/components/FormPopup/FormPopup.tsx
+++ b/src/components/FormPopup/FormPopup.tsx
@@ -27,6 +27,7 @@ export interface DialFormPopupProps extends DialPopupProps {
 
 /**
  * A form-oriented popup dialog.
+ * aliases: FormDialog|FormModal
  *
  * Provides an accessible popup with a title, custom body,
  * and a footer with "Cancel" and "Submit" actions.

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -81,6 +81,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 
 /**
  * DialGrid — A feature-rich data grid wrapper built on ag-Grid with dark theme support.
+ * aliases: DataTable|TableGrid
  *
  * Provides a pre-configured grid with:
  * - Dark theme styling with CSS variable integration

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -8,6 +8,7 @@ export interface DialIconProps {
 
 /**
  * A wrapper component for rendering icons with consistent styling
+ * aliases: IconRenderer|SVGWrapper
  *
  * @example
  * ```tsx

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -30,6 +30,7 @@ export interface DialIconButtonProps
 
 /**
  * A Icon Button component with flexible icon and text positioning
+ * aliases: IconicButton|SymbolButton
  *
  * @example
  * ```tsx

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -50,6 +50,7 @@ export interface DialInputProps
 
 /**
  * A flexible input component with icon support and various styling options
+ * aliases: TextField|FormInput
  *
  * @example
  * ```tsx

--- a/src/components/InputPopup/InputPopup.tsx
+++ b/src/components/InputPopup/InputPopup.tsx
@@ -29,6 +29,8 @@ export interface DialInputPopupProps {
 
 /**
  * An input field that opens a popup when clicked, displaying a selected value or a list of values.
+ * aliases: PopupInput|ReadonlyInput
+ *
  * It supports read-only mode, error states, and disabled state, with customizable styling.
  * The modal content is rendered using a portal for seamless integration.
  *

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -16,6 +16,7 @@ export interface DialLabelProps extends NativeLabelProps {
 
 /**
  * A label component
+ * aliases: FormLabel|RequiredIndicator
  *
  * @example
  * ```tsx

--- a/src/components/LabelledText/LabelledText.tsx
+++ b/src/components/LabelledText/LabelledText.tsx
@@ -13,6 +13,7 @@ export interface DialLabelledTextProps {
 }
 /**
  * A label component for form fields with optional tooltip, content, and custom elements.
+ * aliases: LabelValue|DisplayText
  *
  * @example
  * ```tsx

--- a/src/components/LoadFileArea/LoadFileArea.tsx
+++ b/src/components/LoadFileArea/LoadFileArea.tsx
@@ -20,6 +20,8 @@ export interface DialLoadFileAreaProps extends DialEmptyFileAreaProps {
 
 /**
  * A drag-and-drop file upload area component that allows users to upload files
+ * aliases: FileDropZone|DragDropUpload
+ *
  * either by dragging them into the area or by selecting them through the file picker.
  * Displays helpful text, button prompts, and validation errors for file format or count limits.
  *

--- a/src/components/LoadFileArea/LoadFileAreaField.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.tsx
@@ -25,6 +25,8 @@ export interface DialLoadFileAreaFieldProps extends DialLoadFileAreaProps {
 
 /**
  * A composite file upload field that combines a label, file list management,
+ * aliases: UploadField|FileListField
+ *
  * and a drag-and-drop upload area. Allows users to add, remove, and validate files
  * with customizable restrictions on file types and count.
  *

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -15,6 +15,7 @@ export interface DialLoaderProps {
 
 /**
  * A simple loading spinner component.
+ * aliases: LoadingSpinner|ProgressSpinner
  *
  * Renders a spinning SVG with optional full-width container.
  *

--- a/src/components/NoDataContent/NoDataContent.tsx
+++ b/src/components/NoDataContent/NoDataContent.tsx
@@ -13,6 +13,7 @@ export interface DialNoDataContentProps {
 
 /**
  * A component for displaying a message and icon when there is no data to show.
+ * aliases: EmptyState|NoResults
  *
  * @example
  * ```tsx

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -11,6 +11,7 @@ export interface DialNumberInputProps extends Omit<DialInputProps, 'onChange'> {
 
 /**
  * A number input field component
+ * aliases: NumericField|NumberField
  *
  * @example
  * ```tsx

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -6,6 +6,7 @@ import { DialInput, type DialInputProps } from '@/components/Input/Input';
 
 /**
  * A password input component with show/hide functionality and customizable props.
+ * aliases: SecureInput|ToggleablePassword
  *
  * @example
  * ```tsx

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -43,6 +43,7 @@ export interface DialPopupProps {
 
 /**
  * An accessible modal dialog component using Floating UI.
+ * aliases: Modal|Dialog
  *
  * Renders in a portal with a scrim overlay, focus management, header with a title,
  * content area, optional footer and a close control.

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -18,6 +18,7 @@ export interface DialRadioButtonProps {
 
 /**
  * A stylized, accessible radio input with optional description.
+ * aliases: ChoiceOption|RadioInput
  *
  * Renders a native `<input type="radio" />` paired with a label. When `checked`
  * and `description` are provided, a supporting text block appears under the control.

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -34,6 +34,7 @@ export interface DialRadioGroupProps {
 
 /**
  * Groups multiple `DialRadio` options and renders custom content for the active option.
+ * aliases: SelectionGroup|OptionGroup
  *
  * Uses `DialField` as the field label and a container with `role="radiogroup"`.
  * Content provided in `radioButtons[].content` is shown under the currently active radio.

--- a/src/components/RadioGroupPopupField/RadioGroupPopupField.tsx
+++ b/src/components/RadioGroupPopupField/RadioGroupPopupField.tsx
@@ -37,6 +37,7 @@ export interface RadioGroupPopupFieldProps
 
 /**
  * A composite field that opens a popup with a radio group selector.
+ * aliases: PopupRadio|ChoicePopup
  *
  * Renders a labeled readout using `DialInputPopup`; when opened, a `DialPopup`
  * displays a `DialRadioGroup` allowing the user to pick from a list of options.

--- a/src/components/RemoveButton/RemoveButton.tsx
+++ b/src/components/RemoveButton/RemoveButton.tsx
@@ -14,6 +14,7 @@ export interface DialRemoveButtonProps
 
 /**
  * A specialized button component for removal or delete actions.
+ * aliases: DeleteButton|TrashButton
  *
  * Renders a `DialErrorButton` with a predefined trash icon (`IconTrashX`) as the leading icon.
  * Additional props are passed directly to the underlying `DialErrorButton`.

--- a/src/components/ResizableContainer/ConditionalResizableContainer.tsx
+++ b/src/components/ResizableContainer/ConditionalResizableContainer.tsx
@@ -11,6 +11,7 @@ export interface DialConditionalResizableContainerProps
 
 /**
  * DialConditionalResizableContainer — A conditional wrapper around `DialResizableContainer`.
+ * aliases: OptionalResize|ConditionalPanel
  *
  * This component renders its children inside a resizable container only when `enabled` is true.
  * When `enabled` is false, children are rendered directly without any resizable behavior.

--- a/src/components/ResizableContainer/ResizableContainer.tsx
+++ b/src/components/ResizableContainer/ResizableContainer.tsx
@@ -25,6 +25,8 @@ export interface DialResizableContainerProps {
 
 /**
  * DialResizableContainer — A reusable resizable container
+ * aliases: ResizePanel|SizableContainer
+ *
  * supporting both **controlled** and **uncontrolled** width modes.
  *
  * Controlled Mode

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -24,6 +24,8 @@ export interface DialSearchProps
 
 /**
  * A search input component with a customizable placeholder, icons, flexible props, and the ability
+ * aliases: SearchField|QueryInput
+ *
  * to clear the input value via a clear button. Supports multiple sizes for flexible layouts.
  *
  * @example

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -76,6 +76,7 @@ export interface DialSelectProps {
 
 /**
  * A versatile select supporting single and multiple selections.
+ * aliases: OptionPicker|ChoiceSelector
  *
  * Single mode mirrors the legacy visual:
  * - Trigger shows the selected option's leading icon + label.

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -19,6 +19,7 @@ export interface DialSelectFieldProps
 
 /**
  * A Select field wrapper that composes `DialFormItem` and `DialSelect`.
+ * aliases: SelectInput|ComboField
  *
  * Provides unified label, description, error rendering and a readonly view that shows
  * the selected option labels (comma-separated in single mode, list in multiple).

--- a/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
+++ b/src/components/SharedEntityIndicator/SharedEntityIndicator.tsx
@@ -17,6 +17,7 @@ export interface DialSharedEntityIndicatorProps {
 
 /**
  * A compact icon-only indicator to denote a "shared" entity.
+ * aliases: SharedIcon|AccessIndicator
  *
  * Renders a small arrow-up-right icon with token-based colors.
  *

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -31,6 +31,7 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
 
 /**
  * DialSkeleton
+ * aliases: PlaceholderUI|ShimmerLoader
  *
  * A placeholder component to show while content is loading.
  * Provides various skeleton shapes and configurations.

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -11,6 +11,7 @@ export interface DialStepsProps {
 
 /**
  * Props for the DialSteps component, which renders a multi-step navigation UI.
+ * aliases: StepWizard|ProgressSteps
  *
  * @example
  * ```tsx

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -12,6 +12,7 @@ export interface DialSwitchProps {
 
 /**
  * A Switch component with various styling options
+ * aliases: ToggleSwitch|BinaryToggle
  *
  * @example
  * ```tsx

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -36,6 +36,8 @@ export interface DialTabsProps {
 
 /**
  * A responsive and overflow-aware tabs component that automatically adapts its layout
+ * aliases: TabNavigation|TabBar
+ *
  * between a scrollable tab bar and a dropdown menu on smaller screens.
  *
  * When there are too many tabs to fit in a single line, it introduces a dropdown button

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -19,6 +19,8 @@ export interface DialTagProps {
 
 /**
  * A small tag component used to display labeled items such as categories, filters, or selections.
+ * aliases: Badge|Chip
+ *
  * Optionally supports removal via a close button and multiple colors variants defined by {@link TagVariant}.
  *
  * @example

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -33,6 +33,8 @@ export interface DialTagInputProps extends DialLabelProps {
 
 /**
  * A tag input field that allows users to add multiple tags using the Enter or comma key.
+ * aliases: MultiTag|TagField
+ *
  * Supports removing tags, displaying field labels, optional indicators, validation states,
  * and dynamic layout adjustment when tags wrap to multiple lines.
  *

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -27,6 +27,7 @@ export interface DialTextareaProps
 
 /**
  * A flexible textarea component with validation support and consistent styling
+ * aliases: MultilineInput|TextBox
  *
  * @example
  * ```tsx

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -16,6 +16,7 @@ export interface DialTooltipProps extends DialTooltipContainerOptions {
 
 /**
  * A Tooltip component that displays information on hover
+ * aliases: HoverPopover|InfoPopover
  *
  * @example
  * ```tsx

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,236 @@
+# MCP Server for @epam/ai-dial-ui-kit
+
+An MCP (Model Context Protocol) server that gives AI agents fast, structured access to the UI kit's component library — shipped inside the npm package, zero extra setup.
+
+## Why
+
+Storybook documents components for humans. The MCP server documents them for AI agents. When an AI assistant needs to build a UI with your components, it can:
+
+- **Discover all available components** — Button, Input, Dropdown, FileManager, Form, etc.
+- **Read exact props and types** — required fields, defaults, enums, component-specific behaviors
+- **Access code examples** — copy-paste usage patterns for common scenarios
+- **Query theming & typography** — available design tokens, CSS classes, color variables
+
+This lets agents generate accurate, type-safe, on-brand component code without guessing or hallucinating APIs.
+
+## Quick Start
+
+### 1. Install the peer dependency
+
+```bash
+npm install @modelcontextprotocol/sdk
+```
+
+### 2. Add to MCP configuration
+Add the following code to mcp file servers root according to the tool you use:
+
+```json
+{
+    "ai-dial-ui-kit": {
+      "command": "node",
+      "args": ["./node_modules/@epam/ai-dial-ui-kit/dist/mcp-server.cjs"]
+    }
+}
+```
+
+| Tool | MCP config location | Root field name |
+|---|---|---|
+| Claude Code CLI | `.mcp.json` | mcpServers |
+| Cursor | `.cursor/mcp.json` | mcpServers |
+| GitHub Copilot | `.vscode/mcp.json` | servers|
+
+Example of the full config (for Claude Code)
+```json
+{
+  "mcpServers": {
+     "ai-dial-ui-kit": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./node_modules/@epam/ai-dial-ui-kit/dist/mcp-server.cjs"]
+    }
+  }
+}
+```
+
+### 3. Restart your AI agent
+
+The MCP server is now available. Agents can discover and use components.
+
+### 4. Add instruction to use the mcp
+
+Place the following instruction in your instructions file (AGENTS.md, CLAUDE.md, or project-specific `.instructions.md`):
+
+```markdown
+## When working with @epam/ai-dial-ui-kit
+
+When implementing or modifying components, forms, or UI built with `@epam/ai-dial-ui-kit`, the `ai-dial-ui-kit` MCP server enables you to discover components, read exact prop signatures, access code examples, and understand design tokens and available utilities.
+
+## Component-First Development
+
+**Always prefer UI kit components over raw HTML elements.** Before reaching for native `<button>`, `<input>`, `<select>`, or other HTML elements:
+
+1. **Look for a UI kit component** — Check if a suitable `Dial*` component exists for your use case
+2. **Use raw elements only as last resort** — If and only if no UI kit component meets the requirements, use native HTML (and document why)
+
+## MCP Tools
+
+Use these two tools for all UI kit discovery and documentation needs: `searchEntity(entity, query?)` and `getEntityDetails(entity, name?)`. If you need to look up **ANYTHING** about the ui kit, use the MCP server. **Never** use rg/ls commands for the ui kit module inspection.
+
+> **Note:** Do not use `grep`, `glob`, `find`, or similar file system tools to discover components. The MCP tools provide accurate, structured metadata. File system searches miss examples, miss type information, and are slower.
+```
+
+## How It Works
+
+### Tools
+
+| Tool | Purpose |
+|---|---|
+| `searchEntity` | Search any entity category by name/description. Returns a summary list. |
+| `getEntityDetails` | Fetch full documentation for a specific entity by exact name. |
+
+Both tools accept an `entity` enum parameter:
+
+| Value | Content |
+|---|---|
+| `component` | React components (all start with `Dial`) — props, examples, categories |
+| `hook` | React hooks and context providers — signatures, descriptions |
+| `util` | Utility functions — signatures, descriptions |
+| `type` | Exported TypeScript types, interfaces, and enums — members, values |
+| `constant` | Exported constants — values, descriptions |
+| `typography` | Full CSS utility class reference (`.dial-h1-text`, `.dial-small-text`, etc.) |
+| `theming` | Full theme token system — CSS variable names, color tokens, Tailwind mapping |
+
+## Example: Building a File Upload Form
+
+```
+User: "Build a file upload form with validation and error messages"
+
+Agent:
+  1. Calls searchEntity("component", "file upload")
+  2. Finds DialFileInput, DialFormItem, DialButton, DialAlert
+  3. Calls getEntityDetails("component", "DialFileInput")  → props, examples
+  4. Calls getEntityDetails("component", "DialFormItem")   → how to wire up validation
+  5. Calls getEntityDetails("component", "DialAlert")      → error display
+  6. Generates complete form code with types and error handling
+```
+
+## Distribution
+
+The MCP server ships **inside `@epam/ai-dial-ui-kit`**:
+
+- `dist/mcp-server.cjs` — compiled Node.js server
+- `dist/components-manifest.json` — pre-built component metadata
+
+`@modelcontextprotocol/sdk` is an **optional peer dependency** — not auto-installed. Users who want to use the MCP server install it explicitly.
+
+## Architecture
+
+The manifest is **generated at build time** by parsing `src/index.ts` (source of truth for public exports):
+
+1. **Parse exports** — enumerate components, types, hooks, utils, constants
+2. **Extract metadata** — for each export:
+   - Props: from TypeScript interfaces + JSDoc `@param` tags
+   - Description: from JSDoc first paragraph
+   - Examples: from JSDoc `@example` fenced code blocks
+   - Category: from paired `.stories.tsx` file's `title` field
+3. **Build manifest** — write `dist/components-manifest.json`
+4. **Compile server** — bundle `src/mcp/server.ts` → `dist/mcp-server.cjs`
+
+See [Manifest Schema](#manifest-schema) for details.
+
+## Manifest Schema
+
+```ts
+interface Manifest {
+  version: string;
+  generatedAt: string;
+  kit: {
+    name: string;
+    installation: string;        // "npm install @epam/ai-dial-ui-kit"
+    cssImport: string;           // "import '@epam/ai-dial-ui-kit/styles.css'"
+    peerDependencies: Record<string, string>;
+    setupNotes: string;          // Next.js / Vite integration notes
+  };
+  styles: string;                // typography CSS class reference (markdown)
+  theming: string;               // theming/token reference (markdown)
+  components: ComponentEntry[];
+  types: TypeEntry[];
+  hooks: ExportEntry[];
+  utils: ExportEntry[];
+  constants: ExportEntry[];
+}
+
+interface ComponentEntry {
+  name: string;                  // "DialButton"
+  category: string;              // from stories title
+  description: string;           // first JSDoc paragraph
+  props: {
+    name: string;
+    type: string;                // TypeScript type
+    required: boolean;
+    defaultValue?: string;
+    description?: string;        // from JSDoc @param
+  }[];
+  examples: string[];            // TSX from JSDoc @example
+  sourceFile: string;            // path in src/
+}
+
+interface TypeEntry {
+  name: string;
+  kind: 'enum' | 'interface' | 'type';
+  description?: string;
+  members?: { name: string; value: string; comment?: string }[];
+  typeBody?: string;             // RHS for type aliases
+  sourceFile: string;
+}
+
+interface ExportEntry {
+  name: string;
+  description?: string;          // from JSDoc
+  signature?: string;            // type signature
+  sourceFile: string;
+}
+```
+
+## Troubleshooting
+
+**MCP server won't start: "Cannot find module `@modelcontextprotocol/sdk`"**
+- Install the peer dependency: `npm install @modelcontextprotocol/sdk`
+
+**Manifest not generated or is stale**
+- Ensure `npm run build:manifest` runs as part of the build
+- When developing locally, run `npm run build:manifest` after modifying components
+
+**Component doesn't appear in discoveries**
+- Verify it's exported from `src/index.ts`
+- Check that the component file has a JSDoc comment on the component declaration
+- Run `npm run build:manifest` to regenerate
+- **To improve discoverability**: add search aliases in the JSDoc description. For example, if the component is `DialFileInput`, add "FileUpload|FilePicker" to the description so agents can find it by those terms
+
+**Props table is empty for a component**
+- Component must define a `{ComponentName}Props` interface (e.g., `DialButtonProps`)
+- Add JSDoc `@param` tags on the component declaration for descriptions
+
+**Agents confuse similar components or pick the wrong one**
+- Improve JSDoc descriptions to clearly distinguish purpose and use cases
+- Example: for `DialInput` vs `DialTextarea`, explicitly describe when to use each (single-line vs multi-line, character limits, resize behavior, etc.)
+- Add `@example` blocks showing common, realistic usage patterns that highlight the differences
+
+## Files
+
+```
+src/mcp/
+  README.md               ← this file
+  types.ts                ← manifest schema types
+  generate-manifest.ts    ← build-time manifest generator
+  server.ts               ← MCP server entry point
+```
+
+## Build Scripts
+
+```jsonc
+// package.json:
+"build:manifest": "tsx src/mcp/generate-manifest.ts",
+"build:mcp":      "esbuild src/mcp/server.ts --bundle --platform=node --format=cjs --external:@modelcontextprotocol/sdk --outfile=dist/mcp-server.cjs",
+"build":          "<existing> && npm run build:manifest && npm run build:mcp"
+```

--- a/src/mcp/descriptions/theming.md
+++ b/src/mcp/descriptions/theming.md
@@ -1,0 +1,44 @@
+# Theming & CSS Variable Tokens
+
+AI DIAL UI Kit uses CSS custom properties (variables) for theming.
+Dark and light themes are switched by setting different values for these variables on `:root` or a theme wrapper element.
+
+## Usage in Tailwind
+
+The Tailwind config maps CSS variables to utility classes.
+Use these classes in your components:
+
+```tsx
+// Backgrounds
+<div className="bg-layer-0" />   // darkest background
+<div className="bg-layer-1" />   // main content area
+<div className="bg-layer-2" />   // elevated panels
+
+// Text
+<span className="text-primary" />    // main text color
+<span className="text-secondary" />  // muted text
+<span className="text-error" />      // error state
+
+// Borders
+<div className="border border-primary" />  // standard border
+<div className="border border-error" />    // error border
+```
+
+## Override CSS Variables
+
+```css
+:root {
+  --bg-layer-0: #000000;
+  --bg-layer-1: #0C101D;
+  --bg-layer-2: #161B2D;
+  --bg-layer-3: #1D2439;
+  --text-primary: #EEF1F7;
+  --text-secondary: #9FA6BD;
+  --text-error: #F76464;
+  --stroke-primary: #696E7C;
+  --controls-bg-accent-primary: #3664E2;
+  /* ... see tailwind.config.js for full list */
+}
+```
+
+## Token Reference

--- a/src/mcp/descriptions/theming.md
+++ b/src/mcp/descriptions/theming.md
@@ -29,14 +29,14 @@ Use these classes in your components:
 ```css
 :root {
   --bg-layer-0: #000000;
-  --bg-layer-1: #0C101D;
-  --bg-layer-2: #161B2D;
-  --bg-layer-3: #1D2439;
-  --text-primary: #EEF1F7;
-  --text-secondary: #9FA6BD;
-  --text-error: #F76464;
-  --stroke-primary: #696E7C;
-  --controls-bg-accent-primary: #3664E2;
+  --bg-layer-1: #0c101d;
+  --bg-layer-2: #161b2d;
+  --bg-layer-3: #1d2439;
+  --text-primary: #eef1f7;
+  --text-secondary: #9fa6bd;
+  --text-error: #f76464;
+  --stroke-primary: #696e7c;
+  --controls-bg-accent-primary: #3664e2;
   /* ... see tailwind.config.js for full list */
 }
 ```

--- a/src/mcp/descriptions/typography.md
+++ b/src/mcp/descriptions/typography.md
@@ -1,0 +1,27 @@
+# Typography CSS Utility Classes
+
+## Design-system-compliant classes (`dial-*-text`)
+
+Use these by default. They follow the design system type scale.
+
+| Class                   | Weight   | Size / Line-height      |
+| ----------------------- | -------- | ----------------------- |
+| `.dial-display1-text`   | semibold | 32px / 48px             |
+| `.dial-display2-text`   | semibold | 28px / 40px             |
+| `.dial-h1-text`         | semibold | 22px / 32px             |
+| `.dial-h2-text`         | semibold | 20px / 28px             |
+| `.dial-h3-text`         | semibold | 18px / 26px             |
+| `.dial-body-text`       | normal   | 16px / 24px             |
+| `.dial-body-semi-text`  | semibold | 16px / 24px             |
+| `.dial-small-text`      | normal   | 14px / 20px             |
+| `.dial-small-semi-text` | semibold | 14px / 20px             |
+| `.dial-tiny-text`       | normal   | 12px / 16px             |
+| `.dial-tiny-semi-text`  | semibold | 12px / 16px             |
+| `.dial-caption-text`    | normal   | 10px / 12px             |
+| `.dial-code-text`       | normal   | 14px / 20px (monospace) |
+
+## Legacy classes (avoid in new code)
+
+Classes like `dial-h1`, `dial-h2`, `dial-body`, `dial-small*`, `dial-tiny*`, `dial-caption` are legacy. They can be used in legacy projects if user explicidly specify they need legacy typography.
+
+## Raw SCSS source

--- a/src/mcp/generate-manifest.ts
+++ b/src/mcp/generate-manifest.ts
@@ -1,0 +1,659 @@
+/* eslint-disable no-console */
+import * as ts from 'typescript';
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+} from 'fs';
+import { resolve, join, dirname, relative, extname } from 'path';
+import type {
+  Manifest,
+  ComponentEntry,
+  TypeEntry,
+  ExportEntry,
+  PropEntry,
+  TypeMember,
+  KitInfo,
+} from './types.ts';
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src');
+const DIST = join(ROOT, 'dist');
+const INDEX_PATH = join(SRC, 'index.ts');
+
+// ─── AST helpers ──────────────────────────────────────────────────────────────
+
+interface WithJSDoc {
+  jsDoc?: ts.JSDoc[];
+}
+
+function getJsDocs(node: ts.Node): ts.JSDoc[] {
+  return (node as unknown as WithJSDoc).jsDoc ?? [];
+}
+
+function jsDocText(comment: ts.JSDoc['comment']): string {
+  if (comment === undefined) return '';
+  if (typeof comment === 'string') return comment;
+  interface HasText {
+    text?: string;
+  }
+  return Array.from(comment)
+    .map((c) => (c as HasText).text ?? '')
+    .join('');
+}
+
+interface JSDocInfo {
+  description: string;
+  examples: string[];
+  params: Map<string, string>;
+}
+
+function extractJsDocInfo(node: ts.Node, sf: ts.SourceFile): JSDocInfo {
+  const jsDocs = getJsDocs(node);
+  let description = '';
+  const examples: string[] = [];
+  const params = new Map<string, string>();
+
+  for (const jsDoc of jsDocs) {
+    if (!description) {
+      description = jsDocText(jsDoc.comment).trim();
+    }
+
+    for (const tag of jsDoc.tags ?? []) {
+      if (tag.tagName.text === 'example') {
+        const raw = jsDocText(tag.comment);
+        const codeRe = /```(?:tsx|ts|jsx|js)?\n?([\s\S]*?)```/g;
+        let m: RegExpExecArray | null;
+        let found = false;
+        while ((m = codeRe.exec(raw)) !== null) {
+          examples.push(m[1].trim());
+          found = true;
+        }
+        if (!found && raw.trim()) {
+          examples.push(raw.trim());
+        }
+      }
+
+      if (ts.isJSDocParameterTag(tag)) {
+        const paramName = ts.isIdentifier(tag.name)
+          ? tag.name.text
+          : tag.name.getText(sf);
+        const paramDesc = jsDocText(tag.comment).replace(/^-\s*/, '').trim();
+        if (paramDesc) params.set(paramName, paramDesc);
+      }
+    }
+  }
+
+  return { description, examples, params };
+}
+
+// ─── file helpers ─────────────────────────────────────────────────────────────
+
+function readSf(filePath: string): ts.SourceFile {
+  const content = readFileSync(filePath, 'utf-8');
+  return ts.createSourceFile(filePath, content, ts.ScriptTarget.ES2022, true);
+}
+
+function resolveModulePath(spec: string, fromDir: string): string | null {
+  const base = resolve(fromDir, spec);
+
+  // Direct hit (spec already has extension)
+  if (existsSync(base)) return base;
+
+  // Try common extensions
+  for (const ext of ['.tsx', '.ts', '.jsx', '.js']) {
+    const p = base + ext;
+    if (existsSync(p)) return p;
+  }
+
+  // Try index files
+  for (const ext of ['.tsx', '.ts', '.js']) {
+    const p = join(base, `index${ext}`);
+    if (existsSync(p)) return p;
+  }
+
+  return null;
+}
+
+function relSrc(absPath: string): string {
+  return relative(SRC, absPath).replace(/\\/g, '/');
+}
+
+// ─── index.ts parsing ─────────────────────────────────────────────────────────
+
+interface IndexExport {
+  name: string;
+  isTypeOnly: boolean;
+  resolvedPath: string;
+  section: string;
+}
+
+function buildSectionMap(content: string): string[] {
+  const lines = content.split('\n');
+  const sections: string[] = [];
+  let current = 'component';
+
+  for (const line of lines) {
+    const m = line.trim().match(/^\/\/\s*(.+)$/);
+    if (m) {
+      const s = m[1].toLowerCase();
+      if (s.includes('constant')) current = 'constants';
+      else if (s.includes('util')) current = 'utils';
+      else if (
+        s.includes('model') &&
+        !s.includes('file') &&
+        !s.includes('component')
+      )
+        current = 'models';
+      else if (s.includes('type') && !s.includes('file')) current = 'types';
+      else if (
+        s.includes('hook') ||
+        s.includes('context') ||
+        s.includes('provider')
+      )
+        current = 'hooks';
+      else current = 'component';
+    }
+    sections.push(current);
+  }
+
+  return sections;
+}
+
+function parseIndexFile(): IndexExport[] {
+  const content = readFileSync(INDEX_PATH, 'utf-8');
+  const sf = readSf(INDEX_PATH);
+  const indexDir = dirname(INDEX_PATH);
+  const sectionByLine = buildSectionMap(content);
+  const records: IndexExport[] = [];
+
+  ts.forEachChild(sf, (node) => {
+    if (!ts.isExportDeclaration(node)) return;
+    if (!node.moduleSpecifier || !node.exportClause) return;
+    if (!ts.isNamedExports(node.exportClause)) return;
+
+    const moduleSpec = (node.moduleSpecifier as ts.StringLiteral).text;
+    const resolvedPath = resolveModulePath(moduleSpec, indexDir);
+    if (!resolvedPath) {
+      console.warn(`Could not resolve: ${moduleSpec}`);
+      return;
+    }
+
+    const startLine = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line;
+    const section = sectionByLine[startLine] ?? 'component';
+
+    for (const element of node.exportClause.elements) {
+      const isTypeOnly = node.isTypeOnly || element.isTypeOnly;
+      const name = element.name.text;
+      records.push({ name, isTypeOnly, resolvedPath, section });
+    }
+  });
+
+  return records;
+}
+
+// ─── component extraction ─────────────────────────────────────────────────────
+
+function extractDestructuringDefaults(
+  sf: ts.SourceFile,
+  componentName: string,
+): Map<string, string> {
+  const defaults = new Map<string, string>();
+
+  ts.forEachChild(sf, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== componentName)
+        continue;
+      const init = decl.initializer;
+      if (!init || !ts.isArrowFunction(init)) continue;
+      const param = init.parameters[0];
+      if (!param || !ts.isObjectBindingPattern(param.name)) continue;
+      for (const element of param.name.elements) {
+        if (!element.initializer) continue;
+        const elemName = ts.isIdentifier(element.name)
+          ? element.name.text
+          : element.name.getText(sf);
+        defaults.set(elemName, element.initializer.getText(sf));
+      }
+    }
+  });
+
+  return defaults;
+}
+
+function extractProps(
+  sf: ts.SourceFile,
+  interfaceName: string,
+  paramDescs: Map<string, string>,
+  defaults: Map<string, string>,
+): PropEntry[] {
+  const props: PropEntry[] = [];
+
+  ts.forEachChild(sf, (node) => {
+    if (!ts.isInterfaceDeclaration(node) || node.name.text !== interfaceName)
+      return;
+
+    for (const member of node.members) {
+      if (!ts.isPropertySignature(member) || !member.name) continue;
+      const name = ts.isIdentifier(member.name)
+        ? member.name.text
+        : member.name.getText(sf);
+      const type = member.type?.getText(sf) ?? 'unknown';
+      const required = !member.questionToken;
+      const defaultValue = defaults.get(name);
+      const description = paramDescs.get(name);
+
+      const entry: PropEntry = { name, type, required };
+      if (defaultValue !== undefined) entry.defaultValue = defaultValue;
+      if (description !== undefined) entry.description = description;
+      props.push(entry);
+    }
+  });
+
+  return props;
+}
+
+function getStoryCategory(sourceFilePath: string): string {
+  const dir = dirname(sourceFilePath);
+
+  let storyFile: string | undefined;
+  try {
+    storyFile = readdirSync(dir).find(
+      (f) => f.endsWith('.stories.tsx') || f.endsWith('.stories.ts'),
+    );
+  } catch {
+    // no-op
+  }
+
+  if (!storyFile) {
+    // Fallback: use parent folder name
+    const parts = dir.replace(/\\/g, '/').split('/');
+    const idx = parts.lastIndexOf('components');
+    return idx >= 0 && idx + 1 < parts.length ? parts[idx + 1] : 'Other';
+  }
+
+  const storyContent = readFileSync(join(dir, storyFile), 'utf-8');
+  const titleMatch = storyContent.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
+  if (!titleMatch) return 'Other';
+
+  const parts = titleMatch[1].split('/');
+  // Strip leading 'DIAL' and trailing component name → keep middle categories
+  const start = parts[0].toUpperCase() === 'DIAL' ? 1 : 0;
+  const middle = parts.slice(start, -1);
+  return middle.length > 0 ? middle.join('/') : (parts[start] ?? 'Other');
+}
+
+function buildComponentEntry(rec: IndexExport): ComponentEntry | null {
+  const sf = readSf(rec.resolvedPath);
+  let description = '';
+  let examples: string[] = [];
+  let paramDescs = new Map<string, string>();
+  let found = false;
+
+  ts.forEachChild(sf, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== rec.name) continue;
+      found = true;
+      const info = extractJsDocInfo(node, sf);
+      description = info.description;
+      examples = info.examples;
+      paramDescs = info.params;
+    }
+  });
+
+  // Fallback: function declaration (some wrapper components)
+  if (!found) {
+    ts.forEachChild(sf, (node) => {
+      if (!ts.isFunctionDeclaration(node) || node.name?.text !== rec.name)
+        return;
+      found = true;
+      const info = extractJsDocInfo(node, sf);
+      description = info.description;
+      examples = info.examples;
+      paramDescs = info.params;
+    });
+  }
+
+  if (!found) return null;
+
+  const defaults = extractDestructuringDefaults(sf, rec.name);
+  const propsInterfaceName = `${rec.name}Props`;
+  const props = extractProps(sf, propsInterfaceName, paramDescs, defaults);
+  const category = getStoryCategory(rec.resolvedPath);
+
+  return {
+    name: rec.name,
+    category,
+    description,
+    props,
+    examples,
+    sourceFile: relSrc(rec.resolvedPath),
+  };
+}
+
+// ─── type extraction ──────────────────────────────────────────────────────────
+
+function buildTypeEntry(rec: IndexExport): TypeEntry | null {
+  const sf = readSf(rec.resolvedPath);
+  let result: TypeEntry | null = null;
+
+  ts.forEachChild(sf, (node) => {
+    if (result) return;
+
+    if (ts.isEnumDeclaration(node) && node.name.text === rec.name) {
+      const { description } = extractJsDocInfo(node, sf);
+      const members: TypeMember[] = node.members.map((member) => {
+        const name = ts.isIdentifier(member.name)
+          ? member.name.text
+          : member.name.getText(sf);
+        const value = member.initializer?.getText(sf) ?? '';
+        const { description: comment } = extractJsDocInfo(member, sf);
+        const entry: TypeMember = { name, value };
+        if (comment) entry.comment = comment;
+        return entry;
+      });
+
+      result = {
+        name: rec.name,
+        kind: 'enum',
+        members,
+        sourceFile: relSrc(rec.resolvedPath),
+      };
+      if (description) result.description = description;
+    } else if (ts.isInterfaceDeclaration(node) && node.name.text === rec.name) {
+      const { description } = extractJsDocInfo(node, sf);
+      const members: TypeMember[] = [];
+
+      for (const member of node.members) {
+        if (!ts.isPropertySignature(member) || !member.name) continue;
+        const name = ts.isIdentifier(member.name)
+          ? member.name.text
+          : member.name.getText(sf);
+        const opt = member.questionToken ? '?' : '';
+        const type = member.type?.getText(sf) ?? 'unknown';
+        members.push({ name: `${name}${opt}`, value: type });
+      }
+
+      result = {
+        name: rec.name,
+        kind: 'interface',
+        members,
+        sourceFile: relSrc(rec.resolvedPath),
+      };
+      if (description) result.description = description;
+    } else if (ts.isTypeAliasDeclaration(node) && node.name.text === rec.name) {
+      const { description } = extractJsDocInfo(node, sf);
+      result = {
+        name: rec.name,
+        kind: 'type',
+        sourceFile: relSrc(rec.resolvedPath),
+      };
+      if (description) result.description = description;
+      if (node.type) result.typeBody = node.type.getText(sf);
+    }
+  });
+
+  return result;
+}
+
+// ─── export entry extraction ──────────────────────────────────────────────────
+
+function buildExportEntry(rec: IndexExport): ExportEntry {
+  const sf = readSf(rec.resolvedPath);
+  let description = '';
+  let signature = '';
+
+  ts.forEachChild(sf, (node) => {
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name) || decl.name.text !== rec.name)
+          continue;
+        const info = extractJsDocInfo(node, sf);
+        description = info.description;
+
+        if (decl.type) {
+          signature = `${rec.name}: ${decl.type.getText(sf)}`;
+        } else if (decl.initializer) {
+          const init = decl.initializer;
+          if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+            const params = init.parameters.map((p) => p.getText(sf)).join(', ');
+            const ret = init.type?.getText(sf) ?? 'unknown';
+            signature = `(${params}) => ${ret}`;
+          } else {
+            signature = `${rec.name} = ${init.getText(sf)}`;
+          }
+        }
+      }
+    } else if (ts.isFunctionDeclaration(node) && node.name?.text === rec.name) {
+      const info = extractJsDocInfo(node, sf);
+      description = info.description;
+      const params = node.parameters.map((p) => p.getText(sf)).join(', ');
+      const ret = node.type?.getText(sf) ?? 'void';
+      signature = `function ${rec.name}(${params}): ${ret}`;
+    } else if (ts.isEnumDeclaration(node) && node.name.text === rec.name) {
+      const info = extractJsDocInfo(node, sf);
+      description = info.description;
+      const members = node.members
+        .map((m) => {
+          const mName = ts.isIdentifier(m.name)
+            ? m.name.text
+            : m.name.getText(sf);
+          const mVal = m.initializer ? ` = ${m.initializer.getText(sf)}` : '';
+          return `${mName}${mVal}`;
+        })
+        .join(', ');
+      signature = `enum ${rec.name} { ${members} }`;
+    }
+  });
+
+  const entry: ExportEntry = {
+    name: rec.name,
+    sourceFile: relSrc(rec.resolvedPath),
+  };
+  if (description) entry.description = description;
+  if (signature) entry.signature = signature;
+  return entry;
+}
+
+// ─── kit info ─────────────────────────────────────────────────────────────────
+
+function buildKitInfo(): KitInfo {
+  interface PkgJson {
+    name: string;
+    version: string;
+    description: string;
+    peerDependencies: Record<string, string>;
+  }
+  const pkg = JSON.parse(
+    readFileSync(join(ROOT, 'package.json'), 'utf-8'),
+  ) as PkgJson;
+
+  const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8');
+
+  // Extract Next.js integration section
+  const nextjsMatch = readme.match(
+    /<details>\s*<summary>Next\.js Integration<\/summary>([\s\S]*?)<\/details>/,
+  );
+  const nextjsSection = nextjsMatch
+    ? nextjsMatch[1].trim()
+    : 'See README for framework setup.';
+
+  // Extract theming section headline
+  const themingLine = readme.match(/## 🎨 Theming[^\n]*/)?.[0] ?? '';
+
+  const setupNotes = [
+    '## Next.js Integration',
+    nextjsSection,
+    '',
+    themingLine
+      ? `See "${themingLine.replace(/^#+\s*/, '')}" section in README.`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    name: pkg.name,
+    description: pkg.description,
+    installation: `npm install ${pkg.name}`,
+    cssImport: `import '${pkg.name}/styles.css'`,
+    peerDependencies: pkg.peerDependencies,
+    setupNotes,
+  };
+}
+
+// ─── styles content ───────────────────────────────────────────────────────────
+
+function buildStylesContent(): string {
+  return readFileSync(
+    join(SRC, 'mcp', 'descriptions', 'typography.md'),
+    'utf-8',
+  );
+}
+
+// ─── theming content ──────────────────────────────────────────────────────────
+
+function buildThemingContent(): string {
+  const tailwindConfig = readFileSync(
+    join(ROOT, 'tailwind.config.js'),
+    'utf-8',
+  );
+
+  // Extract CSS variable token groups from tailwind config
+  const tokenGroups: string[] = [];
+  const groupRe = /const (\w+)\s*=\s*\{([\s\S]*?)\n\};/g;
+  let groupMatch: RegExpExecArray | null;
+  while ((groupMatch = groupRe.exec(tailwindConfig)) !== null) {
+    const groupName = groupMatch[1];
+    const body = groupMatch[2];
+    const tokenRe = /'([^']+)':\s*'var\(--([^,]+),\s*([^)]+)\)'/g;
+    const tokens: string[] = [];
+    let tokenMatch: RegExpExecArray | null;
+    while ((tokenMatch = tokenRe.exec(body)) !== null) {
+      tokens.push(
+        `| \`${tokenMatch[1]}\` | \`var(--${tokenMatch[2]})\` | \`${tokenMatch[3]}\` |`,
+      );
+    }
+    if (tokens.length > 0) {
+      tokenGroups.push(
+        `### ${groupName}\n| Tailwind class suffix | CSS variable | Default value |\n|---|---|---|\n${tokens.join('\n')}`,
+      );
+    }
+  }
+
+  const staticContent = readFileSync(
+    join(SRC, 'mcp', 'descriptions', 'theming.md'),
+    'utf-8',
+  );
+  return `${staticContent}\n\n${tokenGroups.join('\n\n')}`;
+}
+
+// ─── main orchestration ───────────────────────────────────────────────────────
+
+function buildManifest(): Manifest {
+  const records = parseIndexFile();
+  const components: ComponentEntry[] = [];
+  const types: TypeEntry[] = [];
+  const hooks: ExportEntry[] = [];
+  const utils: ExportEntry[] = [];
+  const constants: ExportEntry[] = [];
+
+  const processedFiles = new Set<string>();
+
+  for (const rec of records) {
+    // Skip Props types exported from component files (covered by component.props)
+    if (
+      rec.isTypeOnly &&
+      rec.section === 'component' &&
+      rec.name.endsWith('Props')
+    ) {
+      continue;
+    }
+
+    // Skip duplicate processing of the same name from same file
+    const key = `${rec.name}:${rec.resolvedPath}`;
+    if (processedFiles.has(key)) continue;
+    processedFiles.add(key);
+
+    try {
+      if (rec.section === 'component' && !rec.isTypeOnly) {
+        // Only Dial* names are components; others (wrappers, providers) go to hooks
+        if (rec.name.startsWith('Dial')) {
+          const entry = buildComponentEntry(rec);
+          if (entry) components.push(entry);
+        } else {
+          hooks.push(buildExportEntry(rec));
+        }
+      } else if (rec.section === 'types' || rec.section === 'models') {
+        const entry = buildTypeEntry(rec);
+        if (entry) types.push(entry);
+      } else if (rec.section === 'hooks') {
+        hooks.push(buildExportEntry(rec));
+      } else if (rec.section === 'utils') {
+        utils.push(buildExportEntry(rec));
+      } else if (rec.section === 'constants') {
+        constants.push(buildExportEntry(rec));
+      } else if (rec.isTypeOnly) {
+        // Standalone model type exported from anywhere
+        const entry = buildTypeEntry(rec);
+        if (entry) types.push(entry);
+      }
+    } catch (e) {
+      console.warn(`Skipping ${rec.name}: ${(e as Error).message}`);
+    }
+  }
+
+  // Deduplicate types by name (enums may appear in both 'types' and 'models' sections)
+  const seenTypes = new Set<string>();
+  const dedupedTypes = types.filter((t) => {
+    if (seenTypes.has(t.name)) return false;
+    seenTypes.add(t.name);
+    return true;
+  });
+
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')) as {
+    version: string;
+  };
+
+  return {
+    version: pkg.version,
+    generatedAt: new Date().toISOString(),
+    kit: buildKitInfo(),
+    styles: buildStylesContent(),
+    theming: buildThemingContent(),
+    components,
+    types: dedupedTypes,
+    hooks,
+    utils,
+    constants,
+  };
+}
+
+function main(): void {
+  console.log('Generating component manifest...');
+
+  mkdirSync(DIST, { recursive: true });
+
+  const manifest = buildManifest();
+
+  const outPath = join(DIST, 'components-manifest.json');
+  writeFileSync(outPath, JSON.stringify(manifest, null, 2), 'utf-8');
+
+  const ext = extname(outPath);
+  console.log(
+    `Manifest written to ${outPath.replace(ROOT, '.').replace(/\\/g, '/')}`,
+  );
+  console.log(
+    `  ${manifest.components.length} components, ${manifest.types.length} types, ` +
+      `${manifest.hooks.length} hooks, ${manifest.utils.length} utils, ` +
+      `${manifest.constants.length} constants${ext ? '' : ''}`,
+  );
+}
+
+main();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,461 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type {
+  Manifest,
+  ComponentEntry,
+  TypeEntry,
+  ExportEntry,
+} from './types.ts';
+
+// ─── load manifest ────────────────────────────────────────────────────────────
+
+// __dirname is injected by Node.js in CJS (esbuild --format=cjs --platform=node)
+const manifest: Manifest = JSON.parse(
+  readFileSync(join(__dirname, 'components-manifest.json'), 'utf-8'),
+);
+
+// ─── entity kinds ─────────────────────────────────────────────────────────────
+
+type EntityKind =
+  | 'component'
+  | 'hook'
+  | 'util'
+  | 'type'
+  | 'constant'
+  | 'typography'
+  | 'theming';
+
+const ENTITY_KINDS: EntityKind[] = [
+  'component',
+  'hook',
+  'util',
+  'type',
+  'constant',
+  'typography',
+  'theming',
+];
+
+const ENTITY_HINT = ENTITY_KINDS.join(' | ');
+
+// ─── format helpers ───────────────────────────────────────────────────────────
+
+function formatComponent(comp: ComponentEntry): string {
+  const lines: string[] = [
+    `# ${comp.name}`,
+    `**Category:** ${comp.category}`,
+    `**Source:** \`${comp.sourceFile}\``,
+    '',
+  ];
+
+  if (comp.description) lines.push(comp.description, '');
+
+  if (comp.props.length > 0) {
+    lines.push('## Props', '');
+    lines.push('| Prop | Type | Required | Default | Description |');
+    lines.push('|------|------|:--------:|---------|-------------|');
+    for (const prop of comp.props) {
+      const req = prop.required ? '✓' : '';
+      const def = prop.defaultValue ? `\`${prop.defaultValue}\`` : '—';
+      lines.push(
+        `| \`${prop.name}\` | \`${prop.type}\` | ${req} | ${def} | ${prop.description ?? ''} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (comp.examples.length > 0) {
+    lines.push('## Examples', '');
+    for (const ex of comp.examples) lines.push('```tsx', ex, '```', '');
+  }
+
+  const refs = collectTypeRefs(comp);
+  if (refs.length > 0) {
+    lines.push('## Referenced Types', '');
+    for (const r of refs)
+      lines.push(
+        `- \`${r}\` — use getEntityDetails(entity: "type", name: "${r}")`,
+      );
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function formatType(t: TypeEntry): string {
+  const lines: string[] = [
+    `# ${t.name}`,
+    `**Kind:** ${t.kind}`,
+    `**Source:** \`${t.sourceFile}\``,
+    '',
+  ];
+
+  if (t.description) lines.push(t.description, '');
+
+  if (t.kind === 'type' && t.typeBody) {
+    lines.push('## Type', '', '```ts', t.typeBody, '```', '');
+  }
+
+  if (t.members && t.members.length > 0) {
+    if (t.kind === 'enum') {
+      lines.push('## Members', '');
+      lines.push('| Name | Value | Description |');
+      lines.push('|------|-------|-------------|');
+      for (const m of t.members) {
+        lines.push(`| \`${m.name}\` | \`${m.value}\` | ${m.comment ?? ''} |`);
+      }
+    } else {
+      lines.push('## Fields', '');
+      lines.push('| Field | Type |');
+      lines.push('|-------|------|');
+      for (const m of t.members) {
+        lines.push(`| \`${m.name}\` | \`${m.value}\` |`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function formatExport(e: ExportEntry): string {
+  const lines: string[] = [
+    `# ${e.name}`,
+    `**Source:** \`${e.sourceFile}\``,
+    '',
+  ];
+  if (e.description) lines.push(e.description, '');
+  if (e.signature)
+    lines.push('## Signature', '', '```ts', e.signature, '```', '');
+  return lines.join('\n');
+}
+
+function collectTypeRefs(comp: ComponentEntry): string[] {
+  const known = new Set(manifest.types.map((t) => t.name));
+  const refs = new Set<string>();
+  for (const prop of comp.props) {
+    for (const m of prop.type.matchAll(/\b([A-Z][A-Za-z0-9]+)\b/g)) {
+      if (known.has(m[1])) refs.add(m[1]);
+    }
+  }
+  return [...refs].sort();
+}
+
+// ─── search ───────────────────────────────────────────────────────────────────
+
+function searchComponents(query: string): ComponentEntry[] {
+  if (!query.trim()) return manifest.components.slice(0, 20);
+  const q = query.toLowerCase();
+  return manifest.components
+    .map((c) => {
+      let score = 0;
+      const name = c.name.toLowerCase();
+      const desc = c.description.toLowerCase();
+      const cat = c.category.toLowerCase();
+      if (name === q) score = 100;
+      else if (name.startsWith(q)) score = 80;
+      else if (name.includes(q)) score = 60;
+      if (desc.includes(q)) score += 20;
+      if (cat.includes(q)) score += 10;
+      return { c, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((s) => s.c);
+}
+
+function searchExports(pool: ExportEntry[], query: string): ExportEntry[] {
+  if (!query.trim()) return pool.slice(0, 20);
+  const q = query.toLowerCase();
+  return pool
+    .map((e) => {
+      let score = 0;
+      const name = e.name.toLowerCase();
+      const desc = (e.description ?? '').toLowerCase();
+      if (name === q) score = 100;
+      else if (name.startsWith(q)) score = 80;
+      else if (name.includes(q)) score = 60;
+      if (desc.includes(q)) score += 20;
+      return { e, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((s) => s.e);
+}
+
+function searchTypes(query: string): TypeEntry[] {
+  if (!query.trim()) return manifest.types.slice(0, 20);
+  const q = query.toLowerCase();
+  return manifest.types
+    .map((t) => {
+      let score = 0;
+      const name = t.name.toLowerCase();
+      const desc = (t.description ?? '').toLowerCase();
+      if (name === q) score = 100;
+      else if (name.startsWith(q)) score = 80;
+      else if (name.includes(q)) score = 60;
+      if (desc.includes(q)) score += 20;
+      return { t, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((s) => s.t);
+}
+
+// ─── server ───────────────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: manifest.kit.name, version: manifest.version },
+  { capabilities: { tools: {} } },
+);
+
+// ─── tools ────────────────────────────────────────────────────────────────────
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'searchEntity',
+      description:
+        'Search for UI kit entities (components, hooks, utils, types, constants) by name or description. Returns a summary list of matches. For typography and theming, returns the full reference content regardless of query.\n\nExamples:\n  searchEntity("component", "button") → lists Button-related components\n  searchEntity("hook", "click") → lists hooks with "click" in name/description\n  searchEntity("typography") → returns full typography CSS class reference',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          entity: {
+            type: 'string',
+            enum: ENTITY_KINDS,
+            description: 'The entity category to search in.',
+            argumentHint: ENTITY_HINT,
+          },
+          query: {
+            type: 'string',
+            description:
+              'Literal substring to match against name and description. Empty or omitted returns the first 20 results.',
+          },
+        },
+        required: ['entity'],
+      },
+    },
+    {
+      name: 'getEntityDetails',
+      description:
+        'Get full documentation for a specific UI kit entity by exact name — props table, examples, signatures, type members, etc. For typography and theming, returns the full reference content (name not required).\n\nExamples:\n  getEntityDetails("component", "DialButton") → full props + examples\n  getEntityDetails("type", "ButtonSize") → enum values\n  getEntityDetails("hook", "useClickOutside") → signature + description\n  getEntityDetails("theming") → full CSS variable and token reference',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          entity: {
+            type: 'string',
+            enum: ENTITY_KINDS,
+            description: 'The entity category.',
+            argumentHint: ENTITY_HINT,
+          },
+          name: {
+            type: 'string',
+            description:
+              'Exact entity name (e.g. "DialButton", "useClickOutside", "ButtonSize"). Not required for typography and theming.',
+          },
+        },
+        required: ['entity'],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const a = (args ?? {}) as Record<string, unknown>;
+  const entity = a.entity as EntityKind;
+
+  if (!ENTITY_KINDS.includes(entity)) {
+    throw new Error(
+      `Unknown entity kind: "${entity}". Must be one of: ${ENTITY_HINT}`,
+    );
+  }
+
+  // ── searchEntity ──────────────────────────────────────────────────────────
+
+  if (name === 'searchEntity') {
+    const query = typeof a.query === 'string' ? a.query : '';
+
+    if (entity === 'typography') {
+      return { content: [{ type: 'text', text: manifest.styles }] };
+    }
+
+    if (entity === 'theming') {
+      return { content: [{ type: 'text', text: manifest.theming }] };
+    }
+
+    if (entity === 'component') {
+      const results = searchComponents(query);
+      if (results.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No components found matching "${query}". Try a shorter or more literal token.`,
+            },
+          ],
+        };
+      }
+      const header = query
+        ? `Found ${results.length} component(s) matching "${query}":`
+        : `First ${results.length} components (pass a query to filter):`;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              header,
+              '',
+              '| Name | Category | Description |',
+              '|------|----------|-------------|',
+              ...results.map(
+                (c) => `| \`${c.name}\` | ${c.category} | ${c.description} |`,
+              ),
+              '',
+              'Use getEntityDetails(entity: "component", name: "...") for full props and examples.',
+            ].join('\n'),
+          },
+        ],
+      };
+    }
+
+    if (entity === 'type') {
+      const results = searchTypes(query);
+      if (results.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No types found matching "${query}". Try a shorter token.`,
+            },
+          ],
+        };
+      }
+      const header = query
+        ? `Found ${results.length} type(s) matching "${query}":`
+        : `First ${results.length} types (pass a query to filter):`;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              header,
+              '',
+              '| Name | Kind | Description |',
+              '|------|------|-------------|',
+              ...results.map(
+                (t) => `| \`${t.name}\` | ${t.kind} | ${t.description ?? ''} |`,
+              ),
+              '',
+              'Use getEntityDetails(entity: "type", name: "...") for members and values.',
+            ].join('\n'),
+          },
+        ],
+      };
+    }
+
+    // hook | util | constant
+    const pool =
+      entity === 'hook'
+        ? manifest.hooks
+        : entity === 'util'
+          ? manifest.utils
+          : manifest.constants;
+    const results = searchExports(pool, query);
+    if (results.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `No ${entity}s found matching "${query}". Try a shorter token.`,
+          },
+        ],
+      };
+    }
+    const header = query
+      ? `Found ${results.length} ${entity}(s) matching "${query}":`
+      : `First ${results.length} ${entity}s (pass a query to filter):`;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: [
+            header,
+            '',
+            '| Name | Description |',
+            '|------|-------------|',
+            ...results.map((e) => `| \`${e.name}\` | ${e.description ?? ''} |`),
+            '',
+            `Use getEntityDetails(entity: "${entity}", name: "...") for full signature.`,
+          ].join('\n'),
+        },
+      ],
+    };
+  }
+
+  // ── getEntityDetails ──────────────────────────────────────────────────────
+
+  if (name === 'getEntityDetails') {
+    if (entity === 'typography') {
+      return { content: [{ type: 'text', text: manifest.styles }] };
+    }
+
+    if (entity === 'theming') {
+      return { content: [{ type: 'text', text: manifest.theming }] };
+    }
+
+    const entityName = typeof a.name === 'string' ? a.name.trim() : '';
+    if (!entityName) {
+      throw new Error(`"name" is required for entity kind "${entity}"`);
+    }
+
+    if (entity === 'component') {
+      const comp = manifest.components.find((c) => c.name === entityName);
+      if (!comp) {
+        throw new Error(
+          `Component "${entityName}" not found. Use searchEntity(entity: "component") to browse available components.`,
+        );
+      }
+      return { content: [{ type: 'text', text: formatComponent(comp) }] };
+    }
+
+    if (entity === 'type') {
+      const t = manifest.types.find((t) => t.name === entityName);
+      if (!t) {
+        throw new Error(
+          `Type "${entityName}" not found. Use searchEntity(entity: "type") to browse available types.`,
+        );
+      }
+      return { content: [{ type: 'text', text: formatType(t) }] };
+    }
+
+    // hook | util | constant
+    const pool =
+      entity === 'hook'
+        ? manifest.hooks
+        : entity === 'util'
+          ? manifest.utils
+          : manifest.constants;
+    const entry = pool.find((e) => e.name === entityName);
+    if (!entry) {
+      throw new Error(
+        `${entity.charAt(0).toUpperCase() + entity.slice(1)} "${entityName}" not found. Use searchEntity(entity: "${entity}") to browse available ${entity}s.`,
+      );
+    }
+    return { content: [{ type: 'text', text: formatExport(entry) }] };
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+});
+
+// ─── connect ──────────────────────────────────────────────────────────────────
+
+void (async () => {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+})();

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,60 @@
+export interface PropEntry {
+  name: string;
+  type: string;
+  required: boolean;
+  defaultValue?: string;
+  description?: string;
+}
+
+export interface ComponentEntry {
+  name: string;
+  category: string;
+  description: string;
+  props: PropEntry[];
+  examples: string[];
+  sourceFile: string;
+}
+
+export interface TypeMember {
+  name: string;
+  value: string;
+  comment?: string;
+}
+
+export interface TypeEntry {
+  name: string;
+  kind: 'enum' | 'interface' | 'type';
+  description?: string;
+  members?: TypeMember[];
+  typeBody?: string; // RHS text for type aliases, e.g. "'sm' | 'md' | 'lg'"
+  sourceFile: string;
+}
+
+export interface ExportEntry {
+  name: string;
+  description?: string;
+  signature?: string;
+  sourceFile: string;
+}
+
+export interface KitInfo {
+  name: string;
+  description: string;
+  installation: string;
+  cssImport: string;
+  peerDependencies: Record<string, string>;
+  setupNotes: string;
+}
+
+export interface Manifest {
+  version: string;
+  generatedAt: string;
+  kit: KitInfo;
+  styles: string;
+  theming: string;
+  components: ComponentEntry[];
+  types: TypeEntry[];
+  hooks: ExportEntry[];
+  utils: ExportEntry[];
+  constants: ExportEntry[];
+}

--- a/tools/build-mcp.mjs
+++ b/tools/build-mcp.mjs
@@ -1,0 +1,11 @@
+import * as esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/mcp/server.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['@modelcontextprotocol/sdk'],
+  outfile: 'dist/mcp-server.cjs',
+  banner: { js: '#!/usr/bin/env node' },
+});


### PR DESCRIPTION
**Description and UI changes:**

Added built-in mcp server to allow easier lookup of UI Kit components in projects. It make component discovery more efficient, same for getting component details. Also I propose to create and keep up to date CHANGELOG.md and include it in MCP server as well, so agent could easily understand what migrations are needed after breaking changes.

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added