### PR TITLE
fix: remove padding and gap classes from FormItem

### DIFF
--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -148,6 +148,7 @@ export const DialFormItem: FC<DialFormItemProps> = ({
       className={mergeClasses(
         containerBaseClassName,
         orientationClassMap[orientation],
+        'gap-3',
         className,
       )}
     >

--- a/src/components/FormItem/FormItem.tsx
+++ b/src/components/FormItem/FormItem.tsx
@@ -148,7 +148,6 @@ export const DialFormItem: FC<DialFormItemProps> = ({
       className={mergeClasses(
         containerBaseClassName,
         orientationClassMap[orientation],
-        'py-4 gap-3',
         className,
       )}
     >


### PR DESCRIPTION
Removed padding and gap classes from the FormItem component.

**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added