### PR TITLE
fix(chat): add a check to show rename in the context menu with only write permissions (Issue #668)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ export default [
       '**/**.spec.tsx',
       '**/dist',
       '**/storybook-static',
+      '**/coverage',
       '**/.cursor',
       'setupTests.ts',
     ],

--- a/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-grid-context-menu.spec.tsx
@@ -861,6 +861,71 @@ describe('Dial UI Kit :: useGridContextMenu', () => {
     expect(menuItems[0].key).toBe(DialFileManagerActions.Delete);
   });
 
+  test('rename action is not shown when file lacks WRITE permission', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Rename]: 'Rename' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithoutWritePermission);
+
+    expect(menuItems).toHaveLength(0);
+    expect(
+      menuItems.find((item) => item.key === DialFileManagerActions.Rename),
+    ).toBeUndefined();
+  });
+
+  test('rename action is shown when file has WRITE permission', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Rename]: 'Rename' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithWritePermission);
+
+    expect(menuItems).toHaveLength(1);
+    expect(menuItems[0].key).toBe(DialFileManagerActions.Rename);
+  });
+
+  test('rename action is shown when file has no permissions defined', () => {
+    const { result } = renderHook(() =>
+      useGridContextMenu({
+        actionLabels: { [DialFileManagerActions.Rename]: 'Rename' },
+        onDuplicate: vi.fn(),
+        onCopy: vi.fn(),
+        onMove: vi.fn(),
+        onDownload: vi.fn(),
+        onRename: vi.fn(),
+        onDelete: vi.fn(),
+        onInfo: vi.fn(),
+        onUnshare: vi.fn(),
+      }),
+    );
+
+    const menuItems = result.current(fileWithoutPermissions);
+
+    expect(menuItems).toHaveLength(1);
+    expect(menuItems[0].key).toBe(DialFileManagerActions.Rename);
+  });
+
   test('delete action is shown when file has no permissions defined', () => {
     const { result } = renderHook(() =>
       useGridContextMenu({

--- a/src/components/FileManager/hooks/use-grid-context-menu.tsx
+++ b/src/components/FileManager/hooks/use-grid-context-menu.tsx
@@ -281,7 +281,11 @@ export const useGridContextMenu = ({
       const isRenameAvailable =
         file.nodeType === DialFileNodeType.FOLDER ||
         (file.nodeType === DialFileNodeType.ITEM && isRenameFileAvailable);
-      if (actionLabels[DialFileManagerActions.Rename] && isRenameAvailable) {
+      if (
+        actionLabels[DialFileManagerActions.Rename] &&
+        isRenameAvailable &&
+        emptyOrWritePermissions
+      ) {
         items.push({
           key: DialFileManagerActions.Rename,
           label: actionLabels[DialFileManagerActions.Rename],


### PR DESCRIPTION
**Description and UI changes:**

Need to add a check to show rename in the context menu with only write permissions

Issues:

- Issue #668

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added