### PR TITLE
fix: add name consecutive dots error (Issue #754)

### DIFF
--- a/src/components/FileManager/errors.ts
+++ b/src/components/FileManager/errors.ts
@@ -3,3 +3,7 @@ import { NotificationVariant } from '@/types/notification';
 export const DEFAULT_WARNINGS = {
   hiddenItemWarning: `${NotificationVariant.Warning}__A dot at the start of the name will make the item hidden`,
 };
+
+export const DEFAULT_ERRORS = {
+  consecutiveDotsError: 'Name cannot contain consecutive dots',
+};

--- a/src/components/FileManager/hooks/__tests__/use-folder-creation.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-folder-creation.spec.tsx
@@ -270,6 +270,48 @@ describe('Dial UI Kit :: useFolderCreation', () => {
       );
       expect(result.current.validateFolderName('Valid Name')).toBeNull();
     });
+
+    test('returns error for names with consecutive dots', () => {
+      const { result } = renderHook(() =>
+        useFolderCreation({
+          currentFolder: mockCurrentFolder,
+        }),
+      );
+
+      expect(result.current.validateFolderName('...')).toBe(
+        'Name cannot contain consecutive dots',
+      );
+      expect(result.current.validateFolderName('a..b')).toBe(
+        'Name cannot contain consecutive dots',
+      );
+      expect(result.current.validateFolderName('name..')).toBe(
+        'Name cannot contain consecutive dots',
+      );
+    });
+
+    test('consecutive dots error takes precedence over the leading-dot hidden warning', () => {
+      const { result } = renderHook(() =>
+        useFolderCreation({
+          currentFolder: mockCurrentFolder,
+        }),
+      );
+
+      const error = result.current.validateFolderName('..hidden');
+      expect(error).toBe('Name cannot contain consecutive dots');
+    });
+
+    test('still allows a single leading dot without consecutive dots', () => {
+      const { result } = renderHook(() =>
+        useFolderCreation({
+          currentFolder: mockCurrentFolder,
+        }),
+      );
+
+      const error = result.current.validateFolderName('.hidden');
+      expect(error).toBe(
+        'warning__A dot at the start of the name will make the item hidden',
+      );
+    });
   });
 
   describe('saveFolderCreation', () => {

--- a/src/components/FileManager/hooks/__tests__/use-item-renaming.spec.tsx
+++ b/src/components/FileManager/hooks/__tests__/use-item-renaming.spec.tsx
@@ -567,6 +567,7 @@ describe('useItemRenaming hook', () => {
             emptyName: 'Custom empty error',
             duplicateName: 'Custom duplicate error',
             hiddenItemWarning: 'Custom hidden item warning',
+            consecutiveDotsError: 'Custom consecutive dots error',
           },
         }),
       );
