### PR TITLE
feat: [Assets] Limit folder nesting depth in assets to 4 levels (Issue #3447)

### DIFF
--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -1502,4 +1502,121 @@ describe('Dial UI Kit :: FileManager', () => {
       });
     });
   });
+
+  describe('maxNewFolderDepth / onNewFolderDepthExceeded', () => {
+    const ROOT_PATH = '/L1';
+    const L2 = `${ROOT_PATH}/L2`;
+    const L3 = `${L2}/L3`;
+    const L4 = `${L3}/L4`;
+    const L5 = `${L4}/L5`;
+
+    const deepItems: DialFile[] = [
+      {
+        id: 'l1',
+        name: 'L1',
+        path: ROOT_PATH,
+        parentPath: '',
+        nodeType: DialFileNodeType.FOLDER,
+        folderId: 'l1',
+        items: [
+          {
+            id: 'l2',
+            name: 'L2',
+            path: L2,
+            parentPath: ROOT_PATH,
+            nodeType: DialFileNodeType.FOLDER,
+            folderId: 'l2',
+            items: [
+              {
+                id: 'l3',
+                name: 'L3',
+                path: L3,
+                parentPath: L2,
+                nodeType: DialFileNodeType.FOLDER,
+                folderId: 'l3',
+                items: [
+                  {
+                    id: 'l4',
+                    name: 'L4',
+                    path: L4,
+                    parentPath: L3,
+                    nodeType: DialFileNodeType.FOLDER,
+                    folderId: 'l4',
+                    items: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    test('calls onNewFolderDepthExceeded when creating folder at max depth via toolbar', async () => {
+      const onNewFolderDepthExceeded = vi.fn();
+      const onCreateFolder = vi.fn();
+
+      renderWithinSizedShell(
+        <DialFileManager
+          items={deepItems}
+          path={L4}
+          maxNewFolderDepth={4}
+          onNewFolderDepthExceeded={onNewFolderDepthExceeded}
+          onCreateFolder={onCreateFolder}
+          toolbarOptions={{
+            newActions: { newFolder: { label: 'New Folder' } },
+          }}
+        />,
+      );
+
+      const newFolderBtn = await screen.findByTestId('action-new-folder');
+      await userEvent.click(newFolderBtn);
+
+      expect(onNewFolderDepthExceeded).toHaveBeenCalledTimes(1);
+      expect(onCreateFolder).not.toHaveBeenCalled();
+    });
+
+    test('does not call onNewFolderDepthExceeded when below max depth', async () => {
+      const onNewFolderDepthExceeded = vi.fn();
+
+      renderWithinSizedShell(
+        <DialFileManager
+          items={deepItems}
+          path={L3}
+          maxNewFolderDepth={4}
+          onNewFolderDepthExceeded={onNewFolderDepthExceeded}
+          onCreateFolder={vi.fn()}
+          toolbarOptions={{
+            newActions: { newFolder: { label: 'New Folder' } },
+          }}
+        />,
+      );
+
+      const newFolderBtn = await screen.findByTestId('action-new-folder');
+      await userEvent.click(newFolderBtn);
+
+      expect(onNewFolderDepthExceeded).not.toHaveBeenCalled();
+    });
+
+    test('does not restrict creation when maxNewFolderDepth is not set', async () => {
+      const onNewFolderDepthExceeded = vi.fn();
+
+      renderWithinSizedShell(
+        <DialFileManager
+          items={deepItems}
+          path={L4}
+          onNewFolderDepthExceeded={onNewFolderDepthExceeded}
+          onCreateFolder={vi.fn()}
+          toolbarOptions={{
+            newActions: { newFolder: { label: 'New Folder' } },
+          }}
+        />,
+      );
+
+      const newFolderBtn = await screen.findByTestId('action-new-folder');
+      await userEvent.click(newFolderBtn);
+
+      expect(onNewFolderDepthExceeded).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -404,6 +404,8 @@ export interface DialFileManagerProps {
   showHiddenFileSwitcherInDestinationPopup?: boolean;
   showCreateFolderButtonInDestinationPopup?: boolean;
   autoSelectUploadedItems?: boolean;
+  maxNewFolderDepth?: number;
+  onNewFolderDepthExceeded?: () => void;
 }
 
 /**

--- a/src/components/FileManager/FileManagerContext.tsx
+++ b/src/components/FileManager/FileManagerContext.tsx
@@ -237,6 +237,8 @@ export interface FileManagerContextValue {
   hideSearchPathItemName?: boolean;
   showHiddenFileSwitcherInDestinationPopup?: boolean;
   showCreateFolderButtonInDestinationPopup?: boolean;
+  maxNewFolderDepth?: number;
+  onNewFolderDepthExceeded?: () => void;
 }
 
 export const FileManagerContext = createContext<

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -16,6 +16,7 @@ import {
   collectAllDescendants,
   findFolderForPath,
   findNodeByPath,
+  getFolderNestingDepth,
   isFileSelectable,
   isHiddenDotFile,
   normalizeExtensionWithoutDot,
@@ -150,6 +151,8 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   showHiddenFileSwitcherInDestinationPopup,
   showCreateFolderButtonInDestinationPopup,
   autoSelectUploadedItems = false,
+  maxNewFolderDepth,
+  onNewFolderDepthExceeded,
 }) => {
   const {
     selectedPaths: effectiveSelectedPaths,
@@ -330,6 +333,18 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     [items, currentPath],
   );
 
+  const isMaxNestingDepthReached = useCallback(
+    (folder: DialFile, maxDepth?: number) => {
+      if (!maxDepth || !folder) return false;
+      return getFolderNestingDepth(folder.path) > maxDepth;
+    },
+    [],
+  );
+
+  const showNewFolderNestingError = useCallback(() => {
+    onNewFolderDepthExceeded?.();
+  }, [onNewFolderDepthExceeded]);
+
   const {
     handleCopyTo,
     handleMoveTo,
@@ -486,9 +501,23 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   });
 
   const startFolderCreation = useCallback(() => {
+    if (
+      maxNewFolderDepth &&
+      isMaxNestingDepthReached(currentFolder, maxNewFolderDepth - 1)
+    ) {
+      showNewFolderNestingError();
+      return;
+    }
     handleSearchClear();
     startFolderCreationBase();
-  }, [handleSearchClear, startFolderCreationBase]);
+  }, [
+    handleSearchClear,
+    startFolderCreationBase,
+    currentFolder,
+    maxNewFolderDepth,
+    isMaxNestingDepthReached,
+    showNewFolderNestingError,
+  ]);
 
   const { newActions, isNewButtonVisible, isNewButtonDisabled } = useNewActions(
     {
@@ -716,16 +745,36 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   const handleGridAddSibling = useCallback(
     (files: DialFile[]) => {
       if (files.length > 0) {
+        if (
+          maxNewFolderDepth &&
+          isMaxNestingDepthReached(files[0], maxNewFolderDepth)
+        ) {
+          showNewFolderNestingError();
+          return;
+        }
         handleSearchClear();
         startGridSiblingFolderCreation(files[0]);
       }
     },
-    [handleSearchClear, startGridSiblingFolderCreation],
+    [
+      handleSearchClear,
+      startGridSiblingFolderCreation,
+      maxNewFolderDepth,
+      isMaxNestingDepthReached,
+      showNewFolderNestingError,
+    ],
   );
 
   const handleGridAddChild = useCallback(
     (files: DialFile[]) => {
       if (files.length > 0) {
+        if (
+          maxNewFolderDepth &&
+          isMaxNestingDepthReached(files[0], maxNewFolderDepth - 1)
+        ) {
+          showNewFolderNestingError();
+          return;
+        }
         handleSearchClear();
         setCurrentPath(files[0].path);
         setExpandedPaths(new Set(expandedPaths).add(files[0].path || '/'));
@@ -738,22 +787,45 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       expandedPaths,
       setExpandedPaths,
       setCurrentPath,
+      showNewFolderNestingError,
+      maxNewFolderDepth,
+      isMaxNestingDepthReached,
     ],
   );
 
   const handleTreeAddSibling = useCallback(
     (files: DialFile[]) => {
       if (files.length > 0) {
+        if (
+          maxNewFolderDepth &&
+          isMaxNestingDepthReached(files[0], maxNewFolderDepth)
+        ) {
+          showNewFolderNestingError();
+          return;
+        }
         handleSearchClear();
         startTreeSiblingFolderCreation(files[0]);
       }
     },
-    [handleSearchClear, startTreeSiblingFolderCreation],
+    [
+      handleSearchClear,
+      startTreeSiblingFolderCreation,
+      maxNewFolderDepth,
+      isMaxNestingDepthReached,
+      showNewFolderNestingError,
+    ],
   );
 
   const handleTreeAddChild = useCallback(
     (files: DialFile[]) => {
       if (files.length > 0) {
+        if (
+          maxNewFolderDepth &&
+          isMaxNestingDepthReached(files[0], maxNewFolderDepth - 1)
+        ) {
+          showNewFolderNestingError();
+          return;
+        }
         handleSearchClear();
         setCurrentPath(files[0].path);
         setExpandedPaths(new Set(expandedPaths).add(files[0].path || '/'));
@@ -766,6 +838,9 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
       setCurrentPath,
       expandedPaths,
       setExpandedPaths,
+      maxNewFolderDepth,
+      isMaxNestingDepthReached,
+      showNewFolderNestingError,
     ],
   );
 
@@ -969,6 +1044,8 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     unsupportedFileTypeTooltip,
     showHiddenFileSwitcherInDestinationPopup,
     showCreateFolderButtonInDestinationPopup,
+    maxNewFolderDepth,
+    onNewFolderDepthExceeded,
   };
 
   return (

--- a/src/components/FileManager/utils.spec.ts
+++ b/src/components/FileManager/utils.spec.ts
@@ -3,6 +3,7 @@ import type { DialFileAcceptType } from '@/models/file-manager';
 import { DialFileNodeType, type DialFile } from '@/models/file';
 import {
   formatAllowedFileTypesForTooltip,
+  getFolderNestingDepth,
   isFileSelectable,
   splitPathAndName,
   getNextFolderName,
@@ -176,5 +177,22 @@ describe('Dial UI Kit :: getNextFolderName', () => {
       } as DialFile,
     ];
     expect(getNextFolderName(existing)).toBe('New folder 1');
+  });
+});
+
+describe('Dial UI Kit :: getFolderNestingDepth', () => {
+  it('returns 1 for root folder', () => {
+    expect(getFolderNestingDepth('public/')).toBe(1);
+    expect(getFolderNestingDepth('public')).toBe(1);
+  });
+
+  it('returns 3 for third-level folder', () => {
+    expect(getFolderNestingDepth('public/folder1/folder2')).toBe(3);
+    expect(getFolderNestingDepth('public/folder1/folder2/')).toBe(3);
+  });
+
+  it('returns 5 for fifth-level folder', () => {
+    expect(getFolderNestingDepth('public/a/b/c/d')).toBe(5);
+    expect(getFolderNestingDepth('public/a/b/c/d/')).toBe(5);
   });
 });

--- a/src/components/FileManager/utils.ts
+++ b/src/components/FileManager/utils.ts
@@ -275,6 +275,11 @@ export const getRowTooltip = (
   return undefined;
 };
 
+export const getFolderNestingDepth = (folderPath: string): number => {
+  const segments = folderPath.replace(/\/+$/, '').split('/').filter(Boolean);
+  return segments.length;
+};
+
 export const getNextFolderName = (existingFolders: DialFile[]): string => {
   const prefix = `${DEFAULT_FOLDER_BASE_NAME} `;
   const regex = new RegExp(`^${DEFAULT_FOLDER_BASE_NAME} (\\d+)$`);


### PR DESCRIPTION
**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #3447

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added