### PR TITLE
feat: Add possibility to use different color for skeletons

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -37,6 +37,11 @@ const meta: Meta<typeof DialSkeleton> = {
       control: 'text',
       description: 'Height of the skeleton',
     },
+    color: {
+      control: 'color',
+      description:
+        'Custom background color for skeleton elements (overrides the default design token)',
+    },
   },
 };
 
@@ -326,6 +331,83 @@ export const CardSkeleton: Story = {
       />
     </div>
   ),
+};
+
+export const CustomColor: Story = {
+  args: {
+    active: true,
+    color: '#a855f7',
+    avatar: true,
+    paragraph: { rows: 3 },
+  },
+  render: (args) => (
+    <div className="w-[600px]">
+      <DialSkeleton {...args} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the `color` prop to set a custom background color on all skeleton elements. This is useful when the component is rendered on a non-standard background where the default token color would blend in.',
+      },
+    },
+  },
+};
+
+export const CustomColorVariants: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div className="p-4 rounded" style={{ backgroundColor: '#1e1b4b' }}>
+        <DialSkeleton
+          active
+          color="rgba(139, 92, 246, 0.4)"
+          avatar
+          paragraph={{ rows: 2 }}
+        />
+      </div>
+      <div className="p-4 rounded bg-accent-primary">
+        <DialSkeleton
+          active
+          color="rgba(255,255,255,0.3)"
+          paragraph={{ rows: 2 }}
+        />
+      </div>
+      <div className="p-4 rounded">
+        <div className="flex gap-3 items-center mb-3">
+          <DialSkeleton
+            variant={DialSkeletonVariant.Circular}
+            width={40}
+            height={40}
+            active
+            color="#f97316"
+          />
+          <DialSkeleton
+            variant={DialSkeletonVariant.Text}
+            width="50%"
+            height={16}
+            active
+            color="#f97316"
+          />
+        </div>
+        <DialSkeleton
+          variant={DialSkeletonVariant.Rectangular}
+          width="100%"
+          height={100}
+          active
+          color="#f97316"
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom colors applied across different variants and backgrounds.',
+      },
+    },
+  },
 };
 
 export const AllAvatarSizes: Story = {

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -28,6 +28,7 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
   width?: string | number;
   height?: string | number;
   overlay?: ReactNode;
+  color?: string;
 }
 
 /**
@@ -85,6 +86,8 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
  * @param [width] - Width of the skeleton
  * @param [height] - Height of the skeleton
  * @param [className] - Additional CSS classes
+ * @param [overlay] - Content to overlay on top of the skeleton (e.g., a spinner)
+ * @param [color] - Custom background color for the skeleton elements (overrides the default token)
  */
 export const DialSkeleton: FC<DialSkeletonProps> = ({
   active = true,
@@ -97,6 +100,7 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
   width,
   height,
   overlay,
+  color,
   className,
   ...props
 }) => {
@@ -123,6 +127,7 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
     if (width) style.width = typeof width === 'number' ? `${width}px` : width;
     if (height)
       style.height = typeof height === 'number' ? `${height}px` : height;
+    if (color) style.backgroundColor = color;
 
     return (
       <div className={variantClass} style={style} {...props}>
@@ -174,14 +179,21 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
               : 'rounded',
             'flex-shrink-0',
           )}
-          style={{ width: avatarSize, height: avatarSize }}
+          style={{
+            width: avatarSize,
+            height: avatarSize,
+            ...(color && { backgroundColor: color }),
+          }}
         />
       )}
       <div className="flex-1 flex flex-col gap-3">
         {displayTitle && (
           <div
             className={mergeClasses(baseClass, 'h-4 rounded')}
-            style={{ width: titleWidth }}
+            style={{
+              width: titleWidth,
+              ...(color && { backgroundColor: color }),
+            }}
           />
         )}
         {showParagraph && (
@@ -190,7 +202,10 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
               <div
                 key={index}
                 className={mergeClasses(baseClass, 'h-4 rounded')}
-                style={{ width: getParagraphWidth(index) }}
+                style={{
+                  width: getParagraphWidth(index),
+                  ...(color && { backgroundColor: color }),
+                }}
               />
             ))}
           </div>


### PR DESCRIPTION
**Description and UI changes:**

Add possibility to use different color for skeletons

Useful, when need to show skeleton on bg-layer-3.
Cannot set is via className, because it'll set the bg for the whole skeleton as well.
<img width="1854" height="698" alt="image" src="https://github.com/user-attachments/assets/950f1350-0b74-4b7f-99e7-dc74352f6224" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added