### PR TITLE
fix(chat): fix name appearance in path inside move to #643)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -1542,6 +1542,7 @@ export const DialFileManagerView: FC = () => {
           treeOptions={{ header: treeOptions?.header }}
           onFolderPopupPathChange={onFolderPopupPathChange}
           showHiddenFileSwitcher={showHiddenFileSwitcherInDestinationPopup}
+          hideSearchPathItemName={hideSearchPathItemName}
         />
         <ConflictResolutionPopup
           {...conflictResolutionPopupOptions}


### PR DESCRIPTION
**Description and UI changes:**

Path contains filename when Move to /Copy to item from search results.
Path should not contain filename if hideSearchPathItemName is true

Issues:

- Issue #643

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added