### PR TITLE
fix: scroll freezing on inputhover/showing tooltip

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -125,10 +125,13 @@ const InputWrapper: FC<InputWrapperProps> = ({
   const innerRef = useRef<HTMLInputElement | null>(null);
   const ref = useMergeRefs([inputRef, innerRef]);
 
-  // disable mouse wheel changing input value
+  const isNumericInput =
+    type === 'number' || min !== undefined || max !== undefined;
+
+  // Prevent mouse wheel from changing numeric input values only.
   useEffect(() => {
     const el = innerRef.current;
-    if (!el) return;
+    if (!el || !isNumericInput || disabled) return;
 
     const stopScroll = (e: Event) => {
       e.preventDefault();
@@ -139,10 +142,7 @@ const InputWrapper: FC<InputWrapperProps> = ({
     return () => {
       el.removeEventListener('wheel', stopScroll);
     };
-  }, []);
-
-  const isNumericInput =
-    type === 'number' || min !== undefined || max !== undefined;
+  }, [disabled, isNumericInput, type]);
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     handleKeyDown(e, type, min, max);


### PR DESCRIPTION
**Description and UI changes:**

DialInput attached a wheel listener to every input that called preventDefault(), originally meant to stop the mouse wheel from changing number field values. When the cursor was over any input (including text and disabled fields with tooltips), page scrolling was blocked

Fix: The wheel listener is now attached only for enabled numeric inputs (type="number" or min/max set). Text and disabled inputs no longer intercept wheel events, so page scroll works normally

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added