### PR TITLE
feat: Add slider component

### DIFF
--- a/src/components/Slider/Slider.spec.tsx
+++ b/src/components/Slider/Slider.spec.tsx
@@ -156,7 +156,15 @@ describe('Dial UI Kit :: DialSlider', () => {
   });
 
   test('integer step formats value without decimals', () => {
-    render(<DialSlider value={50} min={0} max={100} step={1} onChange={() => undefined} />);
+    render(
+      <DialSlider
+        value={50}
+        min={0}
+        max={100}
+        step={1}
+        onChange={() => undefined}
+      />,
+    );
     expect(screen.getByRole('slider')).toHaveTextContent('50');
   });
 });

--- a/src/components/Slider/Slider.spec.tsx
+++ b/src/components/Slider/Slider.spec.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DialSlider } from './Slider';
+
+describe('Dial UI Kit :: DialSlider', () => {
+  test('renders with correct ARIA attributes', () => {
+    render(
+      <DialSlider
+        value={0.5}
+        min={0}
+        max={1}
+        aria-label="Temperature"
+        onChange={() => undefined}
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuenow', '0.5');
+    expect(slider).toHaveAttribute('aria-valuemin', '0');
+    expect(slider).toHaveAttribute('aria-valuemax', '1');
+    expect(slider).toHaveAttribute('aria-label', 'Temperature');
+  });
+
+  test('displays formatted value in thumb', () => {
+    render(<DialSlider value={0.5} onChange={() => undefined} />);
+    expect(screen.getByRole('slider')).toHaveTextContent('0.5');
+  });
+
+  test('uses custom formatValue', () => {
+    render(
+      <DialSlider
+        value={0.7}
+        formatValue={(v) => `${Math.round(v * 100)}%`}
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByRole('slider')).toHaveTextContent('70%');
+  });
+
+  test('fires onChange on ArrowRight and ArrowLeft', () => {
+    const onChange = vi.fn();
+    render(
+      <DialSlider value={0.5} min={0} max={1} step={0.1} onChange={onChange} />,
+    );
+    const slider = screen.getByRole('slider');
+
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith(0.6);
+
+    onChange.mockClear();
+    fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+    expect(onChange).toHaveBeenCalledWith(0.4);
+  });
+
+  test('fires onChange on ArrowUp and ArrowDown', () => {
+    const onChange = vi.fn();
+    render(
+      <DialSlider value={0.5} min={0} max={1} step={0.1} onChange={onChange} />,
+    );
+    const slider = screen.getByRole('slider');
+
+    fireEvent.keyDown(slider, { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenCalledWith(0.6);
+
+    onChange.mockClear();
+    fireEvent.keyDown(slider, { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenCalledWith(0.4);
+  });
+
+  test('jumps to min/max on Home/End keys', () => {
+    const onChange = vi.fn();
+    render(
+      <DialSlider value={0.5} min={0} max={1} step={0.1} onChange={onChange} />,
+    );
+    const slider = screen.getByRole('slider');
+
+    fireEvent.keyDown(slider, { key: 'Home' });
+    expect(onChange).toHaveBeenCalledWith(0);
+
+    onChange.mockClear();
+    fireEvent.keyDown(slider, { key: 'End' });
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  test('clamps at max boundary', () => {
+    const onChange = vi.fn();
+    render(
+      <DialSlider value={1} min={0} max={1} step={0.1} onChange={onChange} />,
+    );
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowRight' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('clamps at min boundary', () => {
+    const onChange = vi.fn();
+    render(
+      <DialSlider value={0} min={0} max={1} step={0.1} onChange={onChange} />,
+    );
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowLeft' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('does not fire onChange when disabled', () => {
+    const onChange = vi.fn();
+    render(<DialSlider value={0.5} disabled onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowRight' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('thumb is not focusable when disabled', () => {
+    render(<DialSlider value={0.5} disabled onChange={() => undefined} />);
+    expect(screen.getByRole('slider')).toHaveAttribute('tabindex', '-1');
+  });
+
+  test('renders three labels', () => {
+    render(
+      <DialSlider
+        value={0.5}
+        labels={['Precise', 'Neutral', 'Creative']}
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText('Precise')).toBeInTheDocument();
+    expect(screen.getByText('Neutral')).toBeInTheDocument();
+    expect(screen.getByText('Creative')).toBeInTheDocument();
+  });
+
+  test('renders two labels', () => {
+    render(
+      <DialSlider
+        value={0.5}
+        labels={['Min', 'Max']}
+        onChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText('Min')).toBeInTheDocument();
+    expect(screen.getByText('Max')).toBeInTheDocument();
+  });
+
+  test('renders no labels when omitted', () => {
+    const { queryByText } = render(
+      <DialSlider value={0.5} onChange={() => undefined} />,
+    );
+    expect(queryByText('Precise')).not.toBeInTheDocument();
+  });
+
+  test('applies className to outer container', () => {
+    const { container } = render(
+      <DialSlider
+        value={0.5}
+        className="custom-class"
+        onChange={() => undefined}
+      />,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  test('integer step formats value without decimals', () => {
+    render(<DialSlider value={50} min={0} max={100} step={1} onChange={() => undefined} />);
+    expect(screen.getByRole('slider')).toHaveTextContent('50');
+  });
+});

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -68,23 +68,39 @@ const meta = {
     },
     trackClassName: {
       control: { type: 'text' },
-      description: 'Additional classes for the track bar (default: `bg-layer-1`)',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+      description:
+        'Additional classes for the track bar (default: `bg-layer-1`)',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
     },
     fillClassName: {
       control: { type: 'text' },
-      description: 'Additional classes for the filled portion of the track (default: `bg-controls-accent-primary`)',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+      description:
+        'Additional classes for the filled portion of the track (default: `bg-controls-accent-primary`)',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
     },
     thumbClassName: {
       control: { type: 'text' },
-      description: 'Additional classes for the thumb circle (default: `bg-layer-3 text-primary dial-small-text`)',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+      description:
+        'Additional classes for the thumb circle (default: `bg-layer-3 text-primary dial-small-text`)',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
     },
     labelsClassName: {
       control: { type: 'text' },
-      description: 'Additional classes for the labels row (default: `text-secondary dial-tiny-text`)',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+      description:
+        'Additional classes for the labels row (default: `text-secondary dial-tiny-text`)',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
     },
   },
   args: {
@@ -223,7 +239,9 @@ export const CustomStyling: Story = {
 export const Disabled: Story = {
   parameters: {
     docs: {
-      description: { story: 'Disabled state — interaction and focus are blocked.' },
+      description: {
+        story: 'Disabled state — interaction and focus are blocked.',
+      },
     },
   },
   render: ControlledExample,

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1,0 +1,195 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { DialSlider, type DialSliderProps } from './Slider';
+
+const meta = {
+  title: 'Form/Slider',
+  component: DialSlider,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A range slider with a custom thumb showing the current value and optional start/center/end labels below the track.',
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: 'number', min: 0, max: 1, step: 0.1 },
+      description: 'Current slider value',
+      table: { type: { summary: 'number' } },
+    },
+    min: {
+      control: { type: 'number' },
+      description: 'Minimum value',
+      table: { type: { summary: 'number' }, defaultValue: { summary: '0' } },
+    },
+    max: {
+      control: { type: 'number' },
+      description: 'Maximum value',
+      table: { type: { summary: 'number' }, defaultValue: { summary: '1' } },
+    },
+    step: {
+      control: { type: 'number' },
+      description: 'Step increment',
+      table: { type: { summary: 'number' }, defaultValue: { summary: '0.1' } },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disables interaction',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    labels: {
+      control: false,
+      description:
+        'Optional 2- or 3-element label tuple rendered below the track',
+      table: {
+        type: { summary: '[string, string] | [string, string, string]' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    formatValue: {
+      control: false,
+      description: 'Custom formatter for the thumb value display',
+      table: {
+        type: { summary: '(value: number) => string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    onChange: {
+      control: false,
+      description: 'Callback fired with the new value',
+      table: { type: { summary: '(value: number) => void' } },
+    },
+  },
+  args: {
+    value: 0.5,
+    min: 0,
+    max: 1,
+    step: 0.1,
+    disabled: false,
+    onChange: () => undefined,
+  },
+} satisfies Meta<DialSliderProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ControlledExample = (args: DialSliderProps) => {
+  const [value, setValue] = useState(args.value);
+  return (
+    <div className="w-[422px]">
+      <DialSlider
+        {...args}
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          args.onChange?.(v);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default slider with Precise / Neutral / Creative labels, matching the standard AI temperature control UI.',
+      },
+    },
+  },
+  render: ControlledExample,
+  args: {
+    labels: ['Precise', 'Neutral', 'Creative'],
+  },
+};
+
+export const WithoutLabels: Story = {
+  parameters: {
+    docs: {
+      description: { story: 'Slider with no labels below the track.' },
+    },
+  },
+  render: ControlledExample,
+};
+
+export const TwoLabels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Slider with only a start and end label.',
+      },
+    },
+  },
+  render: ControlledExample,
+  args: {
+    labels: ['Min', 'Max'],
+  },
+};
+
+export const IntegerRange: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Slider over an integer range (0–100).',
+      },
+    },
+  },
+  render: (args: DialSliderProps) => {
+    const [value, setValue] = useState(50);
+    return (
+      <div className="w-[422px]">
+        <DialSlider
+          {...args}
+          value={value}
+          onChange={(v) => {
+            setValue(v);
+            args.onChange?.(v);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+    value: 50,
+    labels: ['0', '50', '100'],
+  },
+};
+
+export const CustomFormat: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Uses a custom formatValue to show the value as a percentage.',
+      },
+    },
+  },
+  render: ControlledExample,
+  args: {
+    labels: ['0%', '50%', '100%'],
+    formatValue: (v) => `${Math.round(v * 100)}%`,
+  },
+};
+
+export const Disabled: Story = {
+  parameters: {
+    docs: {
+      description: { story: 'Disabled state — interaction and focus are blocked.' },
+    },
+  },
+  render: ControlledExample,
+  args: {
+    disabled: true,
+    labels: ['Precise', 'Neutral', 'Creative'],
+  },
+};

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -66,6 +66,26 @@ const meta = {
       description: 'Callback fired with the new value',
       table: { type: { summary: '(value: number) => void' } },
     },
+    trackClassName: {
+      control: { type: 'text' },
+      description: 'Additional classes for the track bar (default: `bg-layer-1`)',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+    },
+    fillClassName: {
+      control: { type: 'text' },
+      description: 'Additional classes for the filled portion of the track (default: `bg-controls-accent-primary`)',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+    },
+    thumbClassName: {
+      control: { type: 'text' },
+      description: 'Additional classes for the thumb circle (default: `bg-layer-3 text-primary dial-small-text`)',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+    },
+    labelsClassName: {
+      control: { type: 'text' },
+      description: 'Additional classes for the labels row (default: `text-secondary dial-tiny-text`)',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+    },
   },
   args: {
     value: 0.5,
@@ -178,6 +198,25 @@ export const CustomFormat: Story = {
   args: {
     labels: ['0%', '50%', '100%'],
     formatValue: (v) => `${Math.round(v * 100)}%`,
+  },
+};
+
+export const CustomStyling: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates trackClassName, fillClassName, thumbClassName, and labelsClassName overrides.',
+      },
+    },
+  },
+  render: ControlledExample,
+  args: {
+    labels: ['Precise', 'Neutral', 'Creative'],
+    trackClassName: 'bg-layer-2',
+    fillClassName: 'bg-accent-secondary',
+    thumbClassName: 'bg-layer-4 text-accent-secondary dial-tiny-text',
+    labelsClassName: 'text-primary',
   },
 };
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   type FC,
   type HTMLAttributes,
   type KeyboardEvent,

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -8,8 +8,10 @@ import {
 
 import { mergeClasses } from '@/utils/merge-classes';
 
-export interface DialSliderProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface DialSliderProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange'
+> {
   value: number;
   min?: number;
   max?: number;
@@ -84,9 +86,14 @@ export const DialSlider: FC<DialSliderProps> = ({
 }) => {
   const trackRef = useRef<HTMLDivElement>(null);
 
-  const percent = Math.max(0, Math.min(100, ((value - min) / (max - min)) * 100));
+  const percent = Math.max(
+    0,
+    Math.min(100, ((value - min) / (max - min)) * 100),
+  );
   const precision = getPrecision(step);
-  const displayValue = formatValue ? formatValue(value) : value.toFixed(precision);
+  const displayValue = formatValue
+    ? formatValue(value)
+    : value.toFixed(precision);
 
   const getValueFromClientX = useCallback(
     (clientX: number): number => {

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,0 +1,199 @@
+import {
+  type FC,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  useCallback,
+  useRef,
+} from 'react';
+
+import { mergeClasses } from '@/utils/merge-classes';
+
+export interface DialSliderProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  /** 2-element or 3-element label tuple rendered below the track */
+  labels?: [string, string] | [string, string, string];
+  /** Custom formatter for the thumb value; defaults to fixed-decimal based on step */
+  formatValue?: (value: number) => string;
+  onChange?: (value: number) => void;
+}
+
+const getPrecision = (step: number): number =>
+  (step.toString().split('.')[1] ?? '').length;
+
+/**
+ * A range slider with a custom thumb showing the current value and optional labels.
+ * aliases: RangeInput|TemperatureSlider
+ *
+ * @example
+ * ```tsx
+ * <DialSlider
+ *   value={0.5}
+ *   min={0}
+ *   max={1}
+ *   step={0.1}
+ *   labels={['Precise', 'Neutral', 'Creative']}
+ *   aria-label="Temperature"
+ *   onChange={(v) => console.log(v)}
+ * />
+ * ```
+ *
+ * @param value - Current slider value
+ * @param [min=0] - Minimum value
+ * @param [max=1] - Maximum value
+ * @param [step=0.1] - Step increment
+ * @param [disabled=false] - Disables interaction
+ * @param [labels] - 2 or 3 strings rendered below the track (start, [middle,] end)
+ * @param [formatValue] - Custom value formatter for the thumb display
+ * @param [onChange] - Callback fired with the new value on interaction
+ * @param [className] - Additional CSS classes for the outer container
+ */
+export const DialSlider: FC<DialSliderProps> = ({
+  value,
+  min = 0,
+  max = 1,
+  step = 0.1,
+  disabled = false,
+  labels,
+  formatValue,
+  onChange,
+  className,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...divProps
+}) => {
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const percent = Math.max(0, Math.min(100, ((value - min) / (max - min)) * 100));
+  const precision = getPrecision(step);
+  const displayValue = formatValue ? formatValue(value) : value.toFixed(precision);
+
+  const getValueFromClientX = useCallback(
+    (clientX: number): number => {
+      const track = trackRef.current;
+      if (!track) return value;
+      const rect = track.getBoundingClientRect();
+      const ratio = (clientX - rect.left) / rect.width;
+      const raw = min + ratio * (max - min);
+      const prec = getPrecision(step);
+      const snapped = parseFloat(
+        (Math.round((raw - min) / step) * step + min).toFixed(prec),
+      );
+      return Math.min(max, Math.max(min, snapped));
+    },
+    [min, max, step, value],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      onChange?.(getValueFromClientX(e.clientX));
+    },
+    [disabled, getValueFromClientX, onChange],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled || e.buttons === 0) return;
+      onChange?.(getValueFromClientX(e.clientX));
+    },
+    [disabled, getValueFromClientX, onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      const prec = getPrecision(step);
+      const snap = (v: number) =>
+        parseFloat((Math.round((v - min) / step) * step + min).toFixed(prec));
+      const clamp = (v: number) => Math.min(max, Math.max(min, v));
+
+      let newValue = value;
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          newValue = clamp(snap(value + step));
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          newValue = clamp(snap(value - step));
+          break;
+        case 'Home':
+          newValue = min;
+          break;
+        case 'End':
+          newValue = max;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      if (newValue !== value) onChange?.(newValue);
+    },
+    [disabled, value, step, min, max, onChange],
+  );
+
+  return (
+    <div
+      className={mergeClasses(
+        'flex flex-col gap-2',
+        disabled && 'pointer-events-none opacity-50',
+        className,
+      )}
+      {...divProps}
+    >
+      {/* Track area — 38px tall to contain the thumb without clipping */}
+      <div
+        ref={trackRef}
+        className="relative flex h-[38px] cursor-pointer items-center"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+      >
+        {/* Track bar */}
+        <div className="pointer-events-none absolute inset-x-0 h-3 rounded-[10px] bg-layer-1" />
+        {/* Fill */}
+        <div
+          className="pointer-events-none absolute left-0 h-3 rounded-[10px] bg-controls-accent-primary"
+          style={{ width: `${percent}%` }}
+        />
+        {/* Thumb */}
+        <div
+          role="slider"
+          tabIndex={disabled ? -1 : 0}
+          aria-valuenow={value}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-disabled={disabled || undefined}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          className="dial-small-text absolute -translate-x-1/2 flex size-[38px] cursor-grab select-none items-center justify-center rounded-full bg-layer-3 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          style={{ left: `${percent}%` }}
+          onKeyDown={handleKeyDown}
+        >
+          {displayValue}
+        </div>
+      </div>
+      {labels && (
+        <div className="dial-tiny-text flex text-secondary">
+          {labels.length === 3 ? (
+            <>
+              <span>{labels[0]}</span>
+              <span className="flex-1 text-center">{labels[1]}</span>
+              <span>{labels[2]}</span>
+            </>
+          ) : (
+            <>
+              <span>{labels[0]}</span>
+              <span className="ml-auto">{labels[1]}</span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -20,6 +20,14 @@ export interface DialSliderProps
   /** Custom formatter for the thumb value; defaults to fixed-decimal based on step */
   formatValue?: (value: number) => string;
   onChange?: (value: number) => void;
+  /** Additional classes for the track bar (default: `bg-layer-1`) */
+  trackClassName?: string;
+  /** Additional classes for the filled portion of the track (default: `bg-controls-accent-primary`) */
+  fillClassName?: string;
+  /** Additional classes for the thumb circle (default: `bg-layer-3 text-primary dial-small-text`) */
+  thumbClassName?: string;
+  /** Additional classes for the labels row (default: `text-secondary dial-tiny-text`) */
+  labelsClassName?: string;
 }
 
 const getPrecision = (step: number): number =>
@@ -51,6 +59,10 @@ const getPrecision = (step: number): number =>
  * @param [formatValue] - Custom value formatter for the thumb display
  * @param [onChange] - Callback fired with the new value on interaction
  * @param [className] - Additional CSS classes for the outer container
+ * @param [trackClassName] - Additional CSS classes for the track bar
+ * @param [fillClassName] - Additional CSS classes for the fill portion of the track
+ * @param [thumbClassName] - Additional CSS classes for the thumb circle
+ * @param [labelsClassName] - Additional CSS classes for the labels row
  */
 export const DialSlider: FC<DialSliderProps> = ({
   value,
@@ -62,6 +74,10 @@ export const DialSlider: FC<DialSliderProps> = ({
   formatValue,
   onChange,
   className,
+  trackClassName,
+  fillClassName,
+  thumbClassName,
+  labelsClassName,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
   ...divProps
@@ -155,10 +171,18 @@ export const DialSlider: FC<DialSliderProps> = ({
         onPointerMove={handlePointerMove}
       >
         {/* Track bar */}
-        <div className="pointer-events-none absolute inset-x-0 h-3 rounded-[10px] bg-layer-1" />
+        <div
+          className={mergeClasses(
+            'pointer-events-none absolute inset-x-0 h-3 rounded-[10px] bg-layer-1',
+            trackClassName,
+          )}
+        />
         {/* Fill */}
         <div
-          className="pointer-events-none absolute left-0 h-3 rounded-[10px] bg-controls-accent-primary"
+          className={mergeClasses(
+            'pointer-events-none absolute left-0 h-3 rounded-[10px] bg-controls-accent-primary',
+            fillClassName,
+          )}
           style={{ width: `${percent}%` }}
         />
         {/* Thumb */}
@@ -171,7 +195,10 @@ export const DialSlider: FC<DialSliderProps> = ({
           aria-disabled={disabled || undefined}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
-          className="dial-small-text absolute -translate-x-1/2 flex size-[38px] cursor-grab select-none items-center justify-center rounded-full bg-layer-3 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          className={mergeClasses(
+            'dial-small-text absolute -translate-x-1/2 flex size-[38px] cursor-grab select-none items-center justify-center rounded-full bg-layer-3 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-focus',
+            thumbClassName,
+          )}
           style={{ left: `${percent}%` }}
           onKeyDown={handleKeyDown}
         >
@@ -179,7 +206,12 @@ export const DialSlider: FC<DialSliderProps> = ({
         </div>
       </div>
       {labels && (
-        <div className="dial-tiny-text flex text-secondary">
+        <div
+          className={mergeClasses(
+            'dial-tiny-text flex text-secondary',
+            labelsClassName,
+          )}
+        >
           {labels.length === 3 ? (
             <>
               <span>{labels[0]}</span>

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export { DialCheckbox } from './components/Checkbox/Checkbox';
 export { DialSteps } from './components/Steps/Steps';
 export { DialRadioButton } from './components/RadioButton/RadioButton';
 export { DialRadioGroup } from './components/RadioGroup/RadioGroup';
+export { DialSlider } from './components/Slider/Slider';
+export type { DialSliderProps } from './components/Slider/Slider';
 export { DialNoDataContent } from './components/NoDataContent/NoDataContent';
 export type { DialNoDataContentProps } from './components/NoDataContent/NoDataContent';
 export { DialCollapsibleSidebar } from './components/CollapsibleSidebar/CollapsibleSidebar';


### PR DESCRIPTION
**Description and UI changes:**

Add slider component. Will be useful for at least two apps 

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/485cf849-c0dd-4d32-916b-38d0a8a35347" />


Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added