### PR TITLE
feat!: flatten DialDropdown and DialDropdownIcon menu prop. Issue #369

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,60 @@ This file is read by Cursor, Codex, and other agent harnesses alongside project 
 | New public component        | Storybook story, spec, entry in `src/index.ts`     |
 | Visual / interaction change | Update stories; adjust or add tests                |
 | Peer dependency surface     | Document in README or story descriptions if needed |
+| **Breaking change**         | CHANGELOG.md entry + migration guide (see below)   |
+
+## Breaking changes — documentation required
+
+A **breaking change** is any modification that requires consumers to update their code: renamed/removed props, changed component behaviour, removed exports, altered CSS token names, etc.
+
+### 1. Find the next version
+
+```bash
+git tag --sort=-v:refname | head -1
+```
+
+This gives you the **last released** version. Breaking changes go into the **next** release, so increment the minor version (the middle number) by 1 and reset the patch to 0.
+
+Examples: `0.10.0` → `0.11.0`, `1.3.2` → `1.4.0`.
+
+Use this next version for all entries below.
+
+### 2. Add a CHANGELOG entry
+
+Open `CHANGELOG.md` and add an entry under `## [<version>]` (create the section if it does not exist). Use this format inside a `### Breaking Changes` subsection:
+
+```markdown
+### Breaking Changes
+
+- **`ComponentName` — `oldProp` → `newProp`** — Short explanation of what changed and why.
+  See [migration guide](migration-guides/<version>/<migration-name>.md).
+```
+
+Rules:
+
+- State **what changed**, **from → to**, and **why** (alignment, consistency, accessibility, etc.).
+- Link to the migration guide you will create in step 3.
+- Keep it to 1–3 sentences per item.
+
+### 3. Create a migration guide
+
+Create a new file at `migration-guides/<version>/<migration-name>.md`.  
+Use `migration-guides/_template.md` as the base and fill in all sections:
+
+- **Why this changed** — motivation.
+- **What changed** — before/after table.
+- **Step-by-step migration** — concrete instructions with code examples and a grep command to locate usages.
+- **Verify** — `npm run typecheck && npm run test`.
+
+`<migration-name>` should be kebab-case and describe the change, e.g. `button-variant-prop-rename`.
+
+### 4. Update the migration-guides index
+
+Add a row to the table in `migration-guides/README.md`:
+
+```markdown
+| <version> | [<migration-name>](<version>/<migration-name>.md) | One-line summary |
+```
 
 ## Commands reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to `@epam/ai-dial-ui-kit` are documented here.
