### PR TITLE
fix: Path navigation in breadcrumbs in Move to popup always redirects to public folder (Issue #2654)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -145,6 +145,7 @@ export type DialFileManagerDestinationFolderPopupOptions = Pick<
 > & {
   getCopyHeader?: (itemsCount: number, itemName?: string) => string;
   getMoveHeader?: (itemsCount: number, itemName?: string) => string;
+  processDestinationFolderPath?: (path: string) => string;
 };
 
 export interface FileMetadataPopupOptions {

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -51,6 +51,7 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
   collapsedFileTree?: boolean;
   alertProps?: DialNotificationProps;
   onFolderPopupPathChange?: (newPath?: string) => void;
+  processDestinationFolderPath?: (path: string) => string;
 }
 
 /**
@@ -92,6 +93,9 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
  * @param [sourceFolder] - The source folder path for move operations
  * @param [disabledPathTooltip="Unavailable for the original path. Please select another folder"] - Tooltip text when destination is disabled
  * @param [collapsedFileTree=false] - Whether the file tree should be initially collapsed
+ * @param [processDestinationFolderPath] - Optional function to process the destination folder path before setting it
+ *
+ * @returns A React component for the destination folder selection popup
  */
 export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   onClose,
@@ -114,6 +118,7 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   path,
   collapsedFileTree = false,
   alertProps,
+  processDestinationFolderPath,
   ...restProps
 }: DestinationFolderPopupProps) => {
   const [showHiddenFiles, setShowHiddenFiles] = useState(false);
@@ -158,11 +163,18 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   const handleOnPathChange = useCallback(
     (nextPath?: string) => {
       if (nextPath) {
-        onFolderPopupPathChange?.(nextPath);
-        setDestinationFolderPath?.(nextPath);
+        let path = processDestinationFolderPath
+          ? processDestinationFolderPath(nextPath)
+          : nextPath;
+        onFolderPopupPathChange?.(path);
+        setDestinationFolderPath?.(path);
       }
     },
-    [onFolderPopupPathChange, setDestinationFolderPath],
+    [
+      onFolderPopupPathChange,
+      setDestinationFolderPath,
+      processDestinationFolderPath,
+    ],
   );
 
   const defaultTitle =


### PR DESCRIPTION
**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #2654

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added