@@ -586,6 +587,46 @@ describe('useItemRenaming hook', () => {
         items[0].items![0],
       );
       expect(hiddenError).toBe('Custom hidden item warning');
+
+      const consecutiveDotsError = result.current.renameValidateHandler(
+        '...',
+        items[0].items![0],
+      );
+      expect(consecutiveDotsError).toBe('Custom consecutive dots error');
+    });
+
+    it('returns error for names with consecutive dots', () => {
+      const { result } = renderHook(() => useItemRenaming({ items }));
+
+      const folderA = items[0].items![0];
+
+      expect(result.current.renameValidateHandler('...', folderA)).toBe(
+        'Name cannot contain consecutive dots',
+      );
+      expect(result.current.renameValidateHandler('a..b', folderA)).toBe(
+        'Name cannot contain consecutive dots',
+      );
+      expect(result.current.renameValidateHandler('name..', folderA)).toBe(
+        'Name cannot contain consecutive dots',
+      );
+    });
+
+    it('takes precedence over the leading-dot hidden warning', () => {
+      const { result } = renderHook(() => useItemRenaming({ items }));
+
+      const folderA = items[0].items![0];
+      const error = result.current.renameValidateHandler('..hidden', folderA);
+      expect(error).toBe('Name cannot contain consecutive dots');
+    });
+
+    it('still allows a single leading dot without consecutive dots', () => {
+      const { result } = renderHook(() => useItemRenaming({ items }));
+
+      const folderA = items[0].items![0];
+      const error = result.current.renameValidateHandler('.hidden', folderA);
+      expect(error).toBe(
+        'warning__A dot at the start of the name will make the item hidden',
+      );
     });
 
     it('delegates to onRenameValidate and returns its result', () => {

--- a/src/components/FileManager/hooks/use-folder-creation.tsx
+++ b/src/components/FileManager/hooks/use-folder-creation.tsx
@@ -3,7 +3,10 @@ import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import type { DialUploadFileItem } from '@/models/file-manager';
 import { FOLDER_PLACEHOLDER_FILE_NAME } from '@/components/FileManager/constants';
-import { DEFAULT_WARNINGS } from '@/components/FileManager/errors';
+import {
+  DEFAULT_ERRORS,
+  DEFAULT_WARNINGS,
+} from '@/components/FileManager/errors';
 import { FileManagerCreateFolderType } from '@/types/file-manager';
 import { findFolderForPath } from '../utils';
 import { getNextFolderName } from '@/components/FileManager/utils';
@@ -12,6 +15,7 @@ export interface FolderCreationValidationMessages {
   emptyName?: string;
   duplicateName?: string;
   hiddenItemWarning?: string;
+  consecutiveDotsError?: string;
 }
 
 export interface UseFolderCreationProps {
@@ -49,6 +53,7 @@ const DEFAULT_VALIDATION_MESSAGES: Required<FolderCreationValidationMessages> =
     emptyName: 'Folder name cannot be empty',
     duplicateName: 'A folder with this name already exists',
     hiddenItemWarning: DEFAULT_WARNINGS.hiddenItemWarning,
+    consecutiveDotsError: DEFAULT_ERRORS.consecutiveDotsError,
   };
 
 export const useFolderCreation = ({
@@ -220,6 +225,10 @@ export const useFolderCreation = ({
 
       if (!trimmedName) {
         return messages.emptyName;
+      }
+
+      if (trimmedName.includes('..')) {
+        return messages.consecutiveDotsError;
       }
 
       if (trimmedName.startsWith('.') && trimmedName.length > 1) {

--- a/src/components/FileManager/hooks/use-item-renaming.tsx
+++ b/src/components/FileManager/hooks/use-item-renaming.tsx
@@ -3,18 +3,23 @@ import type { DialCopiedItem } from '@/models/file-manager';
 import { useCallback, useState, useMemo } from 'react';
 import { findNodeByPath } from '@/components/FileManager/utils';
 import { DialFileNodeType } from '@/models/file';
-import { DEFAULT_WARNINGS } from '@/components/FileManager/errors';
+import {
+  DEFAULT_ERRORS,
+  DEFAULT_WARNINGS,
+} from '@/components/FileManager/errors';
 
 export interface RenameValidationMessages {
   emptyName?: string;
   duplicateName?: string;
   hiddenItemWarning?: string;
+  consecutiveDotsError?: string;
 }
 
 const DEFAULT_VALIDATION_MESSAGES: Required<RenameValidationMessages> = {
   emptyName: 'Name cannot be empty',
   duplicateName: 'An item with this name already exists',
   hiddenItemWarning: DEFAULT_WARNINGS.hiddenItemWarning,
+  consecutiveDotsError: DEFAULT_ERRORS.consecutiveDotsError,
 };
 
 function trimTrailingSlashes(path: string): string {
@@ -143,6 +148,10 @@ export const useItemRenaming = ({
 
       if (!trimmedName) {
         return messages.emptyName;
+      }
+
+      if (trimmedName.includes('..')) {
+        return messages.consecutiveDotsError;
       }
 
       if (trimmedName.startsWith('.')) {


### PR DESCRIPTION
**Description and UI changes:**

When the user adds two or more dots, the field validation doesn't work properly

Issues:

- Issue #754

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added