### PR TITLE
feat: add new body paragraph text styles

### DIFF
--- a/src/mcp/descriptions/typography.md
+++ b/src/mcp/descriptions/typography.md
@@ -4,21 +4,23 @@
 
 Use these by default. They follow the design system type scale.
 
-| Class                   | Weight   | Size / Line-height      |
-| ----------------------- | -------- | ----------------------- |
-| `.dial-display1-text`   | semibold | 32px / 48px             |
-| `.dial-display2-text`   | semibold | 28px / 40px             |
-| `.dial-h1-text`         | semibold | 22px / 32px             |
-| `.dial-h2-text`         | semibold | 20px / 28px             |
-| `.dial-h3-text`         | semibold | 18px / 26px             |
-| `.dial-body-text`       | normal   | 16px / 24px             |
-| `.dial-body-semi-text`  | semibold | 16px / 24px             |
-| `.dial-small-text`      | normal   | 14px / 20px             |
-| `.dial-small-semi-text` | semibold | 14px / 20px             |
-| `.dial-tiny-text`       | normal   | 12px / 16px             |
-| `.dial-tiny-semi-text`  | semibold | 12px / 16px             |
-| `.dial-caption-text`    | normal   | 10px / 12px             |
-| `.dial-code-text`       | normal   | 14px / 20px (monospace) |
+| Class                            | Weight   | Size / Line-height      |
+| -------------------------------- | -------- | ----------------------- |
+| `.dial-display1-text`            | semibold | 32px / 48px             |
+| `.dial-display2-text`            | semibold | 28px / 40px             |
+| `.dial-h1-text`                  | semibold | 22px / 32px             |
+| `.dial-h2-text`                  | semibold | 20px / 28px             |
+| `.dial-h3-text`                  | semibold | 18px / 26px             |
+| `.dial-body-text`                | normal   | 16px / 24px             |
+| `.dial-body-semi-text`           | semibold | 16px / 24px             |
+| `.dial-body-paragraph-text`      | normal   | 16px / 26px             |
+| `.dial-body-paragraph-semi-text` | semibold | 16px / 26px             |
+| `.dial-small-text`               | normal   | 14px / 20px             |
+| `.dial-small-semi-text`          | semibold | 14px / 20px             |
+| `.dial-tiny-text`                | normal   | 12px / 16px             |
+| `.dial-tiny-semi-text`           | semibold | 12px / 16px             |
+| `.dial-caption-text`             | normal   | 10px / 12px             |
+| `.dial-code-text`                | normal   | 14px / 20px (monospace) |
 
 ## Legacy classes (avoid in new code)
 

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -61,6 +61,14 @@ const TypographyShowcase = () => (
         className="dial-body-semi-text"
         label="dial-body-semi-text"
       />
+      <TypographyRow
+        className="dial-body-paragraph-text"
+        label="dial-body-paragraph-text"
+      />
+      <TypographyRow
+        className="dial-body-paragraph-semi-text"
+        label="dial-body-paragraph-semi-text"
+      />
       <TypographyRow className="dial-small-text" label="dial-small-text" />
       <TypographyRow
         className="dial-small-semi-text"

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -26,6 +26,14 @@
   @apply font-semibold text-[16px]/[24px];
 }
 
+.dial-body-paragraph-text {
+  @apply font-normal text-[16px]/[26px];
+}
+
+.dial-body-paragraph-semi-text {
+  @apply font-semibold text-[16px]/[26px];
+}
+
 .dial-small-text {
   @apply font-normal text-[14px]/[20px];
 }


### PR DESCRIPTION
**Description and UI changes:**

Add two new text styles to the **typography.scss**:
  - `dial-body-paragraph-text`
  - `dial-body-paragraph-semi-text`

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added