+
+This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
+Versions match the git tags on the `development` branch.
+
+---
+
+## [Unreleased]
+
+_No unreleased changes yet._
+
+---
+
+## [0.11.0]
+
+### Breaking Changes
+
+- **`DialDropdown` — `menu` prop removed, flat props added** — The nested `menu: { items, onClick, header, footer }` prop has been replaced with four top-level props: `items`, `onItemClick`, `menuHeader`, `menuFooter`. `DropdownMenuProps` is no longer exported. `DialDropdownIcon` is updated the same way — its `menu` prop is gone; pass `items` (and optionally `onItemClick`, `menuHeader`, `menuFooter`) directly.
+  See [migration guide](migration-guides/0.11.0/dropdown-menu-prop-flatten.md).
+
+---
+
+## [0.10.0]
+
+---
+
+## Format guide
+
+Each version section may contain these subsections (only include non-empty ones):
+
+### Breaking Changes
+
+> What changed, what it changed **from → to**, and **why**.
+> Every breaking change must have a corresponding migration guide linked below.
+
+- **`ComponentName` prop renamed** — `oldProp` → `newProp` to align with HTML semantics. See [migration guide](migration-guides/0.x.0/component-name-prop-rename.md).
+
+### Added
+
+- Short description of new feature or component.
+
+### Changed
+
+- Backwards-compatible changes to existing behavior or API.
+
+### Deprecated
+
+- Features that will be removed in a future version; include the planned removal version.
+
+### Removed
+
+- Features removed in this release (non-breaking removals, e.g. internal APIs).
+
+### Fixed
+
+- Bug fixes.
+
+### Security
+
+- Vulnerability patches.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,17 @@ export default [
   js.configs.recommended,
 
   {
+    files: ['tools/**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
+  {
     files: ['**/*.{ts,tsx,js,jsx}'],
 
     languageOptions: {

--- a/migration-guides/0.11.0/dropdown-menu-prop-flatten.md
+++ b/migration-guides/0.11.0/dropdown-menu-prop-flatten.md
@@ -1,0 +1,78 @@
+# Migrating `DialDropdown` and `DialDropdownIcon` `menu` prop — v0.11.0
+
+## Why this changed
+
+The nested `menu` object was an unnecessary indirection. Passing `items` directly as a top-level prop is simpler, more consistent with other components in the library, and friendlier to TypeScript autocomplete.
+
+## What changed
+
+| Before                              | After                             |
+| ----------------------------------- | --------------------------------- |
+| `menu={{ items }}`                  | `items={items}`                   |
+| `menu={{ items, onClick: fn }}`     | `items={items} onItemClick={fn}`  |
+| `menu={{ items, header: node }}`    | `items={items} menuHeader={node}` |
+| `menu={{ items, footer: node }}`    | `items={items} menuFooter={node}` |
+| `DropdownMenuProps` (exported type) | Removed — no replacement needed   |
+
+Both `DialDropdown` and `DialDropdownIcon` are affected.
+
+## Step-by-step migration
+
+### 1. Find all usages
+
+```bash
+grep -r "menu={{" src/
+grep -r "DropdownMenuProps" src/
+```
+
+### 2. Replace with the new API
+
+**Before:**
+
+```tsx
+<DialDropdown menu={{ items, onClick: handleClick, header: <h4>Title</h4>, footer: <Footer /> }}>
+  <button type="button">Open</button>
+</DialDropdown>
+
+<DialDropdownIcon
+  ariaLabel="Select model"
+  icon={<IconBrandOpenai />}
+  menu={{ items, onClick: handleClick }}
+/>
+```
+
+**After:**
+
+```tsx
+<DialDropdown
+  items={items}
+  onItemClick={handleClick}
+  menuHeader={<h4>Title</h4>}
+  menuFooter={<Footer />}
+>
+  <button type="button">Open</button>
+</DialDropdown>
+
+<DialDropdownIcon
+  ariaLabel="Select model"
+  icon={<IconBrandOpenai />}
+  items={items}
+  onItemClick={handleClick}
+/>
+```
+
+### 3. Remove `DropdownMenuProps` imports
+
+```tsx
+// Remove this line
+import type { DropdownMenuProps } from '@epam/ai-dial-ui-kit';
+```
+
+### 4. Verify
+
+Run the commands specific to your project, e.g.
+
+```bash
+npm run typecheck
+npm run test
+```

--- a/migration-guides/README.md
+++ b/migration-guides/README.md
@@ -1,0 +1,21 @@
+# Migration Guides
+
+This folder contains step-by-step migration guides for breaking changes introduced in each release of `@epam/ai-dial-ui-kit`.
+
+## Structure
+
+```
+migration-guides/
+  <version>/
+    <migration-name>.md   ← one file per breaking change
+```
+
+## Index
+
+| Version | Guide | Summary |
+| ------- | ----- | ------- |
+| 0.11.0 | [dropdown-menu-prop-flatten](0.11.0/dropdown-menu-prop-flatten.md) | `DialDropdown`/`DialDropdownIcon` `menu` prop replaced with flat `items`, `onItemClick`, `menuHeader`, `menuFooter` props |
+
+---
+
+New guides are added here whenever a breaking change is introduced. See [CHANGELOG.md](../CHANGELOG.md) for the full list of changes per release.

--- a/migration-guides/_template.md
+++ b/migration-guides/_template.md
@@ -1,0 +1,54 @@
+# Migration guide template
+
+Use this file as a template when adding a new migration guide.
+Copy it to `migration-guides/<version>/<migration-name>.md` and fill in the sections.
+
+---
+
+# Migrating `<what changed>` — v`<from>` → v`<to>`
+
+## Why this changed
+
+_Explain the motivation: API consistency, accessibility improvement, removed ambiguity, etc._
+
+## What changed
+
+| Before     | After      |
+| ---------- | ---------- |
+| `oldThing` | `newThing` |
+
+## Step-by-step migration
+
+### 1. Find all usages
+
+```bash
+# Example: search for the old prop name across your project
+grep -r "oldPropName" src/
+```
+
+### 2. Replace with the new API
+
+**Before:**
+
+```tsx
+<DialComponent oldPropName="value" />
+```
+
+**After:**
+
+```tsx
+<DialComponent newPropName="value" />
+```
+
+### 3. Verify
+
+Run the commands specific to your project, e.g.
+
+```bash
+npm run typecheck
+npm run test
+```
+
+## Notes
+
+_Any edge cases, optional codemods, or further reading._

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -167,10 +167,8 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
 
         <li className={mergeClasses(breadcrumbItemBaseClassName)}>
           <DialDropdown
-            menu={{
-              items: dropdownItems,
-              onClick: handleDropdownItemClick,
-            }}
+            items={dropdownItems}
+            onItemClick={handleDropdownItemClick}
             placement="bottom-start"
             matchReferenceWidth={false}
           >

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -43,9 +43,7 @@ export const DialButtonDropdown: FC<DialButtonDropdownProps> = ({
   return (
     <div>
       <DialDropdown
-        menu={{
-          items,
-        }}
+        items={items}
         onOpenChange={(open) => setIsDropdownOpen(open)}
       >
         <DialButton

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -212,12 +212,12 @@ describe('Dial UI Kit :: Dropdown', () => {
             icon: <IconCheck />,
           },
           {
-              key: 'i2',
-              label: 'With Icon Disabled',
-              disabled: true,
-              icon: <IconCheck />,
-            },
-          ]}
+            key: 'i2',
+            label: 'With Icon Disabled',
+            disabled: true,
+            icon: <IconCheck />,
+          },
+        ]}
       >
         <button type="button">Open</button>
       </DialDropdown>,

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -25,7 +25,7 @@ const readPosition = (el: HTMLElement) =>
 describe('Dial UI Kit :: Dropdown', () => {
   test('renders & toggles aria-expanded on open/close', () => {
     const { container } = render(
-      <DialDropdown menu={{ items }}>
+      <DialDropdown items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -44,13 +44,11 @@ describe('Dial UI Kit :: Dropdown', () => {
     const onMenu = vi.fn();
     render(
       <DialDropdown
-        menu={{
-          items: [
-            { key: 'a', label: 'A', onClick: onItem },
-            { key: 'b', label: 'B' },
-          ],
-          onClick: onMenu,
-        }}
+        items={[
+          { key: 'a', label: 'A', onClick: onItem },
+          { key: 'b', label: 'B' },
+        ]}
+        onItemClick={onMenu}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -65,7 +63,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('disabled prevents opening', () => {
     render(
-      <DialDropdown disabled menu={{ items }}>
+      <DialDropdown disabled items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -78,7 +76,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('opens on context menu trigger', () => {
     render(
-      <DialDropdown trigger={[DropdownTrigger.ContextMenu]} menu={{ items }}>
+      <DialDropdown trigger={[DropdownTrigger.ContextMenu]} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -89,7 +87,7 @@ describe('Dial UI Kit :: Dropdown', () => {
   test('closable overlay shows button and calls onClose', () => {
     const onClose = vi.fn();
     render(
-      <DialDropdown closable onClose={onClose} menu={{ items }}>
+      <DialDropdown closable onClose={onClose} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -105,13 +103,11 @@ describe('Dial UI Kit :: Dropdown', () => {
     const onMenu = vi.fn();
     render(
       <DialDropdown
-        menu={{
-          items: [
-            { key: 'x', label: 'X', disabled: true, onClick: onItem },
-            { key: 'y', label: 'Y' },
-          ],
-          onClick: onMenu,
-        }}
+        items={[
+          { key: 'x', label: 'X', disabled: true, onClick: onItem },
+          { key: 'y', label: 'Y' },
+        ]}
+        onItemClick={onMenu}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -125,7 +121,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('error item has proper class and overlay width hugs content', () => {
     render(
-      <DialDropdown menu={{ items }} matchReferenceWidth={false}>
+      <DialDropdown items={items} matchReferenceWidth={false}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -148,7 +144,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       { key: 'item2', label: 'Item 2' },
     ];
     render(
-      <DialDropdown menu={{ items: itemsWithHeader }}>
+      <DialDropdown items={itemsWithHeader}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -173,7 +169,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       },
     ];
     render(
-      <DialDropdown menu={{ items: itemsWithHeader, onClick: onMenu }}>
+      <DialDropdown items={itemsWithHeader} onItemClick={onMenu}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -186,7 +182,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('outsideClosable=false keeps menu open on outside press', () => {
     render(
-      <DialDropdown outsideClosable={false} menu={{ items }}>
+      <DialDropdown outsideClosable={false} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -208,22 +204,20 @@ describe('Dial UI Kit :: Dropdown', () => {
   test('icon is rendered and inherits state classes (danger/disabled)', () => {
     render(
       <DialDropdown
-        menu={{
-          items: [
-            {
-              key: 'i1',
-              label: 'With Icon Danger',
-              danger: true,
-              icon: <IconCheck />,
-            },
-            {
+        items={[
+          {
+            key: 'i1',
+            label: 'With Icon Danger',
+            danger: true,
+            icon: <IconCheck />,
+          },
+          {
               key: 'i2',
               label: 'With Icon Disabled',
               disabled: true,
               icon: <IconCheck />,
             },
-          ],
-        }}
+          ]}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -252,12 +246,10 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     render(
       <DialDropdown
-        menu={{
-          items: [
-            { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
-          ],
-          onClick: onMenu,
-        }}
+        items={[
+          { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
+        ]}
+        onItemClick={onMenu}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -278,7 +270,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('becomes disabled while open -> closes via effect', () => {
     const { rerender } = render(
-      <DialDropdown disabled={false} menu={{ items }}>
+      <DialDropdown disabled={false} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -287,7 +279,7 @@ describe('Dial UI Kit :: Dropdown', () => {
     expect(screen.getByRole('menu')).toBeInTheDocument();
 
     rerender(
-      <DialDropdown disabled menu={{ items }}>
+      <DialDropdown disabled items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -297,7 +289,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('ignores contextmenu when trigger does not include ContextMenu', () => {
     render(
-      <DialDropdown menu={{ items }}>
+      <DialDropdown items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -318,7 +310,7 @@ describe('Dial UI Kit :: Dropdown', () => {
         >
           <button type="button">Safe Outside</button>
         </div>
-        <DialDropdown outsidePressIgnoreRef={ignoreRef} menu={{ items }}>
+        <DialDropdown outsidePressIgnoreRef={ignoreRef} items={items}>
           <button type="button">Open</button>
         </DialDropdown>
       </div>,
@@ -337,7 +329,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('explicit placement uses flip middleware path', () => {
     render(
-      <DialDropdown placement="bottom-end" menu={{ items }}>
+      <DialDropdown placement="bottom-end" items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -348,7 +340,7 @@ describe('Dial UI Kit :: Dropdown', () => {
   test('opens on hover when enabled', async () => {
     const user = userEvent.setup();
     const { container } = render(
-      <DialDropdown trigger={[DropdownTrigger.Hover]} menu={{ items }}>
+      <DialDropdown trigger={[DropdownTrigger.Hover]} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -367,7 +359,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('controlled mode uses the `open` prop (isControlled ? !!open) regardless of defaultOpen or clicks', () => {
     const { container, rerender } = render(
-      <DialDropdown open={false} defaultOpen={true} menu={{ items }}>
+      <DialDropdown open={false} defaultOpen={true} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -380,7 +372,7 @@ describe('Dial UI Kit :: Dropdown', () => {
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 
     rerender(
-      <DialDropdown open={true} defaultOpen={true} menu={{ items }}>
+      <DialDropdown open={true} defaultOpen={true} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -389,7 +381,7 @@ describe('Dial UI Kit :: Dropdown', () => {
     expect(screen.getByRole('menu')).toBeInTheDocument();
 
     rerender(
-      <DialDropdown open={false} defaultOpen={true} menu={{ items }}>
+      <DialDropdown open={false} defaultOpen={true} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -404,12 +396,10 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     render(
       <DialDropdown
-        menu={{
-          items: [
-            { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
-          ],
-          onClick: onMenu,
-        }}
+        items={[
+          { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
+        ]}
+        onItemClick={onMenu}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -436,11 +426,9 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     render(
       <DialDropdown
-        menu={{
-          header: () => <div>{headerText}</div>,
-          footer: <div>{footerText}</div>,
-          items,
-        }}
+        items={items}
+        menuHeader={() => <div>{headerText}</div>}
+        menuFooter={<div>{footerText}</div>}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -473,7 +461,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       <DialDropdown
         disabled
         trigger={[DropdownTrigger.ContextMenu]}
-        menu={{ items }}
+        items={items}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -490,10 +478,8 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     render(
       <DialDropdown
-        menu={{
-          header: () => <div role="hdr">{headerText}</div>,
-          items: simpleItems,
-        }}
+        items={simpleItems}
+        menuHeader={() => <div role="hdr">{headerText}</div>}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -524,13 +510,11 @@ describe('Dial UI Kit :: Dropdown', () => {
     const headerText = 'Filters';
     render(
       <DialDropdown
-        menu={{
-          header: <div>{headerText}</div>,
-          items: [
-            { key: 'a', label: 'A' },
-            { key: 'b', label: 'B' },
-          ],
-        }}
+        items={[
+          { key: 'a', label: 'A' },
+          { key: 'b', label: 'B' },
+        ]}
+        menuHeader={<div>{headerText}</div>}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -552,13 +536,11 @@ describe('Dial UI Kit :: Dropdown', () => {
 
     render(
       <DialDropdown
-        menu={{
-          items: [
-            { key: 'a', label: 'A' },
-            { key: 'b', label: 'B' },
-          ],
-          footer: footerFn,
-        }}
+        items={[
+          { key: 'a', label: 'A' },
+          { key: 'b', label: 'B' },
+        ]}
+        menuFooter={footerFn}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -584,7 +566,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       <DialDropdown
         anchorToMouse
         trigger={[DropdownTrigger.ContextMenu]}
-        menu={{ items }}
+        items={items}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -599,7 +581,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       <DialDropdown
         anchorToMouse
         trigger={[DropdownTrigger.Click]}
-        menu={{ items }}
+        items={items}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -612,7 +594,7 @@ describe('Dial UI Kit :: Dropdown', () => {
   test('calls onOpenChange on open and close', () => {
     const onOpenChange = vi.fn();
     render(
-      <DialDropdown onOpenChange={onOpenChange} menu={{ items }}>
+      <DialDropdown onOpenChange={onOpenChange} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -626,7 +608,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('matchReferenceWidth=false -> menu has w-max and no inline min-width', () => {
     render(
-      <DialDropdown matchReferenceWidth={false} menu={{ items }}>
+      <DialDropdown matchReferenceWidth={false} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -643,7 +625,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       <DialDropdown
         anchorToMouse
         trigger={[DropdownTrigger.Click]}
-        menu={{ items }}
+        items={items}
       >
         <button type="button">Open</button>
       </DialDropdown>,
@@ -675,7 +657,7 @@ describe('Dial UI Kit :: Dropdown', () => {
 
   test('does not change position when anchorToMouse=false (covers early return)', async () => {
     const { container } = render(
-      <DialDropdown trigger={[DropdownTrigger.Click]} menu={{ items }}>
+      <DialDropdown trigger={[DropdownTrigger.Click]} items={items}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -704,7 +686,7 @@ describe('Dial UI Kit :: Dropdown', () => {
     const { container } = render(
       <DialDropdown
         trigger={[DropdownTrigger.ContextMenu]}
-        menu={{ items }}
+        items={items}
         anchorToMouse
       >
         <button type="button">Open</button>
@@ -734,7 +716,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       },
     ];
     render(
-      <DialDropdown menu={{ items: itemsWithSub }}>
+      <DialDropdown items={itemsWithSub}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -760,7 +742,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       },
     ];
     const { container } = render(
-      <DialDropdown menu={{ items: itemsWithSub }}>
+      <DialDropdown items={itemsWithSub}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -794,7 +776,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       },
     ];
     render(
-      <DialDropdown menu={{ items: itemsWithSub }}>
+      <DialDropdown items={itemsWithSub}>
         <button type="button">Open</button>
       </DialDropdown>,
     );
@@ -820,7 +802,7 @@ describe('Dial UI Kit :: Dropdown', () => {
       },
     ];
     render(
-      <DialDropdown menu={{ items: itemsWithSub }}>
+      <DialDropdown items={itemsWithSub}>
         <button type="button">Open</button>
       </DialDropdown>,
     );

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -262,9 +262,7 @@ export const WithCustomHeader: Story = {
     menuHeader: (
       <div className="px-3 pt-2">
         <div className="flex items-center justify-between text-secondary">
-          <span className="dial-small-text font-medium">
-            Custom Time Range
-          </span>
+          <span className="dial-small-text font-medium">Custom Time Range</span>
           <IconChevronDown size={14} />
         </div>
       </div>
@@ -322,10 +320,7 @@ const FooterActionsExample = (args: DialDropdownProps) => {
       menuFooter={() => (
         <div className="px-2 pb-2 pt-1 border-t border-divider">
           <div className="flex items-center justify-end gap-2">
-            <DialNeutralButton
-              label="Cancel"
-              onClick={() => setOpen(false)}
-            />
+            <DialNeutralButton label="Cancel" onClick={() => setOpen(false)} />
             <DialPrimaryButton label="Apply" onClick={() => setOpen(false)} />
           </div>
         </div>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -120,7 +120,10 @@ const meta = {
     defaultOpen: { control: false },
     onOpenChange: { control: false },
     onClose: { control: false },
-    menu: { control: false },
+    items: { control: false },
+    onItemClick: { control: false },
+    menuHeader: { control: false },
+    menuFooter: { control: false },
     renderOverlay: { control: false },
     children: { control: false },
   },
@@ -131,7 +134,7 @@ const meta = {
     anchorToMouse: false,
     matchReferenceWidth: true,
     children: <TriggerBtn />,
-    menu: { items },
+    items,
   },
 } satisfies Meta<typeof DialDropdown>;
 
@@ -153,7 +156,7 @@ export const SpecWidthHugContent: Story = {
   args: {
     placement: 'bottom-start',
     matchReferenceWidth: false,
-    menu: { items: specItems },
+    items: specItems,
   },
 };
 
@@ -212,7 +215,7 @@ export const SecondaryEllipsisTrigger: Story = {
         iconBefore={<IconDots size={DIAL_ICON_SIZE.SM} />}
       />
     ),
-    menu: { items: specItems },
+    items: specItems,
     placement: 'bottom-end',
   },
 };
@@ -230,7 +233,7 @@ export const AllowedPlacements: Story = {
         {...args}
         placement="bottom-start"
         allowedPlacements={['top-start', 'top-end']}
-        menu={{ items: specItems }}
+        items={specItems}
       >
         <TriggerBtn label="Allowed Placements" />
       </DialDropdown>
@@ -255,19 +258,17 @@ export const WithCustomHeader: Story = {
   name: 'With custom header',
   args: {
     placement: 'bottom-start',
-    menu: {
-      header: (
-        <div className="px-3 pt-2">
-          <div className="flex items-center justify-between text-secondary">
-            <span className="dial-small-text font-medium">
-              Custom Time Range
-            </span>
-            <IconChevronDown size={14} />
-          </div>
+    items: [{ key: 'divider', type: DropdownItemType.Divider }, ...timeItems],
+    menuHeader: (
+      <div className="px-3 pt-2">
+        <div className="flex items-center justify-between text-secondary">
+          <span className="dial-small-text font-medium">
+            Custom Time Range
+          </span>
+          <IconChevronDown size={14} />
         </div>
-      ),
-      items: [{ key: 'divider', type: DropdownItemType.Divider }, ...timeItems],
-    },
+      </div>
+    ),
   },
 };
 
@@ -275,16 +276,14 @@ export const WithCustomFooter: Story = {
   name: 'With custom footer',
   args: {
     placement: 'bottom-start',
-    menu: {
-      items: timeItems,
-      footer: (
-        <div className="px-3 py-2 border-t">
-          <span className="dial-small-text text-primary font-medium">
-            Footer content
-          </span>
-        </div>
-      ),
-    },
+    items: timeItems,
+    menuFooter: (
+      <div className="px-3 py-2 border-t">
+        <span className="dial-small-text text-primary font-medium">
+          Footer content
+        </span>
+      </div>
+    ),
   },
 };
 
@@ -292,23 +291,21 @@ export const WithHeaderAndFooter: Story = {
   name: 'With header and footer',
   args: {
     placement: 'bottom-start',
-    menu: {
-      header: (
-        <div className="px-3 py-2 border-b">
-          <span className="dial-small-text text-primary font-medium">
-            Select time range
-          </span>
-        </div>
-      ),
-      items: timeItems,
-      footer: (
-        <div className="px-3 py-2 border-t">
-          <span className="dial-small-text text-primary font-medium">
-            Footer content
-          </span>
-        </div>
-      ),
-    },
+    items: timeItems,
+    menuHeader: (
+      <div className="px-3 py-2 border-b">
+        <span className="dial-small-text text-primary font-medium">
+          Select time range
+        </span>
+      </div>
+    ),
+    menuFooter: (
+      <div className="px-3 py-2 border-t">
+        <span className="dial-small-text text-primary font-medium">
+          Footer content
+        </span>
+      </div>
+    ),
   },
 };
 
@@ -321,20 +318,18 @@ const FooterActionsExample = (args: DialDropdownProps) => {
       trigger={[DropdownTrigger.Click]}
       open={open}
       onOpenChange={setOpen}
-      menu={{
-        items: timeItems,
-        footer: () => (
-          <div className="px-2 pb-2 pt-1 border-t border-divider">
-            <div className="flex items-center justify-end gap-2">
-              <DialNeutralButton
-                label="Cancel"
-                onClick={() => setOpen(false)}
-              />
-              <DialPrimaryButton label="Apply" onClick={() => setOpen(false)} />
-            </div>
+      items={timeItems}
+      menuFooter={() => (
+        <div className="px-2 pb-2 pt-1 border-t border-divider">
+          <div className="flex items-center justify-end gap-2">
+            <DialNeutralButton
+              label="Cancel"
+              onClick={() => setOpen(false)}
+            />
+            <DialPrimaryButton label="Apply" onClick={() => setOpen(false)} />
           </div>
-        ),
-      }}
+        </div>
+      )}
     >
       <TriggerBtn label="With footer actions" />
     </DialDropdown>
@@ -351,7 +346,7 @@ export const ContextMenuAtCursor: Story = {
     trigger: [DropdownTrigger.ContextMenu],
     anchorToMouse: true,
     matchReferenceWidth: false,
-    menu: { items: specItems },
+    items: specItems,
   },
   render: (args) => (
     <DialDropdown {...args}>
@@ -368,7 +363,7 @@ export const ClickNearCursor: Story = {
     trigger: [DropdownTrigger.Click],
     anchorToMouse: true,
     matchReferenceWidth: false,
-    menu: { items: specItems },
+    items: specItems,
   },
   render: (args) => (
     <DialDropdown {...args}>
@@ -489,7 +484,7 @@ export const DropdownDynamicButtons: Story = {
         onOpenChange={setOpen}
         onClose={() => setOpen(false)}
         placement="bottom"
-        menu={{ items }}
+        items={items}
       >
         <TriggerBtn label="Dynamic items" />
       </DialDropdown>
@@ -503,43 +498,41 @@ export const WithSubMenu: Story = {
     <DialDropdown
       {...args}
       placement="bottom-start"
-      menu={{
-        items: [
-          {
-            key: 'profile',
-            label: 'Profile',
-            icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
-          },
-          {
-            key: 'more',
-            label: 'More actions',
-            icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
-            children: [
-              {
-                key: 'open',
-                label: 'Open in new tab',
-                icon: <IconExternalLink size={DIAL_ICON_SIZE.SM} />,
-              },
-              {
-                key: 'copy',
-                label: 'Duplicate',
-                icon: <IconCopy size={DIAL_ICON_SIZE.SM} />,
-              },
-              {
-                key: 'del',
-                label: 'Delete',
-                icon: <IconTrash size={DIAL_ICON_SIZE.SM} />,
-                danger: true,
-              },
-            ],
-          },
-          {
-            key: 'logout',
-            label: 'Logout',
-            icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
-          },
-        ],
-      }}
+      items={[
+        {
+          key: 'profile',
+          label: 'Profile',
+          icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
+        },
+        {
+          key: 'more',
+          label: 'More actions',
+          icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+          children: [
+            {
+              key: 'open',
+              label: 'Open in new tab',
+              icon: <IconExternalLink size={DIAL_ICON_SIZE.SM} />,
+            },
+            {
+              key: 'copy',
+              label: 'Duplicate',
+              icon: <IconCopy size={DIAL_ICON_SIZE.SM} />,
+            },
+            {
+              key: 'del',
+              label: 'Delete',
+              icon: <IconTrash size={DIAL_ICON_SIZE.SM} />,
+              danger: true,
+            },
+          ],
+        },
+        {
+          key: 'logout',
+          label: 'Logout',
+          icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+        },
+      ]}
     >
       <TriggerBtn label="Sub-menu" />
     </DialDropdown>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -47,16 +47,12 @@ import { DialCloseButton } from '@/components/CloseButton/CloseButton';
 import { mergeClasses } from '@/utils/merge-classes';
 import { DropdownSubMenuItem } from './DropdownSubMenuItem';
 
-export interface DropdownMenuProps {
-  items: DropdownItem[];
-  onClick?: (info: { key: string; domEvent: MouseEvent }) => void;
-  header?: ReactNode | (() => ReactNode);
-  footer?: ReactNode | (() => ReactNode);
-}
-
 export interface DialDropdownProps {
   children: ReactNode;
-  menu?: DropdownMenuProps;
+  items?: DropdownItem[];
+  onItemClick?: (info: { key: string; domEvent: MouseEvent }) => void;
+  menuHeader?: ReactNode | (() => ReactNode);
+  menuFooter?: ReactNode | (() => ReactNode);
   renderOverlay?: () => ReactNode;
   trigger?: DropdownTrigger[];
   placement?: Placement;
@@ -88,12 +84,12 @@ export interface DialDropdownProps {
  * @example
  * ```tsx
  * // Simple items menu
- * <DialDropdown menu={{ items: [{ key: 'profile', label: 'Profile' }, { key: 'logout', label: 'Logout' }] }}>
+ * <DialDropdown items={[{ key: 'profile', label: 'Profile' }, { key: 'logout', label: 'Logout' }]}>
  *   <button type="button" className="px-3 py-2 rounded border">Open</button>
  * </DialDropdown>
  *
  * // Hover trigger
- * <DialDropdown trigger={[DropdownTrigger.Hover]} placement="bottom-end" menu={{ items }}>
+ * <DialDropdown trigger={[DropdownTrigger.Hover]} placement="bottom-end" items={items}>
  *   <button type="button" className="px-3 py-2 rounded border">Hover me</button>
  * </DialDropdown>
  *
@@ -104,8 +100,11 @@ export interface DialDropdownProps {
  * ```
  *
  * @param children - Trigger element(s) to anchor and open the menu
- * @param [menu] - Items-based menu definition
- * @param [renderOverlay] - Render function for fully custom overlay content (ignored when `menu` is provided)
+ * @param [items] - Menu items to render
+ * @param [onItemClick] - Global handler fired when any item is clicked
+ * @param [menuHeader] - Content rendered above the items list
+ * @param [menuFooter] - Content rendered below the items list
+ * @param [renderOverlay] - Render function for fully custom overlay content (ignored when `items` is provided)
  * @param [trigger=[DropdownTrigger.Click]] - Interactions that open the menu
  * @param [placement] - Floating UI placement string; when omitted, auto placement is used
  * @param [allowedPlacements] - Restricts the allowed placements
@@ -133,7 +132,10 @@ const getRefWidth = (el: ReferenceElement): number => {
 
 export const DialDropdown: FC<DialDropdownProps> = ({
   children,
-  menu,
+  items,
+  onItemClick,
+  menuHeader,
+  menuFooter,
   renderOverlay,
   trigger = [DropdownTrigger.Click],
   placement,
@@ -309,24 +311,24 @@ export const DialDropdown: FC<DialDropdownProps> = ({
     (item: DropdownItem) => (e: MouseEvent) => {
       if (item.disabled) return;
       item.onClick?.({ key: item.key, domEvent: e });
-      menu?.onClick?.({ key: item.key, domEvent: e });
+      onItemClick?.({ key: item.key, domEvent: e });
       setOpen(false);
     },
-    [menu, setOpen],
+    [onItemClick, setOpen],
   );
 
   const overlayContent: ReactNode = useMemo(() => {
     if (renderOverlay) return renderOverlay();
-    if (!menu) return null;
+    if (!items) return null;
 
     return (
       <>
-        {menu.header && (
-          <>{typeof menu.header === 'function' ? menu.header() : menu.header}</>
+        {menuHeader && (
+          <>{typeof menuHeader === 'function' ? menuHeader() : menuHeader}</>
         )}
 
         <div role="none" className="py-1" aria-label="dropdown">
-          {menu.items.map((it) => {
+          {items.map((it) => {
             if (it.type === DropdownItemType.Divider) {
               return (
                 <div
@@ -398,12 +400,12 @@ export const DialDropdown: FC<DialDropdownProps> = ({
           })}
         </div>
 
-        {menu.footer && (
-          <>{typeof menu.footer === 'function' ? menu.footer() : menu.footer}</>
+        {menuFooter && (
+          <>{typeof menuFooter === 'function' ? menuFooter() : menuFooter}</>
         )}
       </>
     );
-  }, [handleItemClick, menu, renderOverlay, setOpen]);
+  }, [handleItemClick, items, menuFooter, menuHeader, renderOverlay, setOpen]);
 
   const referenceProps = getReferenceProps({
     onContextMenu,

--- a/src/components/DropdownIcon/DropdownIcon.spec.tsx
+++ b/src/components/DropdownIcon/DropdownIcon.spec.tsx
@@ -17,7 +17,7 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai />}
-        menu={{ items }}
+        items={items}
       />,
     );
 
@@ -37,7 +37,7 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai data-testid="model-icon" />}
-        menu={{ items }}
+        items={items}
         size={ElementSize.Small}
         showCaret={false}
       />,
@@ -56,7 +56,7 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai />}
-        menu={{ items }}
+        items={items}
         showCaret={false}
       />,
     );
@@ -72,7 +72,7 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai />}
-        menu={{ items }}
+        items={items}
         disabled
       />,
     );
@@ -90,7 +90,7 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai />}
-        menu={{ items }}
+        items={items}
         open={false}
         onOpenChange={onOpenChange}
       />,
@@ -106,7 +106,8 @@ describe('Dial UI Kit :: DropdownIcon', () => {
       <DialDropdownIcon
         ariaLabel="Select model"
         icon={<IconBrandOpenai />}
-        menu={{ items, onClick }}
+        items={items}
+        onItemClick={onClick}
         className="custom-wrapper"
         buttonClassName="custom-button"
         iconClassName="custom-icon"

--- a/src/components/DropdownIcon/DropdownIcon.stories.tsx
+++ b/src/components/DropdownIcon/DropdownIcon.stories.tsx
@@ -91,7 +91,7 @@ const meta = {
     showCaret: { control: { type: 'boolean' } },
     icon: { control: false },
     caretIcon: { control: false },
-    menu: { control: false },
+    items: { control: false },
     placement: { control: false },
     allowedPlacements: { control: false },
     className: { control: false },
@@ -101,7 +101,7 @@ const meta = {
   args: {
     ariaLabel: 'Select model',
     icon: <IconBrandOpenai size={DIAL_ICON_SIZE.MD} />,
-    menu: { items: modelItems },
+    items: modelItems,
     showCaret: true,
     disabled: false,
   },
@@ -204,7 +204,7 @@ export const ModelSelector: Story = {
             {selected.icon}
           </span>
         }
-        menu={{ items }}
+        items={items}
         maxDropdownHeight={200}
       />
     );

--- a/src/components/DropdownIcon/DropdownIcon.tsx
+++ b/src/components/DropdownIcon/DropdownIcon.tsx
@@ -4,7 +4,6 @@ import { type FC, type ReactNode, useState } from 'react';
 import {
   DialDropdown,
   type DialDropdownProps,
-  type DropdownMenuProps,
 } from '@/components/Dropdown/Dropdown';
 import { DialIcon } from '@/components/Icon/Icon';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
@@ -13,9 +12,8 @@ import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DialDropdownIconProps extends Omit<
   DialDropdownProps,
-  'children' | 'menu' | 'className'
+  'children' | 'className'
 > {
-  menu: DropdownMenuProps;
   icon: ReactNode;
   ariaLabel: string;
   size?: ElementSize;
@@ -35,11 +33,11 @@ export interface DialDropdownIconProps extends Omit<
  * <DialDropdownIcon
  *   ariaLabel="Select model"
  *   icon={<IconBrandOpenai size={18} />}
- *   menu={{ items }}
+ *   items={items}
  * />
  * ```
  *
- * @param menu - Dropdown menu definition.
+ * @param items - Menu items to display.
  * @param icon - Primary trigger icon.
  * @param ariaLabel - Accessible name for the trigger button.
  * @param [size=ElementSize.Standard] - Trigger size.
@@ -50,7 +48,6 @@ export interface DialDropdownIconProps extends Omit<
  * @param [showCaret=true] - Whether to render the caret.
  */
 export const DialDropdownIcon: FC<DialDropdownIconProps> = ({
-  menu,
   icon,
   ariaLabel,
   size = ElementSize.Standard,
@@ -80,7 +77,6 @@ export const DialDropdownIcon: FC<DialDropdownIconProps> = ({
   return (
     <DialDropdown
       {...dropdownProps}
-      menu={menu}
       disabled={disabled}
       placement={placement}
       matchReferenceWidth={matchReferenceWidth}

--- a/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
+++ b/src/components/FileManager/components/ConflictResolutionPopup/ConflictResolutionPopup.tsx
@@ -294,19 +294,17 @@ export const ConflictResolutionPopup: FC<ConflictResolutionPopupProps> = ({
               <DialDropdown
                 trigger={[DropdownTrigger.Click]}
                 open={isOpen}
-                menu={{
-                  items: dropdownItems,
-                  onClick: ({ key }) => {
-                    setFileDecisions((prev) => {
-                      const next = new Map(prev);
-                      next.set(
-                        params.data.path,
-                        key as DialFileManagerConflictActions,
-                      );
-                      return next;
-                    });
-                    setOpenDropdownPath(undefined);
-                  },
+                items={dropdownItems}
+                onItemClick={({ key }) => {
+                  setFileDecisions((prev) => {
+                    const next = new Map(prev);
+                    next.set(
+                      params.data.path,
+                      key as DialFileManagerConflictActions,
+                    );
+                    return next;
+                  });
+                  setOpenDropdownPath(undefined);
                 }}
                 placement="bottom-start"
                 matchReferenceWidth={false}

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -212,7 +212,7 @@ export const DialDestinationFolderPopup: FC<DestinationFolderPopupProps> = ({
           <div className="flex items-center gap-4 min-w-0">
             {isMobile ? (
               <DialDropdown
-                menu={{ items: mobileFooterDropdownItems }}
+                items={mobileFooterDropdownItems}
                 open={mobileMenuOpen}
                 onOpenChange={setMobileMenuOpen}
               >

--- a/src/components/FileManager/components/FileManagerBulkActionsToolbar/FileManagerBulkActionsToolbar.tsx
+++ b/src/components/FileManager/components/FileManagerBulkActionsToolbar/FileManagerBulkActionsToolbar.tsx
@@ -125,7 +125,7 @@ export const DialFileManagerBulkActionsToolbar: FC<
         <div className="flex flex-1 w-full gap-3 items-center justify-end">
           {hiddenActions.length > 0 && (
             <DialDropdown
-              menu={{ items: hiddenActions }}
+              items={hiddenActions}
               allowedPlacements={['bottom', 'bottom-start']}
             >
               <DialButton

--- a/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
+++ b/src/components/FileManager/components/FileManagerToolbar/DialFileManagerToolbar.tsx
@@ -178,7 +178,7 @@ export const DialFileManagerToolbar: FC<DialFileManagerToolbarProps> = ({
   const renderMobileActions = () => (
     <>
       <DialDropdown
-        menu={{ items: dropdownItems }}
+        items={dropdownItems}
         allowedPlacements={['bottom', 'bottom-start']}
       >
         <DialGhostIconButton

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -258,7 +258,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
               trigger={[DropdownTrigger.ContextMenu]}
               className="w-full"
               anchorToMouse
-              menu={{ items: menuItems }}
+              items={menuItems}
             >
               <div
                 style={{ paddingLeft: `${level * FOLDER_LEVEL_PADDING}px` }}
@@ -322,7 +322,7 @@ export const DialFoldersTree: FC<DialFoldersTreeProps> = ({
                     <DialDropdown
                       placement="bottom-start"
                       allowedPlacements={['top-start', 'top-end']}
-                      menu={{ items: menuItems }}
+                      items={menuItems}
                       className="sticky right-0"
                     >
                       <DialIcon

--- a/src/components/FileManager/hooks/use-grid-actions-column.tsx
+++ b/src/components/FileManager/hooks/use-grid-actions-column.tsx
@@ -56,7 +56,7 @@ export const useGridActionsColumn = ({
         <DialDropdown
           placement="bottom-start"
           allowedPlacements={['top-start', 'top-end', 'bottom-start']}
-          menu={{ items }}
+          items={items}
           className={mergeClasses('sticky right-0', buttonClassName)}
         >
           <DialIcon

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -400,18 +400,16 @@ export const Compact: Story = {
                 <DialDropdown
                   placement="bottom-start"
                   allowedPlacements={['top-start', 'top-end']}
-                  menu={{
-                    items: [
-                      {
-                        key: 'copy',
-                        label: 'Copy',
-                      },
-                      {
-                        key: 'delete',
-                        label: 'Delete',
-                      },
-                    ],
-                  }}
+                  items={[
+                    {
+                      key: 'copy',
+                      label: 'Copy',
+                    },
+                    {
+                      key: 'delete',
+                      label: 'Delete',
+                    },
+                  ]}
                   className="sticky right-0"
                 >
                   <DialIcon

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -233,7 +233,7 @@ export const DialGrid = <T extends object>({
         return (
           <DialDropdown
             trigger={[DropdownTrigger.ContextMenu]}
-            menu={{ items }}
+            items={items}
             anchorToMouse
             matchReferenceWidth
             className="w-full"
@@ -418,7 +418,7 @@ export const DialGrid = <T extends object>({
         return (
           <DialDropdown
             trigger={[DropdownTrigger.ContextMenu]}
-            menu={{ items }}
+            items={items}
             anchorToMouse
             matchReferenceWidth
             className={classNames(

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -77,6 +77,14 @@ When implementing or modifying components, forms, or UI built with `@epam/ai-dia
 Use these two tools for all UI kit discovery and documentation needs: `searchEntity(entity, query?)` and `getEntityDetails(entity, name?)`. If you need to look up **ANYTHING** about the ui kit, use the MCP server. **Never** use rg/ls commands for the ui kit module inspection.
 
 > **Note:** Do not use `grep`, `glob`, `find`, or similar file system tools to discover components. The MCP tools provide accurate, structured metadata. File system searches miss examples, miss type information, and are slower.
+
+## Breaking Changes & Migration
+
+When you encounter type errors after a package upgrade, or when a prop no longer exists on a component:
+
+1. Check `CHANGELOG.md` for a `### Breaking Changes` entry matching the new version.
+2. Follow the linked migration guide in `migration-guides/<version>/`.
+3. Use `getEntityDetails("component", "DialXxx")` to confirm the current prop signature before applying the fix.
 ```
 
 ## How It Works
@@ -112,6 +120,18 @@ Agent:
   4. Calls getEntityDetails("component", "DialFormItem")   → how to wire up validation
   5. Calls getEntityDetails("component", "DialNotification")      → error display
   6. Generates complete form code with types and error handling
+```
+
+## Example: Migrating After a Breaking Change
+
+```
+User: "After upgrading @epam/ai-dial-ui-kit the `menu` prop on DialDropdown no longer exists"
+
+Agent:
+  1. Reads CHANGELOG.md → finds Breaking Changes entry for the new version
+  2. Follows link to migration-guides/<version>/dropdown-menu-prop-flatten.md
+  3. Calls getEntityDetails("component", "DialDropdown") → confirms new flat prop names
+  4. Applies the migration: menu={{ items }} → items={items}, etc.
 ```
 
 ## Distribution

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -19,6 +19,89 @@ import type {
 const manifest: Manifest = JSON.parse(
   readFileSync(join(__dirname, 'components-manifest.json'), 'utf-8'),
 );
+
+// ─── changelog & migration-guides ────────────────────────────────────────────
+
+const changelogPath = join(__dirname, 'CHANGELOG.md');
+const changelogRaw = existsSync(changelogPath)
+  ? readFileSync(changelogPath, 'utf-8')
+  : '';
+
+const migrationGuidesDir = join(__dirname, 'migration-guides');
+
+/**
+ * Parse the CHANGELOG into a map of version → section text.
+ * Sections are delimited by `## [x.y.z]` headings.
+ */
+function parseChangelog(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const sectionRegex = /^## \[(\d+\.\d+\.\d+)\]/gm;
+  const sections: { version: string; start: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = sectionRegex.exec(content)) !== null) {
+    sections.push({ version: match[1], start: match.index });
+  }
+  for (let i = 0; i < sections.length; i++) {
+    const { version, start } = sections[i];
+    const end =
+      i + 1 < sections.length ? sections[i + 1].start : content.length;
+    map.set(version, content.slice(start, end).trim());
+  }
+  return map;
+}
+
+const changelogSections = parseChangelog(changelogRaw);
+
+function parseSemver(v: string): [number, number, number] {
+  const p = v.split('.').map(Number);
+  return [p[0] ?? 0, p[1] ?? 0, p[2] ?? 0];
+}
+
+/** Returns true when a > b */
+function semverGt(a: string, b: string): boolean {
+  const [a0, a1, a2] = parseSemver(a);
+  const [b0, b1, b2] = parseSemver(b);
+  if (a0 !== b0) return a0 > b0;
+  if (a1 !== b1) return a1 > b1;
+  return a2 > b2;
+}
+
+/**
+ * Returns versions from `changelogSections` that fall in the range
+ * (fromVersion, toVersion] — i.e. newer than `from` and at most `to`.
+ */
+function versionsInRange(from: string, to: string): string[] {
+  return [...changelogSections.keys()].filter(
+    (v) => semverGt(v, from) && !semverGt(v, to),
+  );
+}
+
+/**
+ * Read all migration-guide markdown files for the given versions.
+ * Returns an array of { version, filename, content } objects.
+ */
+function readMigrationGuides(
+  versions: string[],
+): { version: string; filename: string; content: string }[] {
+  const guides: { version: string; filename: string; content: string }[] = [];
+  if (!existsSync(migrationGuidesDir)) return guides;
+
+  for (const version of versions) {
+    const vDir = join(migrationGuidesDir, version);
+    if (!existsSync(vDir)) continue;
+    const files = readdirSync(vDir).filter(
+      (f) => f.endsWith('.md') && !f.startsWith('_'),
+    );
+    for (const file of files.sort()) {
+      guides.push({
+        version,
+        filename: file,
+        content: readFileSync(join(vDir, file), 'utf-8'),
+      });
+    }
+  }
+  return guides;
+}
 
 // ─── entity kinds ─────────────────────────────────────────────────────────────
 
@@ -272,6 +355,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['entity'],
       },
     },
+    {
+      name: 'getMigrationGuides',
+      description:
+        'Returns the CHANGELOG entries and step-by-step migration guides for all breaking changes introduced between two versions of @epam/ai-dial-ui-kit.\n\nPass the version you are currently on as `fromVersion` and the version you are upgrading to as `toVersion`. The tool returns the changelog section for each intermediate release plus the full text of every migration guide that applies.\n\nExamples:\n  getMigrationGuides("0.9.0", "0.10.0") → changelog + guides for 0.10.0\n  getMigrationGuides("0.8.0", "0.10.0") → changelog + guides for 0.9.0 and 0.10.0',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          fromVersion: {
+            type: 'string',
+            description:
+              'The version you are upgrading FROM (exclusive), e.g. "0.9.0".',
+          },
+          toVersion: {
+            type: 'string',
+            description:
+              'The version you are upgrading TO (inclusive), e.g. "0.10.0".',
+          },
+        },
+        required: ['fromVersion', 'toVersion'],
+      },
+    },
   ],
 }));
 
@@ -458,6 +562,56 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       );
     }
     return { content: [{ type: 'text', text: formatExport(entry) }] };
+  }
+
+  // ── getMigrationGuides ────────────────────────────────────────────────────
+
+  if (name === 'getMigrationGuides') {
+    const fromVersion =
+      typeof a.fromVersion === 'string' ? a.fromVersion.trim() : '';
+    const toVersion = typeof a.toVersion === 'string' ? a.toVersion.trim() : '';
+
+    if (!fromVersion || !toVersion) {
+      throw new Error('"fromVersion" and "toVersion" are required.');
+    }
+
+    const versions = versionsInRange(fromVersion, toVersion).sort((a, b) =>
+      semverGt(a, b) ? 1 : -1,
+    );
+
+    if (versions.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `No changelog entries found for versions between ${fromVersion} (exclusive) and ${toVersion} (inclusive). Either this range is already up to date or the versions are unknown.`,
+          },
+        ],
+      };
+    }
+
+    const sections: string[] = [];
+
+    for (const version of versions) {
+      const changelogSection = changelogSections.get(version);
+      if (changelogSection) sections.push(changelogSection);
+
+      const guides = readMigrationGuides([version]);
+      for (const guide of guides) {
+        sections.push(
+          `---\n\n<!-- Migration guide: ${guide.version}/${guide.filename} -->\n\n${guide.content}`,
+        );
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: sections.join('\n\n'),
+        },
+      ],
+    };
   }
 
   throw new Error(`Unknown tool: ${name}`);

--- a/tools/build-mcp.mjs
+++ b/tools/build-mcp.mjs
@@ -1,4 +1,10 @@
 import * as esbuild from 'esbuild';
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const dist = join(root, 'dist');
 
 await esbuild.build({
   entryPoints: ['src/mcp/server.ts'],
@@ -9,3 +15,16 @@ await esbuild.build({
   outfile: 'dist/mcp-server.cjs',
   banner: { js: '#!/usr/bin/env node' },
 });
+
+// Copy CHANGELOG.md into dist so the MCP server can serve it at runtime.
+const changelogSrc = join(root, 'CHANGELOG.md');
+if (existsSync(changelogSrc)) {
+  mkdirSync(dist, { recursive: true });
+  cpSync(changelogSrc, join(dist, 'CHANGELOG.md'));
+}
+
+// Copy migration-guides/ into dist (version sub-folders with *.md files).
+const migrationSrc = join(root, 'migration-guides');
+if (existsSync(migrationSrc)) {
+  cpSync(migrationSrc, join(dist, 'migration-guides'), { recursive: true });
+}


### PR DESCRIPTION
**Description and UI changes:**
BREAKING CHANGE: the nested `menu` prop is replaced with flat top-level props: `items`, `onItemClick`, `menuHeader`, `menuFooter`. `DropdownMenuProps` is no longer exported. All internal consumers updated.

See migration-guides/0.11.0/dropdown-menu-prop-flatten.md

Issues:

- Issue #369

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added