### PR TITLE
fix: fixed size of invalid file input in LoadFileAreaFeald (Issue #3500)

### DIFF
--- a/src/components/LoadFileArea/FilledInput.tsx
+++ b/src/components/LoadFileArea/FilledInput.tsx
@@ -53,7 +53,7 @@ export const DialFilledInput: FC<DialFilledInputProps> = ({
     <DialInput
       {...props}
       iconBefore={getIcon()}
-      containerClassName="h-[40px] p-0"
+      containerClassName={classNames('h-[40px] p-0', isInvalid && 'h-[60px]')}
       className={classNames(
         'rounded-r-none border-r-0',
         isInvalid && 'text-error',

--- a/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
+++ b/src/components/LoadFileArea/LoadFileAreaField.stories.tsx
@@ -161,6 +161,7 @@ export const InvalidFormat: Story = {
   },
   args: {
     ...Empty.args,
+    errorText: 'Unsupported file type',
     fileFormatError: 'Unsupported file type',
     isInvalid: (file: File) => file.name.endsWith('.exe'),
   },


### PR DESCRIPTION
**Description and UI changes:**

Before: 
<img width="1052" height="862" alt="image" src="https://github.com/user-attachments/assets/94af954a-6e52-41ff-8338-657b807a216e" />
After: 
<img width="805" height="643" alt="image" src="https://github.com/user-attachments/assets/bed5db3a-aee1-44c4-8fec-b636f68ce787" />


Issues:

- Issue #3500

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added