### PR TITLE
fix: DialSelect inlineSearch resurrects cleared value on close

### DIFF
--- a/src/components/Select/Select.spec.tsx
+++ b/src/components/Select/Select.spec.tsx
@@ -175,6 +175,97 @@ describe('Dial UI Kit :: DialSelect', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('inlineSearch: a cleared input is not resurrected on close when customSelectedValue is stale (issue #3053)', () => {
+    const onInlineQueryChange = vi.fn();
+    // open is controlled so we can drive the close transition deterministically.
+    // customSelectedValue stays stale, mimicking a consumer that commits the
+    // cleared value asynchronously.
+    const { rerender } = renderSelect({
+      inlineSearch: true,
+      open: true,
+      customSelectedValue: 'Option 2',
+      value: 'opt-2',
+      onInlineQueryChange,
+    });
+
+    const inlineInput = screen.getByDisplayValue(
+      'Option 2',
+    ) as HTMLInputElement;
+    fireEvent.change(inlineInput, { target: { value: '' } });
+    expect(inlineInput).toHaveValue('');
+    expect(onInlineQueryChange).toHaveBeenLastCalledWith('');
+
+    // Close the dropdown while customSelectedValue is still the stale old value.
+    rerender(
+      <DialSelect
+        options={baseOptions}
+        inlineSearch
+        open={false}
+        customSelectedValue="Option 2"
+        value="opt-2"
+        onInlineQueryChange={onInlineQueryChange}
+      />,
+    );
+
+    // The cleared input must stick — it must not snap back to the stale value.
+    expect(inlineInput).toHaveValue('');
+  });
+
+  test('inlineSearch: external customSelectedValue change still syncs the closed input', () => {
+    const { rerender } = renderSelect({
+      inlineSearch: true,
+      customSelectedValue: 'Option 2',
+      value: 'opt-2',
+    });
+
+    expect(screen.getByDisplayValue('Option 2')).toBeInTheDocument();
+
+    rerender(
+      <DialSelect
+        options={baseOptions}
+        inlineSearch
+        customSelectedValue="Option 4"
+        value="opt-4"
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
+  });
+
+  test('inlineSearch: a value changed while open is applied to the input on close (not swallowed)', () => {
+    const { rerender } = renderSelect({
+      inlineSearch: true,
+      open: true,
+      customSelectedValue: 'Option 2',
+      value: 'opt-2',
+    });
+    expect(screen.getByDisplayValue('Option 2')).toBeInTheDocument();
+
+    // Value changes externally while the dropdown is open — must not clobber editing.
+    rerender(
+      <DialSelect
+        options={baseOptions}
+        inlineSearch
+        open
+        customSelectedValue="Option 4"
+        value="opt-4"
+      />,
+    );
+    expect(screen.getByDisplayValue('Option 2')).toBeInTheDocument();
+
+    // On close the change made while open must now be applied.
+    rerender(
+      <DialSelect
+        options={baseOptions}
+        inlineSearch
+        open={false}
+        customSelectedValue="Option 4"
+        value="opt-4"
+      />,
+    );
+    expect(screen.getByDisplayValue('Option 4')).toBeInTheDocument();
+  });
+
   test('option with children renders as submenu trigger (aria-haspopup, not selectable directly)', () => {
     renderSelect({
       options: [

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -221,9 +221,21 @@ export const DialSelect: FC<DialSelectProps> = ({
     if (!isOpen && !inlineSearch) setQuery('');
   }, [inlineSearch, isOpen, setQuery]);
 
+  const prevCustomSelectedValueRef = useRef(customSelectedValue);
   useEffect(() => {
-    if (inlineSearch && !isOpen && customSelectedValue)
+    if (!inlineSearch) return;
+    // Sync the inline input only when the selected value changes externally —
+    // never merely because the dropdown closed. Reverting to customSelectedValue
+    // on close would resurrect a value the user just cleared whenever the consumer
+    // commits the change asynchronously (see issue #3053).
+    if (customSelectedValue === prevCustomSelectedValueRef.current) return;
+    // Defer both the ref bump and the sync until the dropdown is closed: while it
+    // is open the user may be editing, so we must not clobber their input — but we
+    // must still apply the change once they close (don't swallow it).
+    if (!isOpen) {
+      prevCustomSelectedValueRef.current = customSelectedValue;
       setQuery(customSelectedValue || '');
+    }
   }, [customSelectedValue, inlineSearch, isOpen, setQuery]);
 
   const setSelection = useCallback(
@@ -252,8 +264,8 @@ export const DialSelect: FC<DialSelectProps> = ({
           options.find((o) => o.value === val) ??
           options.flatMap((o) => o.children ?? []).find((c) => c.value === val);
         if (selectedOption) {
+          // setQuery already fires onInlineQueryChange — don't call it again.
           setQuery(selectedOption.label);
-          onInlineQueryChange?.(selectedOption.label);
         }
       }
       setOpen(false);
@@ -266,7 +278,6 @@ export const DialSelect: FC<DialSelectProps> = ({
       selectedValues,
       options,
       setQuery,
-      onInlineQueryChange,
     ],
   );
 


### PR DESCRIPTION
## What

In `DialSelect` inline search mode, if you cleared the text and then closed the dropdown, the old value came back. This fixes that.

## Why

Every time the dropdown closed, the input was reset back to the selected value — even when you had just cleared it. So the cleared text was overwritten with the old value.

## How

- Only update the input when the selected value really changes, not just because the dropdown closed.
- Apply that change when the dropdown closes, so changes are not lost and your typing is not interrupted.
- Removed a duplicate `onInlineQueryChange` call (it was firing twice on selection).

## Tests

Added 3 tests, all 19 in `Select.spec.tsx` pass:
- cleared input stays cleared after closing
- a new value from outside still shows up in the input
- a value changed while the dropdown is open is applied when it closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)