### PR TITLE
fix: Added ability to hide Add Folder button in destination folder popup (Issue #3506)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -402,6 +402,7 @@ export interface DialFileManagerProps {
   nonClickableTableColumns?: FileManagerColumnKey[];
   hideSearchPathItemName?: boolean;
   showHiddenFileSwitcherInDestinationPopup?: boolean;
+  showCreateFolderButtonInDestinationPopup?: boolean;
   autoSelectUploadedItems?: boolean;
 }
 
@@ -666,6 +667,7 @@ export const DialFileManagerView: FC = () => {
     nonClickableTableColumns,
     hideSearchPathItemName,
     showHiddenFileSwitcherInDestinationPopup,
+    showCreateFolderButtonInDestinationPopup,
     newFolderDefaultName,
   } = useFileManagerContext();
 
@@ -1568,6 +1570,7 @@ export const DialFileManagerView: FC = () => {
           treeOptions={{ header: treeOptions?.header }}
           onFolderPopupPathChange={onFolderPopupPathChange}
           showHiddenFileSwitcher={showHiddenFileSwitcherInDestinationPopup}
+          showCreateFolderButton={showCreateFolderButtonInDestinationPopup}
           hideSearchPathItemName={hideSearchPathItemName}
         />
         <ConflictResolutionPopup

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -236,6 +236,7 @@ export interface FileManagerContextValue {
   unsupportedFileTypeTooltip?: string;
   hideSearchPathItemName?: boolean;
   showHiddenFileSwitcherInDestinationPopup?: boolean;
+  showCreateFolderButtonInDestinationPopup?: boolean;
 }
 
 export const FileManagerContext = createContext<

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -148,6 +148,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   nonClickableTableColumns,
   hideSearchPathItemName,
   showHiddenFileSwitcherInDestinationPopup,
+  showCreateFolderButtonInDestinationPopup,
   autoSelectUploadedItems = false,
 }) => {
   const {
@@ -967,6 +968,7 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     fileTooLargeTooltip,
     unsupportedFileTypeTooltip,
     showHiddenFileSwitcherInDestinationPopup,
+    showCreateFolderButtonInDestinationPopup,
   };
 
   return (

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.spec.tsx
@@ -611,4 +611,25 @@ describe('Dial UI Kit :: DialDestinationFolderPopup', () => {
 
     expect(screen.queryByText('Show hidden files')).not.toBeInTheDocument();
   });
+
+  test('hides Add folder button', () => {
+    render(
+      <DialDestinationFolderPopup
+        open={true}
+        onClose={vi.fn()}
+        items={mockFiles}
+        rootItem={{
+          id: 'root',
+          name: 'Root',
+          path: '/',
+          folderId: 'root-folder',
+          nodeType: DialFileNodeType.FOLDER,
+          label: 'Root',
+        }}
+        showCreateFolderButton={false}
+      />,
+    );
+
+    expect(screen.queryByText('Add folder')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.stories.tsx
@@ -155,3 +155,10 @@ export const WithoutHiddenFilesSwitcher: Story = {
     showHiddenFileSwitcher: false,
   },
 };
+
+export const WithoutAddFolderButton: Story = {
+  args: {
+    mode: 'move',
+    showCreateFolderButton: false,
+  },
+};

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -43,6 +43,7 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
   moveLabel?: string;
   addFolderLabel?: string;
   showHiddenFileSwitcher?: boolean;
+  showCreateFolderButton?: boolean;
   hiddenFilesSwitcherLabel?: string;
   mode?: 'copy' | 'move';
   header?: ReactNode;
@@ -109,6 +110,7 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   mode = DestinationFolderMode.Copy,
   hiddenFilesSwitcherLabel = 'Show hidden files',
   showHiddenFileSwitcher = true,
+  showCreateFolderButton = true,
   onUploadFiles,
   onValidateUpload,
   maxFileSize,
@@ -131,8 +133,10 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
   }, []);
 
   const mobileFooterDropdownItems = useMemo<DropdownItem[]>(() => {
-    const footerDropdownItems = [
-      {
+    const footerDropdownItems = [];
+
+    if (showCreateFolderButton) {
+      footerDropdownItems.push({
         key: 'add-folder',
         label: addFolderLabel,
         icon: (
@@ -142,8 +146,8 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
           fileManagerActionRef.current?.createFolder();
           setMobileMenuOpen(false);
         },
-      },
-    ];
+      });
+    }
 
     if (showHiddenFileSwitcher) {
       footerDropdownItems.push({
@@ -158,7 +162,12 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
     }
 
     return footerDropdownItems;
-  }, [addFolderLabel, hiddenFilesSwitcherLabel, showHiddenFileSwitcher]);
+  }, [
+    addFolderLabel,
+    hiddenFilesSwitcherLabel,
+    showHiddenFileSwitcher,
+    showCreateFolderButton,
+  ]);
 
   const handleOnPathChange = useCallback(
     (nextPath?: string) => {
@@ -220,17 +229,21 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
               </DialDropdown>
             ) : (
               <>
-                <DialPrimaryButton
-                  label={addFolderLabel}
-                  appearance={ButtonAppearance.Ghost}
-                  iconBefore={<IconFolderPlus {...BASE_ICON_PROPS} />}
-                  onClick={() => {
-                    fileManagerActionRef.current?.createFolder();
-                  }}
-                />
+                {showCreateFolderButton && (
+                  <DialPrimaryButton
+                    label={addFolderLabel}
+                    appearance={ButtonAppearance.Ghost}
+                    iconBefore={<IconFolderPlus {...BASE_ICON_PROPS} />}
+                    onClick={() => {
+                      fileManagerActionRef.current?.createFolder();
+                    }}
+                  />
+                )}
+                {showCreateFolderButton && showHiddenFileSwitcher && (
+                  <div className="w-px h-[26px] bg-controls-disable-accent my-2" />
+                )}
                 {showHiddenFileSwitcher && (
                   <>
-                    <div className="w-px h-[26px] bg-controls-disable-accent my-2" />
                     <div className="inline-flex items-center cursor-pointer">
                       <DialSwitch
                         label={hiddenFilesSwitcherLabel}


### PR DESCRIPTION
**Description and UI changes:**

<img width="1456" height="631" alt="image" src="https://github.com/user-attachments/assets/e5c1414c-8568-44a0-8d4e-f7721234576b" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added