### PR TITLE
fix: [Prompts/Files] Bulk buttons are not displayed after cancelling Replace Or Duplicate Item flow (Issue #2950)

### DIFF
--- a/src/components/FileManager/hooks/use-file-clipboard.ts
+++ b/src/components/FileManager/hooks/use-file-clipboard.ts
@@ -59,6 +59,10 @@ export const useFileClipboard = ({
   } = useConflictResolution({
     getDestinationFiles,
     onResolve: (items, destinationFolder) => {
+      if (!items?.length) {
+        return;
+      }
+
       if (operationMetadata?.type === DestinationFolderMode.Copy) {
         onCopyFiles?.(items, destinationFolder);
         onCopySuccess?.();


### PR DESCRIPTION
**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #2950

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added