### PR TITLE
fix(chat): disable hidden files selecting for attach (Issue #691)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -740,13 +740,12 @@ export const DialFileManagerView: FC = () => {
       allowedFileTypes?: DialFileAcceptType[],
       maxSelectableFileSize?: number,
     ) => {
-      return !!getRowDisabledTooltip(
-        row,
-        allowedFileTypes,
-        maxSelectableFileSize,
+      return (
+        !!getDisabledTooltip?.(row) ||
+        !!getRowDisabledTooltip(row, allowedFileTypes, maxSelectableFileSize)
       );
     },
-    [getRowDisabledTooltip],
+    [getRowDisabledTooltip, getDisabledTooltip],
   );
 
   const disabledGridRowIds = useMemo(() => {

--- a/src/components/FileManager/FileManagerTooltip.tsx
+++ b/src/components/FileManager/FileManagerTooltip.tsx
@@ -93,8 +93,9 @@ export const FileManagerTooltip = ({
   const hoveredRowTooltipContent = useMemo(() => {
     if (!hoveredRowFile) return undefined;
 
-    if (getDisabledTooltip && hoveredRowFile.folderId) {
-      return getDisabledTooltip(hoveredRowFile);
+    if (getDisabledTooltip) {
+      const tooltip = getDisabledTooltip(hoveredRowFile);
+      if (tooltip) return tooltip;
     }
 
     return getRowDisabledTooltip(


### PR DESCRIPTION
**Description and UI changes:**

Hidden files and files from hidden folder should be disabled (with tooltip-explanation) for attach

Issues:

- Issue #691

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added