### PR TITLE
fix: [Input] No tooltip for long values in "Key" and "Value" fields in Defaults section

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,8 @@
 import {
+  useCallback,
   useEffect,
   useRef,
+  useState,
   type ChangeEvent,
   type FC,
   type InputHTMLAttributes,
@@ -124,6 +126,22 @@ const InputWrapper: FC<InputWrapperProps> = ({
 }) => {
   const innerRef = useRef<HTMLInputElement | null>(null);
   const ref = useMergeRefs([inputRef, innerRef]);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const checkTruncation = useCallback(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    setIsTruncated(el.scrollWidth > el.clientWidth);
+  }, []);
+
+  useEffect(() => {
+    checkTruncation();
+  }, [value, checkTruncation]);
+
+  useEffect(() => {
+    window.addEventListener('resize', checkTruncation);
+    return () => window.removeEventListener('resize', checkTruncation);
+  }, [checkTruncation]);
 
   // disable mouse wheel changing input value
   useEffect(() => {
@@ -230,8 +248,11 @@ const InputWrapper: FC<InputWrapperProps> = ({
       </div>
     );
   };
-  return disabled && type !== 'password' ? (
-    <DialTooltip tooltip={tooltipText || value}>{input()}</DialTooltip>
+  const showTooltip = (disabled && type !== 'password') || isTruncated;
+  const resolvedTooltip = tooltipText || value;
+
+  return showTooltip && resolvedTooltip ? (
+    <DialTooltip tooltip={resolvedTooltip}>{input()}</DialTooltip>
   ) : (
     input()
   );


### PR DESCRIPTION
**Description and UI changes:**

added tooltip for truncated value

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added