### PR TITLE
feat: Add flat sections variant to SchemaRenderer

### DIFF
--- a/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
@@ -81,8 +81,17 @@ describe('DialSchemaRenderer', () => {
     );
   });
 
-  it('does not show error indicator before a field is touched', () => {
-    render(<DialSchemaRenderer schema={simpleSchema} />);
+  it('show error indicator before a field is touched when skipUntouched is false', () => {
+    render(<DialSchemaRenderer schema={simpleSchema} skipUntouched={false} />);
+    const nameSectionHeader = screen
+      .getByText('Name')
+      .closest('[role="button"]');
+    expect(nameSectionHeader).toBeInTheDocument();
+    expect(nameSectionHeader?.textContent).toContain('error');
+  });
+
+  it('does not show error indicator before a field is touched when skipUntouched is true', () => {
+    render(<DialSchemaRenderer schema={simpleSchema} skipUntouched={true} />);
     const nameSectionHeader = screen
       .getByText('Name')
       .closest('[role="button"]');

--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -530,3 +530,30 @@ export const CustomFieldRenderer: Story = {
     },
   },
 };
+
+export const SkipUntouchedComparison: StoryObj = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '32px' }}>
+      <div style={{ flex: 1 }}>
+        <h3 style={{ marginBottom: '12px', fontWeight: 600 }}>
+          skipUntouched: false (default) — errors shown immediately
+        </h3>
+        <DialSchemaRenderer
+          schema={credentialsSchema}
+          variant={SchemaRendererVariant.Flat}
+          skipUntouched={false}
+        />
+      </div>
+      <div style={{ flex: 1 }}>
+        <h3 style={{ marginBottom: '12px', fontWeight: 600 }}>
+          skipUntouched: true — errors shown only after interaction
+        </h3>
+        <DialSchemaRenderer
+          schema={credentialsSchema}
+          variant={SchemaRendererVariant.Flat}
+          skipUntouched={true}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -212,9 +212,13 @@ const meta: Meta<typeof DialSchemaRenderer> = {
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: [SchemaRendererVariant.Sections, SchemaRendererVariant.Flat],
+      options: [
+        SchemaRendererVariant.Sections,
+        SchemaRendererVariant.Flat,
+        SchemaRendererVariant.FlatSections,
+      ],
       description:
-        "'sections' wraps each top-level property in a collapsible card; 'flat' renders primitives as plain form fields",
+        "'sections' wraps each top-level property in a collapsible card; 'flat' renders primitives as plain form fields; 'flat-sections' renders an h2 heading above each section's fields",
     },
     readonly: {
       control: { type: 'boolean' },
@@ -269,6 +273,13 @@ export const ArrayWithDiscriminator: Story = {
     defaultValue: {
       tools: [{ type: 'rest-api', name: 'My API', url: 'https://example.com' }],
     },
+  },
+};
+
+export const FlatSectionsVariant: Story = {
+  args: {
+    variant: SchemaRendererVariant.FlatSections,
+    schema: flatMixedSchema,
   },
 };
 

--- a/src/components/SchemaRenderer/SchemaRenderer.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.tsx
@@ -55,6 +55,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
   onPropertyChange,
   onDefaultValues,
   renderField,
+  skipUntouched = false,
 }) => {
   const mergedTexts = useMemo(
     () => ({ ...DEFAULT_SCHEMA_TEXTS, ...texts }),
@@ -105,6 +106,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
         renderField,
         touchedPaths,
         markTouched,
+        skipUntouched,
       }}
     >
       <div className={mergeClasses('flex flex-col gap-4', className)}>
@@ -152,6 +154,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
           const errors = validateRequired(propValue, resolved, schema, key);
           const prefix = key + '.';
           const isSectionTouched =
+            !skipUntouched ||
             touchedPaths.has(key) ||
             [...touchedPaths].some((p) => p.startsWith(prefix));
 

--- a/src/components/SchemaRenderer/SchemaRenderer.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.tsx
@@ -130,6 +130,24 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
             );
           }
 
+          if (variant === SchemaRendererVariant.FlatSections) {
+            return (
+              <div key={key} className="flex flex-col gap-3">
+                <h2 className="dial-small-semi-text text-primary">
+                  {propLabel}
+                </h2>
+                <SchemaFieldContent
+                  schema={propSchema}
+                  value={propValue}
+                  onChange={(v) => handlePropertyChange(key, v)}
+                  path={[key]}
+                  level={0}
+                  required={isRequired}
+                />
+              </div>
+            );
+          }
+
           const summary = buildSummary(propValue, resolved, schema);
           const errors = validateRequired(propValue, resolved, schema, key);
           const prefix = key + '.';

--- a/src/components/SchemaRenderer/components/SchemaField.tsx
+++ b/src/components/SchemaRenderer/components/SchemaField.tsx
@@ -8,6 +8,7 @@ import {
   isObjectType,
   buildSummary,
   validateRequired,
+  isMissingRequiredValue,
 } from '@/components/SchemaRenderer/utils';
 import { SchemaSection } from './SchemaSection';
 import { SchemaFieldContent } from './SchemaFieldContent';
@@ -36,6 +37,7 @@ import { SchemaFieldContent } from './SchemaFieldContent';
  * @param [level=0] - Nesting depth; object/array fields render as collapsible sections
  * @param [required] - Whether the field is required (shows error when empty)
  * @param [label] - Display label; falls back to schema title or path segment
