### PR TITLE
fix: [RTL] Arabic text issue when text-left class is used. Issue #715

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -387,7 +387,7 @@ export const DialDropdown: FC<DialDropdownProps> = ({
                 )}
                 <span
                   className={classNames(
-                    'flex-1 truncate text-left',
+                    'flex-1 truncate text-start',
                     it.danger && 'text-error',
                     it.disabled && 'text-secondary',
                   )}

--- a/src/components/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/Dropdown/DropdownSubMenuItem.tsx
@@ -65,7 +65,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
         )}
         <span
           className={classNames(
-            'flex-1 truncate text-left',
+            'flex-1 truncate text-start',
             item.disabled && 'text-secondary',
           )}
         >
@@ -118,7 +118,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
                 )}
                 <span
                   className={classNames(
-                    'flex-1 truncate text-left',
+                    'flex-1 truncate text-start',
                     child.danger && 'text-error',
                     child.disabled && 'text-secondary',
                   )}

--- a/src/components/EllipsisTooltip/EllipsisTooltip.tsx
+++ b/src/components/EllipsisTooltip/EllipsisTooltip.tsx
@@ -113,7 +113,7 @@ export const DialEllipsisTooltip: FC<DialEllipsisTooltipProps> = ({
         <span
           id={id}
           className={mergeClasses(
-            'block truncate flex-1 min-w-0 max-w-full text-left',
+            'block truncate flex-1 min-w-0 max-w-full text-start',
             className,
           )}
           aria-label={isTruncated ? fullText : undefined}

--- a/src/components/Tooltip/TooltipTrigger.tsx
+++ b/src/components/Tooltip/TooltipTrigger.tsx
@@ -55,7 +55,7 @@ export const DialTooltipTrigger: FC<TooltipTriggerProps> = ({
     <span
       ref={ref}
       {...context.getReferenceProps(props)}
-      className={props.className ?? 'dial-tooltip-trigger text-left'}
+      className={props.className ?? 'dial-tooltip-trigger text-start'}
     >
       {children}
     </span>


### PR DESCRIPTION
**Description and UI changes:**

DialDropdown, DialEllipsisTooltip and DialTooltipTrigger components contained `text-left` class, which caused issues while using arabic text with `rtl` direction.

- Issue #715 

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
