### PR TITLE
fix: fix deselect missing items in FileManager selection lifecycle (Issue #632)

### DIFF
--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -222,6 +222,28 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     return map;
   }, [effectiveSelectedPaths, items]);
 
+  useEffect(() => {
+    if (effectiveSelectedPaths.size === 0) return;
+
+    let hasMissingPaths = false;
+    for (const path of effectiveSelectedPaths) {
+      if (!findNodeByPath(items, path)) {
+        hasMissingPaths = true;
+        break;
+      }
+    }
+
+    if (hasMissingPaths) {
+      const nextPaths = new Set<string>();
+      for (const path of effectiveSelectedPaths) {
+        if (findNodeByPath(items, path)) {
+          nextPaths.add(path);
+        }
+      }
+      setSelectedPaths(nextPaths);
+    }
+  }, [items, effectiveSelectedPaths, setSelectedPaths]);
+
   const { currentPath, setCurrentPath, handlePathChange } = useCurrentPath({
     path,
     defaultPath,


### PR DESCRIPTION
**Description and UI changes:**

Problem: When autoSelectUploadedItems is enabled, the UI selects a temporary "stub" file during upload. If the upload fails (e.g., due to network error) and the file is removed from the items list, the selectedPaths state retains the path. This keeps the Bulk Actions Toolbar visible ("1 item selected"), which hides the "New" button and breaks subsequent interactions (and E2E tests).

Solution: Added a side effect to FileManagerProvider that validates effectiveSelectedPaths against the current items list and automatically removes any "phantom" paths that are no longer present.

Issues:

- Issue #632 

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added