### PR TITLE
fix: fix outside click durign name edit (Issue #723)

### DIFF
--- a/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
+++ b/src/components/FileManager/components/FileManagerItemNameInput/FileManagerItemNameInput.tsx
@@ -10,6 +10,7 @@ import { BASE_ICON_PROPS } from '@/constants/icon';
 import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
 import { NotificationVariant } from '@/types/notification';
+import { editableContainerProps } from '@/hooks/use-editable-item';
 
 export interface DialFileManagerItemNameInputProps {
   type: DialItemType;
@@ -135,7 +136,7 @@ export const DialFileManagerItemNameInput: FC<
   };
 
   return (
-    <div className="flex gap-2 items-center">
+    <div className="flex gap-2 items-center" {...editableContainerProps}>
       <DialFileManagerItemIcon
         name={name}
         type={type}

--- a/src/hooks/__tests__/use-editable-item.spec.tsx
+++ b/src/hooks/__tests__/use-editable-item.spec.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { FC } from 'react';
+import {
+  useEditableItem,
+  type UseEditableItemOptions,
+} from '../use-editable-item';
+
+const Harness: FC<UseEditableItemOptions> = (options) => {
+  const { inputRef, value, onChange, invalid, invalidMessage } =
+    useEditableItem(options);
+
+  return (
+    <div>
+      <input
+        data-testid="input"
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-invalid={invalid}
+      />
+      <span data-testid="message">{invalidMessage}</span>
+      <button data-testid="outside">outside</button>
+    </div>
+  );
+};
+
+describe('Dial UI Kit :: useEditableItem :: outside click (blur)', () => {
+  it('saves the typed value on blur when valid (rename)', () => {
+    const onSave = vi.fn();
+    render(
+      <Harness
+        value="folder"
+        isEditing
+        onSave={onSave}
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'renamed' } });
+    });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(onSave).toHaveBeenCalledWith('renamed');
+  });
+
+  it('reverts to the default name and saves it on blur when invalid (rename)', () => {
+    const onSave = vi.fn();
+    render(
+      <Harness
+        value="original"
+        isEditing
+        onSave={onSave}
+        // empty name is invalid, original name is valid
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.change(input, { target: { value: '   ' } });
+    });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    // exits edit mode by committing the default (original) name, not trapping focus
+    expect(onSave).toHaveBeenCalledWith('original');
+  });
+
+  it('reverts to the default folder name and creates it on blur when invalid (creation)', () => {
+    const onCreateFolderSave = vi.fn();
+    render(
+      <Harness
+        value="New folder"
+        isEditing={false}
+        isCreating
+        onCreateFolderSave={onCreateFolderSave}
+        // names containing % are invalid here, the default "New folder" is valid
+        onValidate={(v) => (/%/.test(v) ? 'forbidden symbol' : null)}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.change(input, { target: { value: '%%%' } });
+    });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(onCreateFolderSave).toHaveBeenCalledWith('New folder');
+  });
+
+  it('cancels on blur when both the value and the default are invalid', () => {
+    const onCreateFolderSave = vi.fn();
+    const onCreateFolderCancel = vi.fn();
+    render(
+      <Harness
+        value=""
+        isEditing={false}
+        isCreating
+        onCreateFolderSave={onCreateFolderSave}
+        onCreateFolderCancel={onCreateFolderCancel}
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(onCreateFolderSave).not.toHaveBeenCalled();
+    expect(onCreateFolderCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not commit when focus stays inside the input container', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <Harness
+        value="folder"
+        isEditing
+        onSave={onSave}
+        onValidate={() => null}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+    // simulate focus moving to a node still inside the input element
+    act(() => {
+      fireEvent.blur(input, { relatedTarget: input });
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+    void container;
+  });
+
+  it('saves on a pointer press outside the field', () => {
+    const onSave = vi.fn();
+    render(
+      <Harness
+        value="folder"
+        isEditing
+        onSave={onSave}
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    act(() => {
+      fireEvent.pointerDown(document.body);
+    });
+
+    expect(onSave).toHaveBeenCalledWith('folder');
+  });
+
+  it('reverts to the default name on a pointer press outside when invalid', () => {
+    const onSave = vi.fn();
+    render(
+      <Harness
+        value="original"
+        isEditing
+        onSave={onSave}
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: '   ' } });
+    });
+    act(() => {
+      fireEvent.pointerDown(document.body);
+    });
+
+    expect(onSave).toHaveBeenCalledWith('original');
+  });
+
+  it('does not commit on a pointer press inside the field container', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <div data-editable-container>
+        <Harness
+          value="folder"
+          isEditing
+          onSave={onSave}
+          onValidate={() => null}
+        />
+      </div>,
+    );
+
+    const adornment = document.createElement('button');
+    container
+      .querySelector('[data-editable-container]')!
+      .appendChild(adornment);
+
+    act(() => {
+      fireEvent.pointerDown(adornment);
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('does not double-save when both the pointer press and blur fire', () => {
+    const onSave = vi.fn();
+    render(
+      <Harness
+        value="folder"
+        isEditing
+        onSave={onSave}
+        onValidate={(v) => (v.trim() ? null : 'required')}
+      />,
+    );
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+    act(() => {
+      fireEvent.pointerDown(document.body);
+      fireEvent.blur(input);
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/use-editable-item.tsx
+++ b/src/hooks/use-editable-item.tsx
@@ -7,6 +7,11 @@ import {
   type RefObject,
 } from 'react';
 
+export const EDITABLE_CONTAINER_ATTRIBUTE = 'data-editable-container';
+export const editableContainerProps = {
+  [EDITABLE_CONTAINER_ATTRIBUTE]: '',
+} as const;
+
 export interface UseEditableItemOptions {
   value: string;
   isEditing: boolean;
@@ -92,6 +97,7 @@ export function useEditableItem({
   const [invalidMessage, setInvalidMessage] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const cancelSavingRef = useRef<boolean>(false);
+  const committedRef = useRef<boolean>(false);
 
   const resetValidationState = useCallback((state = false, error = '') => {
     setInvalid(state);
@@ -130,26 +136,26 @@ export function useEditableItem({
     [validate],
   );
 
+  const commit = useCallback(
+    (valueToCommit: string) => {
+      if (isCreating && !cancelSavingRef.current && !isLoading) {
+        onCreateFolderSave?.(valueToCommit);
+      } else if (!isCreating && isEditing) {
+        onSave?.(valueToCommit);
+      }
+      cancelSavingRef.current = false;
+    },
+    [onSave, onCreateFolderSave, isCreating, isEditing, isLoading],
+  );
+
   const save = useCallback(() => {
     if (validate(value)) {
-      if (isCreating && !cancelSavingRef.current && !isLoading) {
-        onCreateFolderSave?.(value);
-      } else if (!isCreating && isEditing) {
-        onSave?.(value);
-      }
+      commit(value);
     } else {
       inputRef.current?.focus();
     }
     cancelSavingRef.current = false;
-  }, [
-    validate,
-    onSave,
-    value,
-    onCreateFolderSave,
-    isCreating,
-    isEditing,
-    isLoading,
-  ]);
+  }, [validate, value, commit]);
 
   const cancel = useCallback(() => {
     if (restoreOnCancel) {
@@ -173,10 +179,35 @@ export function useEditableItem({
     isCreating,
   ]);
 
+  /**
+   * Commits the edit when focus leaves the input (outside click / blur).
+   * Always exits edit mode: a valid value is saved as-is, while an invalid
+   * value falls back to the default name (`initialValue`) and is committed,
+   * instead of trapping the user inside the field.
+   */
+  const saveOnBlur = useCallback(() => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+
+    if (validate(value)) {
+      commit(value);
+      return;
+    }
+
+    if (validate(initialValue)) {
+      setValue(initialValue);
+      resetValidationState();
+      commit(initialValue);
+    } else {
+      cancel();
+    }
+  }, [validate, value, initialValue, commit, cancel, resetValidationState]);
+
   useEffect(() => {
     if (!isEditing && !isCreating) return;
 
     cancelSavingRef.current = false;
+    committedRef.current = false;
     setValue(initialValue);
     resetValidationState();
 
@@ -205,30 +236,37 @@ export function useEditableItem({
   }, [isEditing, isCreating, save, cancel]);
 
   useEffect(() => {
-    if (!isEditing && !isCreating) return;
+    if ((!isEditing && !isCreating) || isLoading) return;
 
     const el = inputRef.current;
     if (!el) return;
 
-    const handleBlur = (e: FocusEvent) => {
-      const nextTarget = e.relatedTarget as Node | null;
-      const stillInside = nextTarget && el.contains(nextTarget);
+    const isInsideField = (node: Node | null): boolean => {
+      if (!node) return false;
+      const container = el.closest(`[${EDITABLE_CONTAINER_ATTRIBUTE}]`) ?? el;
+      return container.contains(node);
+    };
 
-      if (!stillInside && !isLoading) {
-        if (validate(value)) {
-          save();
-        } else {
-          el.focus();
-        }
+    const handlePointerDown = (e: PointerEvent) => {
+      if (!isInsideField(e.target as Node | null)) {
+        saveOnBlur();
       }
     };
 
+    const handleBlur = (e: FocusEvent) => {
+      if (!isInsideField(e.relatedTarget as Node | null)) {
+        saveOnBlur();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
     el.addEventListener('blur', handleBlur);
 
     return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
       el.removeEventListener('blur', handleBlur);
     };
-  }, [isEditing, isCreating, value, validate, save, isLoading]);
+  }, [isEditing, isCreating, isLoading, saveOnBlur]);
 
   return { inputRef, value, onChange, invalid, invalidMessage };
 }

--- a/src/hooks/use-editable-item.tsx
+++ b/src/hooks/use-editable-item.tsx
@@ -148,15 +148,6 @@ export function useEditableItem({
     [onSave, onCreateFolderSave, isCreating, isEditing, isLoading],
   );
 
-  const save = useCallback(() => {
-    if (validate(value)) {
-      commit(value);
-    } else {
-      inputRef.current?.focus();
-    }
-    cancelSavingRef.current = false;
-  }, [validate, value, commit]);
-
   const cancel = useCallback(() => {
     if (restoreOnCancel) {
       setValue(initialValue);
@@ -233,7 +224,7 @@ export function useEditableItem({
 
     el.addEventListener('keydown', handleKey);
     return () => el.removeEventListener('keydown', handleKey);
-  }, [isEditing, isCreating, save, cancel]);
+  }, [isEditing, isCreating, cancel]);
 
   useEffect(() => {
     if ((!isEditing && !isCreating) || isLoading) return;


### PR DESCRIPTION
**Description and UI changes:**

Clicking outside should exit the editing mode and set the name, if the name is incorrect, then set the default name

Issues:

- Issue #723

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added