### PR TITLE
feat: [TagInput, AutocompleteInput] added readonly state

### DIFF
--- a/src/components/AutocompleteInput/AutocompleteInputValue.spec.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputValue.spec.tsx
@@ -3,11 +3,27 @@ import { describe, expect, test } from 'vitest';
 import { DialAutocompleteInputValue } from './AutocompleteInputValue';
 
 describe('Dial UI Kit :: DialAutocompleteInputValue', () => {
-  test('renders selected items as list items', () => {
+  test('renders selected items as tags', () => {
     render(<DialAutocompleteInputValue selectedItems={['val1', 'val2']} />);
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(2);
-    expect(items[0]).toHaveTextContent('val1');
-    expect(items[1]).toHaveTextContent('val2');
+    expect(screen.getByText('val1')).toBeTruthy();
+    expect(screen.getByText('val2')).toBeTruthy();
+  });
+
+  test('renders placeholder when no items are selected', () => {
+    render(<DialAutocompleteInputValue placeholder="Pick items" />);
+    expect(screen.getByText('Pick items')).toBeTruthy();
+  });
+
+  test('collapseTagOverflow: renders all items when all fit', () => {
+    render(
+      <DialAutocompleteInputValue
+        selectedItems={['a', 'b', 'c']}
+        collapseTagOverflow
+      />,
+    );
+    // getAllByText because the measurement (aria-hidden) div duplicates text nodes
+    expect(screen.getAllByText('a').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('b').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('c').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/components/AutocompleteInput/AutocompleteInputValue.stories.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputValue.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialAutocompleteInputValue } from './AutocompleteInputValue';
+
+/**
+ * `DialAutocompleteInputValue` is a read-only display component, typically embedded inside a
+ * `dial-input` container (e.g. a select trigger). It renders selected items as tags and
+ * falls back to a placeholder when the list is empty.
+ */
+const meta: Meta<typeof DialAutocompleteInputValue> = {
+  title: 'Form/AutocompleteInputValue',
+  component: DialAutocompleteInputValue,
+  tags: ['form', 'input', 'tags', 'autocomplete'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Read-only tag display used inside select/autocomplete triggers. Renders selected items as tags with an optional `+N` overflow chip when `collapseTagOverflow` is enabled.',
+      },
+    },
+  },
+  argTypes: {
+    selectedItems: {
+      control: { type: 'object' },
+      description: 'Array of selected item strings to display as tags',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Text shown when no items are selected',
+    },
+    collapseTagOverflow: {
+      control: 'boolean',
+      description:
+        'Keeps items on one line and shows a `+N` chip with a tooltip for overflow items',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <div className="dial-input px-3 py-2 flex flex-row items-center w-full justify-between cursor-pointer">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const MANY_ITEMS = [
+  'React',
+  'TypeScript',
+  'Storybook',
+  'Tailwind',
+  'Vite',
+  'Vitest',
+  'React1',
+  'TypeScript2',
+  'Storybook3',
+  'Tailwind4',
+  'Vite5',
+  'Vitest6',
+];
+
+export const Default: Story = {
+  args: {
+    selectedItems: ['React', 'TypeScript', 'Storybook'],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    selectedItems: [],
+    placeholder: 'Select items…',
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    selectedItems: ['React'],
+  },
+};
+
+export const ManyItems: Story = {
+  args: {
+    selectedItems: MANY_ITEMS,
+  },
+};
+
+export const CollapsedOverflow: Story = {
+  args: {
+    selectedItems: MANY_ITEMS,
+    collapseTagOverflow: true,
+  },
+};

--- a/src/components/AutocompleteInput/AutocompleteInputValue.tsx
+++ b/src/components/AutocompleteInput/AutocompleteInputValue.tsx
@@ -1,20 +1,19 @@
-import classNames from 'classnames';
 import type { FC } from 'react';
-import { DialTooltip } from '@/components/Tooltip/Tooltip';
-import { DialTag } from '@/components/Tag/Tag';
+import { DialTagInput } from '@/components/TagInput/TagInput';
 
 export interface DialAutocompleteInputValueProps {
   placeholder?: string;
   selectedItems?: string[];
   listClassName?: string;
   listElementClassName?: string;
+  collapseTagOverflow?: boolean;
 }
 
 /**
  * A component that displays a list of selected items in a customizable, styled list. Each item is
  * aliases: SelectedList|ItemDisplay
  *
- * rendered as a button wrapped in a tooltip, allowing for truncation and additional context when
+ * rendered as a tag wrapped in a tooltip, allowing for truncation and additional context when
  * hovered. The component is flexible and supports custom CSS classes for styling the list and
  * individual list items.
  *
@@ -24,37 +23,38 @@ export interface DialAutocompleteInputValueProps {
  *   selectedItems={['Item 1', 'Item 2', 'Item 3']}
  *   listClassName="custom-list-class"
  *   listElementClassName="custom-item-class"
+ *   collapseTagOverflow
  * />
  * ```
  *
  * @param [placeholder] - Placeholder text to display when no items are selected.
  * @param [selectedItems] - An array of strings representing the selected items to display. If empty or undefined, the component renders nothing.
- * @param [listClassName] - Additional CSS classes applied to the `<ul>` element containing the list of selected items.
- * @param [listElementClassName] - Additional CSS classes applied to each `<li>` element representing an individual selected item.
+ * @param [listClassName] - Additional CSS classes applied to the container element containing the list of selected items.
+ * @param [listElementClassName] - Additional CSS classes applied to each tag element representing an individual selected item.
+ * @param [collapseTagOverflow=false] - When true, keeps items on one line and shows `+N` chip with a tooltip for overflow items.
  */
 export const DialAutocompleteInputValue: FC<
   DialAutocompleteInputValueProps
-> = ({ selectedItems, listClassName, listElementClassName, placeholder }) => {
-  return selectedItems?.length ? (
-    <ul
-      className={classNames(
-        'flex-row items-center truncate flex-wrap',
-        'flex gap-x-2 gap-y-1',
-        listClassName,
-      )}
-    >
-      {selectedItems?.map((selectedItem, index) => (
-        <li key={`${selectedItem}_${index}`}>
-          <DialTooltip tooltip={selectedItem}>
-            <DialTag
-              tag={selectedItem}
-              className={classNames([listElementClassName])}
-            />
-          </DialTooltip>
-        </li>
-      ))}
-    </ul>
-  ) : placeholder ? (
-    <span className="text-secondary">{placeholder}</span>
-  ) : null;
+> = ({
+  selectedItems,
+  placeholder,
+  collapseTagOverflow = false,
+  listClassName,
+  listElementClassName,
+}) => {
+  if (!selectedItems?.length) {
+    return placeholder ? (
+      <span className="text-secondary">{placeholder}</span>
+    ) : null;
+  }
+
+  return (
+    <DialTagInput
+      readOnly
+      initialTags={selectedItems}
+      collapseTagOverflow={collapseTagOverflow}
+      containerClassName={listClassName}
+      tagClassName={listElementClassName}
+    />
+  );
 };

--- a/src/components/TagInput/TagInput.spec.tsx
+++ b/src/components/TagInput/TagInput.spec.tsx
@@ -137,4 +137,41 @@ describe('Dial UI Kit :: DialTagInput', () => {
       'Hint',
     );
   });
+
+  describe('readOnly', () => {
+    test('does not render a textbox', () => {
+      render(<DialTagInput readOnly initialTags={['React', 'TypeScript']} />);
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    test('renders all initial tags', () => {
+      render(<DialTagInput readOnly initialTags={['React', 'TypeScript']} />);
+      expect(screen.getByText('React')).toBeInTheDocument();
+      expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    });
+
+    test('does not render remove buttons on tags', () => {
+      render(<DialTagInput readOnly initialTags={['React', 'TypeScript']} />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    test('does not render the outer dial-input wrapper', () => {
+      const { container } = render(
+        <DialTagInput readOnly initialTags={['React']} />,
+      );
+      expect(container.querySelector('.dial-input')).not.toBeInTheDocument();
+    });
+
+    test('with collapseTagOverflow, renders single-line flex row', () => {
+      const { container } = render(
+        <DialTagInput
+          readOnly
+          collapseTagOverflow
+          initialTags={['React', 'TypeScript']}
+        />,
+      );
+      const row = container.querySelector('.flex-nowrap.overflow-hidden');
+      expect(row).toBeTruthy();
+    });
+  });
 });

--- a/src/components/TagInput/TagInput.stories.tsx
+++ b/src/components/TagInput/TagInput.stories.tsx
@@ -72,6 +72,11 @@ const meta: Meta<typeof DialTagInput> = {
       description:
         'Single-line tags with a +N chip when they do not fit the field width',
     },
+    readOnly: {
+      control: 'boolean',
+      description:
+        'Hides the text input so no new tags can be added. The outer label/caption wrapper is also omitted, making the component embeddable inside an existing container.',
+    },
   },
 };
 export default meta;
@@ -150,6 +155,30 @@ export const CollapsedOverflow: Story = {
   },
 };
 
+export const ReadOnly: Story = {
+  render: InteractiveTagInput,
+  args: {
+    readOnly: true,
+    initialTags: ['React', 'TypeScript', 'Storybook'],
+  },
+};
+
+export const ReadOnlyCollapsedOverflow: Story = {
+  render: InteractiveTagInput,
+  args: {
+    readOnly: true,
+    collapseTagOverflow: true,
+    initialTags: [
+      'React',
+      'TypeScript',
+      'Storybook',
+      'Tailwind',
+      'Vite',
+      'Vitest',
+    ],
+  },
+};
+
 export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-5 w-[450px] text-primary">
@@ -194,6 +223,30 @@ export const AllVariants: Story = {
           label="Tags"
           disabled
           initialTags={['React']}
+        />
+      </div>
+      <div>
+        <h4 className="text-lg font-semibold mb-2">Read Only (embedded)</h4>
+        <InteractiveTagInput
+          readOnly
+          initialTags={['React', 'TypeScript', 'Storybook']}
+        />
+      </div>
+      <div>
+        <h4 className="text-lg font-semibold mb-2">
+          Read Only + Collapsed overflow
+        </h4>
+        <InteractiveTagInput
+          readOnly
+          collapseTagOverflow
+          initialTags={[
+            'React',
+            'TypeScript',
+            'Storybook',
+            'Tailwind',
+            'Vite',
+            'Vitest',
+          ]}
         />
       </div>
     </div>

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -20,7 +20,7 @@ const TAG_ROW_GAP_PX = 8;
 const COLLAPSED_INPUT_RESERVE_PX = 24;
 
 export interface DialTagInputProps extends DialLabelProps {
-  elementId: string;
+  elementId?: string;
   initialTags?: string[];
   placeholder?: string;
   captionDescription?: string;
@@ -28,6 +28,9 @@ export interface DialTagInputProps extends DialLabelProps {
   invalid?: boolean;
   disabled?: boolean;
   collapseTagOverflow?: boolean;
+  readOnly?: boolean;
+  containerClassName?: string;
+  tagClassName?: string;
   onChange?: (tags: string[]) => void;
 }
 
@@ -60,6 +63,9 @@ export interface DialTagInputProps extends DialLabelProps {
  * @param [invalid=false] - Whether the field should be styled as invalid.
  * @param [disabled=false] - Whether the input and remove buttons are disabled.
  * @param [collapseTagOverflow=false] - When true, keeps tags on one line and shows `+N` for overflow.
+ * @param [readOnly=false] - When true, hides the text input (no new tags can be added). The outer wrapper and label/caption are also omitted so the component can be embedded inside an existing container.
+ * @param [containerClassName] - Additional CSS classes applied to the tag container (the flex row wrapping all tags).
+ * @param [tagClassName] - Additional CSS classes applied to each individual tag.
  * @param [onChange] - Callback fired whenever the tag list changes (tag added or removed).
  */
 export const DialTagInput: FC<DialTagInputProps> = ({
@@ -73,6 +79,9 @@ export const DialTagInput: FC<DialTagInputProps> = ({
   invalid,
   disabled,
   collapseTagOverflow = false,
+  readOnly = false,
+  containerClassName,
+  tagClassName,
   onChange,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -100,8 +109,8 @@ export const DialTagInput: FC<DialTagInputProps> = ({
     if (rowWidth === 0) return;
 
     const overflowChipWidth = overflowMeasureRef.current?.offsetWidth ?? 0;
-    const effectiveWidth =
-      rowWidth - COLLAPSED_INPUT_RESERVE_PX - TAG_ROW_GAP_PX;
+    const inputReserve = readOnly ? 0 : COLLAPSED_INPUT_RESERVE_PX;
+    const effectiveWidth = rowWidth - inputReserve - TAG_ROW_GAP_PX;
 
     let totalWidth = 0;
     let fitCount = 0;
@@ -125,7 +134,7 @@ export const DialTagInput: FC<DialTagInputProps> = ({
     }
 
     setVisibleTagCount(fitCount);
-  }, [collapseTagOverflow, tags]);
+  }, [collapseTagOverflow, readOnly, tags.length]);
 
   const addTag = (value: string) => {
     const trimmed = value.trim().replace(/,$/, '');
@@ -208,6 +217,88 @@ export const DialTagInput: FC<DialTagInputProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(initialTags)]);
 
+  const innerContainer = (
+    <div
+      ref={containerRef}
+      className={classNames(
+        'flex gap-2 items-center relative',
+        collapseTagOverflow
+          ? 'flex-nowrap overflow-hidden w-full min-w-0'
+          : classNames('flex-wrap', wraps ? 'flex-col-reverse' : 'flex-row'),
+        containerClassName,
+      )}
+    >
+      {(collapseTagOverflow ? tags.slice(0, visibleTagCount) : tags).map(
+        (tag, index) => (
+          <DialTag
+            key={tag + index}
+            tag={tag}
+            className={tagClassName}
+            remove={
+              !disabled && !readOnly ? () => handleRemove(index) : undefined
+            }
+          />
+        ),
+      )}
+
+      {collapseTagOverflow && visibleTagCount < tags.length && (
+        <DialTooltip
+          tooltip={tags.slice(visibleTagCount).join(', ')}
+          triggerClassName="inline-flex shrink-0 cursor-pointer"
+        >
+          <DialTag tag={`+${tags.length - visibleTagCount}`} />
+        </DialTooltip>
+      )}
+
+      {!readOnly && (
+        <input
+          id={elementId}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          className={classNames(
+            'dial-input outline-none !border-none w-full flex-1 !p-1 !h-auto',
+            collapseTagOverflow ? 'min-w-0' : 'min-w-[100px]',
+          )}
+          placeholder={placeholder ?? ''}
+          disabled={disabled}
+        />
+      )}
+
+      {collapseTagOverflow && (
+        <div
+          className="absolute left-0 top-0 invisible pointer-events-none h-0 overflow-hidden whitespace-nowrap"
+          aria-hidden
+        >
+          {tags.map((tag, index) => (
+            <div
+              key={`measure-${tag}-${index}`}
+              ref={setTagMeasureRef(index)}
+              className="inline-flex shrink-0"
+            >
+              <DialTag
+                tag={tag}
+                className={tagClassName}
+                remove={
+                  !disabled && !readOnly ? () => handleRemove(index) : undefined
+                }
+              />
+            </div>
+          ))}
+          <div ref={overflowMeasureRef} className="inline-flex shrink-0">
+            <DialTag tag={`+${tags.length}`} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  if (readOnly) {
+    return innerContainer;
+  }
+
   return (
     <div className="flex flex-col gap-2 w-full">
       <DialLabel label={label} required={required} htmlFor={elementId} />
@@ -218,74 +309,7 @@ export const DialTagInput: FC<DialTagInputProps> = ({
           disabled && 'dial-input-disable',
         )}
       >
-        <div
-          ref={containerRef}
-          className={classNames(
-            'flex gap-2 items-center relative',
-            collapseTagOverflow
-              ? 'flex-nowrap overflow-hidden w-full min-w-0'
-              : classNames(
-                  'flex-wrap',
-                  wraps ? 'flex-col-reverse' : 'flex-row',
-                ),
-          )}
-        >
-          {(collapseTagOverflow ? tags.slice(0, visibleTagCount) : tags).map(
-            (tag, index) => (
-              <DialTag
-                key={tag + index}
-                tag={tag}
-                remove={!disabled ? () => handleRemove(index) : undefined}
-              />
-            ),
-          )}
-
-          {collapseTagOverflow && visibleTagCount < tags.length && (
-            <DialTooltip
-              tooltip={tags.slice(visibleTagCount).join(', ')}
-              triggerClassName="inline-flex shrink-0 cursor-pointer"
-            >
-              <DialTag tag={`+${tags.length - visibleTagCount}`} />
-            </DialTooltip>
-          )}
-
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onBlur={handleBlur}
-            className={classNames(
-              'dial-input outline-none !border-none w-full flex-1 !p-1 !h-auto',
-              collapseTagOverflow ? 'min-w-0' : 'min-w-[100px]',
-            )}
-            placeholder={placeholder ?? ''}
-            disabled={disabled}
-          />
-
-          {collapseTagOverflow && (
-            <div
-              className="absolute left-0 top-0 invisible pointer-events-none h-0 overflow-hidden whitespace-nowrap"
-              aria-hidden
-            >
-              {tags.map((tag, index) => (
-                <div
-                  key={`measure-${tag}-${index}`}
-                  ref={setTagMeasureRef(index)}
-                  className="inline-flex shrink-0"
-                >
-                  <DialTag
-                    tag={tag}
-                    remove={!disabled ? () => handleRemove(index) : undefined}
-                  />
-                </div>
-              ))}
-              <div ref={overflowMeasureRef} className="inline-flex shrink-0">
-                <DialTag tag={`+${tags.length}`} />
-              </div>
-            </div>
-          )}
-        </div>
+        {innerContainer}
       </div>
       {renderCaption()}
     </div>


### PR DESCRIPTION

**Description and UI changes:**

added readonly state for tagInput, for using as embedded inside autocomplete input

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added