### PR TITLE
fix: [File Manager] fixed breadcrumbs for long labels (Issue #3590)

### DIFF
--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,13 +7,13 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 shrink-0 dial-small-text';
+  'flex items-center gap-2 min-w-0 dial-small-text';
 
-export const breadcrumbItemVisibleClassName = 'basis-[20%] flex-none';
+export const breadcrumbItemVisibleClassName = 'shrink-0 max-w-[30%]';
 export const breadcrumbItemLastClassName = 'flex-1 min-w-0';
 
 export const breadcrumbLinkBaseClassName =
-  'inline-flex items-center gap-1 min-w-0 transition-colors';
+  'flex flex-1 items-center gap-1 min-w-0 transition-colors';
 
 export const breadcrumbLinkInteractiveClassName =
   'text-secondary hover:text-accent-primary';

--- a/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.stories.tsx
+++ b/src/components/FileManager/components/FileManagerNavigationPanel/FileManagerNavigationPanel.stories.tsx
@@ -69,6 +69,12 @@ export const LongPath: Story = {
   },
 };
 
+export const LongLabels: Story = {
+  args: {
+    path: 'Organization/Product Design Team/UI Components Library/Breadcrumb Navigation/Very Long Subfolder Name That Will Definitely Be Truncated/Another Very Long Subfolder With Lots Of Extra Words That Should Be Truncated Because It Is Way Too Long To Fit/Current Working Folder With An Extremely Long Descriptive Name That Exceeds The Available Space And Must Be Truncated With Ellipsis At The End Of The Text',
+  },
+};
+
 export const WithLinks: Story = {
   args: {
     path: 'Org/Team/Design/Assets',


### PR DESCRIPTION
**Description and UI changes:**

<img width="1228" height="828" alt="image" src="https://github.com/user-attachments/assets/8a3e3462-f9b2-4a13-8204-0f449ae2b4f1" />

Issues:

- Issue #3590

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added