+ * @param [skipUntouched] - When `true`, required-field errors are only shown after the user has interacted with a field.
  */
 export const SchemaField: FC<SchemaFieldProps> = ({
   schema,
@@ -50,6 +52,7 @@ export const SchemaField: FC<SchemaFieldProps> = ({
     rootSchema,
     defaultExpanded = true,
     touchedPaths = new Set<string>(),
+    skipUntouched = false,
   } = useSchemaContext();
   const resolved = resolveRef(schema, rootSchema);
 
@@ -67,6 +70,7 @@ export const SchemaField: FC<SchemaFieldProps> = ({
     const pathStr = path.join('.');
     const prefix = pathStr + '.';
     const isSectionTouched =
+      !skipUntouched ||
       touchedPaths.has(pathStr) ||
       [...touchedPaths].some((p) => p.startsWith(prefix));
     return (
@@ -90,11 +94,9 @@ export const SchemaField: FC<SchemaFieldProps> = ({
     );
   }
 
-  const isTouched = touchedPaths.has(path.join('.'));
+  const isTouched = !skipUntouched || touchedPaths.has(path.join('.'));
   const error =
-    isTouched &&
-    required &&
-    (value === undefined || value === null || value === '')
+    isTouched && required && isMissingRequiredValue(value)
       ? `${label ?? 'Field'} is required`
       : undefined;
 

--- a/src/components/SchemaRenderer/context.tsx
+++ b/src/components/SchemaRenderer/context.tsx
@@ -19,6 +19,7 @@ interface SchemaRendererContextValue {
   ) => React.ReactNode;
   touchedPaths?: ReadonlySet<string>;
   markTouched?: (path: string) => void;
+  skipUntouched?: boolean;
 }
 
 export const SchemaRendererContext =

--- a/src/components/SchemaRenderer/tests/SchemaField.spec.tsx
+++ b/src/components/SchemaRenderer/tests/SchemaField.spec.tsx
@@ -12,10 +12,16 @@ const renderWithSchema = (
   ui: ReactElement,
   schema: JsonSchema = {},
   touchedPaths?: ReadonlySet<string>,
+  skipUntouched?: boolean,
 ) =>
   render(
     <SchemaRendererContext.Provider
-      value={{ rootSchema: schema, texts: DEFAULT_SCHEMA_TEXTS, touchedPaths }}
+      value={{
+        rootSchema: schema,
+        texts: DEFAULT_SCHEMA_TEXTS,
+        touchedPaths,
+        skipUntouched,
+      }}
     >
       {ui}
     </SchemaRendererContext.Provider>,
@@ -114,7 +120,7 @@ describe('Dial UI Kit :: SchemaField', () => {
     expect(screen.getByText('Email is required')).toBeInTheDocument();
   });
 
-  test('does not show required error before the field is touched', () => {
+  test('show required error before the field is touched when skipUntouched is undefined', () => {
     renderWithSchema(
       <SchemaField
         schema={{ type: 'string' }}
@@ -125,6 +131,24 @@ describe('Dial UI Kit :: SchemaField', () => {
         level={0}
         required
       />,
+    );
+    expect(screen.queryByText('Email is required')).toBeInTheDocument();
+  });
+
+  test('does not show required error before the field is touched if skipUntouched is true', () => {
+    renderWithSchema(
+      <SchemaField
+        schema={{ type: 'string' }}
+        value=""
+        onChange={vi.fn()}
+        path={['field']}
+        label="Email"
+        level={0}
+        required
+      />,
+      {},
+      undefined,
+      true,
     );
     expect(screen.queryByText('Email is required')).not.toBeInTheDocument();
   });

--- a/src/components/SchemaRenderer/types.ts
+++ b/src/components/SchemaRenderer/types.ts
@@ -3,6 +3,7 @@ import type React from 'react';
 export enum SchemaRendererVariant {
   Sections = 'sections',
   Flat = 'flat',
+  FlatSections = 'flat-sections',
 }
 
 export enum SchemaDisplayMode {

--- a/src/components/SchemaRenderer/types.ts
+++ b/src/components/SchemaRenderer/types.ts
@@ -116,6 +116,11 @@ export interface DialSchemaRendererProps {
    * properties still use collapsible sections.
    */
   variant?: SchemaRendererVariant;
+  /**
+   * When `true`, required-field errors are only shown after the user has interacted
+   * with a field. When `false` (default), all unfilled required fields are highlighted immediately.
+   */
+  skipUntouched?: boolean;
   onChange?: (value: Record<string, unknown>) => void;
   onPropertyChange?: (path: string, value: unknown) => void;
   onDefaultValues?: (value: Record<string, unknown>) => void;

--- a/src/components/SchemaRenderer/utils.ts
+++ b/src/components/SchemaRenderer/utils.ts
@@ -22,6 +22,10 @@ export function resolveRef(
   return { ...fullyResolved, ...siblings };
 }
 
+export function isMissingRequiredValue(value: unknown): boolean {
+  return value === undefined || value === null || value === '';
+}
+
 export function isObjectType(schema: JsonSchemaDef): boolean {
   return (
     schema.type === JsonSchemaType.Object ||
@@ -161,7 +165,7 @@ export function validateRequired(
   for (const key of required) {
     const fieldPath = path ? `${path}.${key}` : key;
     const v = obj?.[key];
-    if (v === undefined || v === null) {
+    if (isMissingRequiredValue(v)) {
       const propSchema = resolved.properties?.[key];
       const label = propSchema?.title ?? toFieldLabel(key);
       errors.push({ path: fieldPath, message: `${label} is required` });


### PR DESCRIPTION
**Description and UI changes:**

1) 
Added variant of sections with only header, no collapse:

<img width="1919" height="725" alt="image" src="https://github.com/user-attachments/assets/1be0ffe1-ea19-445b-8441-6212b6e77ee4" />
2) Added param to configure whether to show fields as invalid before user touched them
3) Unified required field validation (same check in two places instead of different rules)


Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added