### PR TITLE
feat: added enchantments for different components

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -20,6 +20,11 @@ export interface DialAccordionProps {
   defaultExpanded?: boolean;
   /** Disables toggling. */
   disabled?: boolean;
+  /**
+   * Renders the panel permanently expanded: the content is always visible, the
+   * chevron icon is hidden and the header is no longer interactive.
+   */
+  nonCollapsible?: boolean;
   /** Fired when the header is clicked. Receives the next expanded state. */
   onToggle?: (expanded: boolean) => void;
   /** Additional CSS classes for the outer container. */
@@ -51,6 +56,7 @@ export interface DialAccordionProps {
  * @param [expanded] - Controlled expanded state.
  * @param [defaultExpanded=false] - Initial expanded state when uncontrolled.
  * @param [disabled] - Disables toggling.
+ * @param [nonCollapsible] - Renders the panel permanently expanded without a chevron or toggle.
  * @param [onToggle] - Fired when the header is clicked. Receives the next expanded state.
  * @param [className] - Additional CSS classes for the outer container.
  * @param [headerClassName] - Additional CSS classes for the header button.
@@ -63,6 +69,7 @@ export const DialAccordion: FC<DialAccordionProps> = ({
   expanded,
   defaultExpanded = false,
   disabled,
+  nonCollapsible,
   onToggle,
   className,
   headerClassName,
@@ -70,7 +77,11 @@ export const DialAccordion: FC<DialAccordionProps> = ({
 }) => {
   const isControlled = expanded !== undefined;
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
-  const isExpanded = isControlled ? expanded : internalExpanded;
+  const isExpanded = nonCollapsible
+    ? true
+    : isControlled
+      ? expanded
+      : internalExpanded;
   const contentId = useId();
 
   const handleToggle = () => {
@@ -88,21 +99,24 @@ export const DialAccordion: FC<DialAccordionProps> = ({
         type="button"
         aria-expanded={isExpanded}
         aria-controls={contentId}
-        disabled={disabled}
+        disabled={disabled || nonCollapsible}
         onClick={handleToggle}
         className={mergeClasses(
           'flex w-full items-center gap-2 p-4 text-left',
           disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          nonCollapsible && 'cursor-default',
           headerClassName,
         )}
       >
-        <DialIcon
-          className={classNames(
-            'text-secondary transition-transform',
-            isExpanded && 'rotate-90',
-          )}
-          icon={<IconChevronRight size={DIAL_ICON_SIZE.SM} />}
-        />
+        {!nonCollapsible && (
+          <DialIcon
+            className={classNames(
+              'text-secondary transition-transform',
+              isExpanded && 'rotate-90',
+            )}
+            icon={<IconChevronRight size={DIAL_ICON_SIZE.SM} />}
+          />
+        )}
         <span className="dial-body-text text-primary">{title}</span>
         {description != null && description !== false && (
           <span className="dial-tiny-text text-secondary">{description}</span>

--- a/src/components/Analytics/Bar/Bar.stories.tsx
+++ b/src/components/Analytics/Bar/Bar.stories.tsx
@@ -38,7 +38,14 @@ const meta: Meta<typeof DialAnalyticsBar> = {
       description:
         'Renders the loading state: a loader instead of the value and an empty track.',
     },
+    inline: {
+      control: 'boolean',
+      description:
+        'Renders the title and bar on a single row (50% title, 50% bar + value).',
+    },
     className: { control: 'text' },
+    titleClassName: { control: 'text' },
+    valueClassName: { control: 'text' },
     ariaLabel: { control: 'text' },
   },
 };
@@ -112,4 +119,26 @@ export const ColorScale: Story = {
       ))}
     </div>
   ),
+};
+
+export const Inline: Story = {
+  args: {
+    title: 'Relevance',
+    value: 0.82,
+    valueLabel: '82%',
+    inline: true,
+    className: 'w-[420px]',
+  },
+};
+
+export const InlineCustomClasses: Story = {
+  args: {
+    title: 'Relevance',
+    value: 0.82,
+    valueLabel: '82%',
+    inline: true,
+    titleClassName: 'dial-small-semi-text text-secondary',
+    valueClassName: 'text-accent-primary',
+    className: 'w-[420px]',
+  },
 };

--- a/src/components/Analytics/Bar/Bar.tsx
+++ b/src/components/Analytics/Bar/Bar.tsx
@@ -39,6 +39,15 @@ export interface DialAnalyticsBarProps {
   colorMap?: AnalyticsBarColorStop[];
   /** Additional CSS classes for the outer container. */
   className?: string;
+  /** Additional CSS classes for the title label. */
+  titleClassName?: string;
+  /** Additional CSS classes for the value label. */
+  valueClassName?: string;
+  /**
+   * Renders the bar on a single row: the title takes the left half and the bar
+   * with its value takes the right half. Defaults to the stacked layout.
+   */
+  inline?: boolean;
   /** Accessible label for the bar. Falls back to the `title` when it is a string. */
   ariaLabel?: string;
 }
@@ -75,6 +84,9 @@ export interface DialAnalyticsBarProps {
  * @param [valueLabel] - Text rendered above the bar, on the right. Defaults to `value`.
  * @param [colorMap=DEFAULT_ANALYTICS_BAR_COLOR_MAP] - Color bands keyed by ratio.
  * @param [className] - Additional CSS classes for the outer container.
+ * @param [titleClassName] - Additional CSS classes for the title label.
+ * @param [valueClassName] - Additional CSS classes for the value label.
+ * @param [inline] - Renders the title and bar on a single row (50% / 50%).
  * @param [ariaLabel] - Accessible label for the bar.
  */
 export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
@@ -86,6 +98,9 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
   valueLabel,
   colorMap = DEFAULT_ANALYTICS_BAR_COLOR_MAP,
   className,
+  titleClassName,
+  valueClassName,
+  inline,
   ariaLabel,
 }) => {
   const ratio = getAnalyticsBarRatio(value ?? 0, maxValue);
@@ -94,38 +109,72 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
   const resolvedAriaLabel =
     ariaLabel ?? (typeof title === 'string' ? title : undefined);
 
+  const valueSlot = error ? (
+    <DialAnalyticsErrorTag />
+  ) : isLoading ? (
+    <DialLoader fullWidth={false} />
+  ) : (
+    <span
+      className={mergeClasses(
+        'dial-small-semi-text text-primary',
+        valueClassName,
+      )}
+    >
+      {displayValue}
+    </span>
+  );
+
+  const barTrack = (
+    <div
+      role="progressbar"
+      aria-valuenow={error || isLoading ? undefined : value}
+      aria-valuemin={0}
+      aria-valuemax={maxValue}
+      aria-label={resolvedAriaLabel}
+      className={mergeClasses(
+        'w-full overflow-hidden rounded-sm',
+        inline ? 'h-1' : 'h-2',
+        error ? 'bg-error' : 'bg-layer-1',
+      )}
+    >
+      {!error && !isLoading && (
+        <div
+          className="h-full rounded-sm transition-[width] duration-300"
+          style={{ width: `${ratio * 100}%`, backgroundColor: color }}
+        />
+      )}
+    </div>
+  );
+
+  const titleSlot = (
+    <span
+      className={mergeClasses('dial-small-text text-primary', titleClassName)}
+    >
+      {title}
+    </span>
+  );
+
+  if (inline) {
+    return (
+      <div
+        className={mergeClasses('flex flex-row items-center gap-2', className)}
+      >
+        <div className="w-1/2 min-w-0">{titleSlot}</div>
+        <div className="flex w-1/2 flex-row items-center gap-2">
+          <div className="min-w-0 flex-1">{barTrack}</div>
+          {valueSlot}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={mergeClasses('flex flex-col gap-1', className)}>
       <div className="flex flex-row items-center justify-between gap-2">
-        <span className="dial-small-text text-primary">{title}</span>
-        {error ? (
-          <DialAnalyticsErrorTag />
-        ) : isLoading ? (
-          <DialLoader fullWidth={false} />
-        ) : (
-          <span className="dial-small-semi-text text-primary">
-            {displayValue}
-          </span>
-        )}
+        {titleSlot}
+        {valueSlot}
       </div>
-      <div
-        role="progressbar"
-        aria-valuenow={error || isLoading ? undefined : value}
-        aria-valuemin={0}
-        aria-valuemax={maxValue}
-        aria-label={resolvedAriaLabel}
-        className={mergeClasses(
-          'h-2 w-full overflow-hidden rounded-sm',
-          error ? 'bg-error' : 'bg-layer-1',
-        )}
-      >
-        {!error && !isLoading && (
-          <div
-            className="h-full rounded-sm transition-[width] duration-300"
-            style={{ width: `${ratio * 100}%`, backgroundColor: color }}
-          />
-        )}
-      </div>
+      {barTrack}
     </div>
   );
 };

--- a/src/components/Analytics/BarGroup/BarGroup.spec.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.spec.tsx
@@ -5,11 +5,11 @@ import { DialAnalyticsBarGroup } from './BarGroup';
 const data = { accuracy: 0.82, recall: 0.64, precision: 0.91 };
 
 describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
-  test('renders the title and an entry count description', () => {
+  test('renders the title without a default description', () => {
     render(<DialAnalyticsBarGroup title="Relevance" data={data} />);
 
     expect(screen.getByText('Relevance')).toBeInTheDocument();
-    expect(screen.getByText('3 numeric results')).toBeInTheDocument();
+    expect(screen.queryByText('3 numeric results')).toBeNull();
   });
 
   test('renders a bar per entry, expanded by default', () => {
@@ -64,7 +64,6 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
   test('handles an empty data object', () => {
     render(<DialAnalyticsBarGroup title="Empty" data={{}} />);
 
-    expect(screen.getByText('0 numeric results')).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).toBeNull();
   });
 

--- a/src/components/Analytics/BarGroup/BarGroup.stories.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.stories.tsx
@@ -34,11 +34,18 @@ const meta: Meta<typeof DialAnalyticsBarGroup> = {
       control: 'boolean',
       description: 'Renders a loader in place of the bars while data loads.',
     },
+    inline: {
+      control: 'boolean',
+      description:
+        'Renders every bar on a single row (50% title, 50% bar + value).',
+    },
     onBarClick: {
       action: 'barClick',
       description:
         'Invoked with the entry key and value when a bar is clicked.',
     },
+    barTitleClassName: { control: 'text' },
+    barValueClassName: { control: 'text' },
     className: { control: 'text' },
   },
 };
@@ -107,4 +114,62 @@ export const Clickable: Story = {
     onBarClick: (key, value) => alert(`${key}: ${value}`),
     className: 'w-[420px]',
   },
+};
+
+export const Inline: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
+    inline: true,
+    className: 'w-[420px]',
+  },
+};
+
+export const InlineCustomClasses: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
+    inline: true,
+    barTitleClassName: 'dial-small-semi-text text-secondary',
+    barValueClassName: 'text-accent-primary',
+    className: 'w-[420px]',
+  },
+};
+
+export const TwoGroupsSideBySide: Story = {
+  name: 'Two groups side by side',
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-row gap-4">
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ accuracy: 0.82, recall: 0.64, precision: 0.91 }}
+          className="w-[320px]"
+          nonCollapsible
+        />
+        <DialAnalyticsBarGroup
+          title="Latency"
+          data={{ p50: 0.45, p95: 0.78 }}
+          className="w-[320px]"
+          nonCollapsible
+        />
+      </div>
+      <div className="flex flex-row gap-4">
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ accuracy: 0.82, recall: 0.64, precision: 0.91 }}
+          className="w-[320px]"
+          nonCollapsible
+          inline
+        />
+        <DialAnalyticsBarGroup
+          title="Latency"
+          data={{ p50: 0.45, p95: 0.78 }}
+          className="w-[320px]"
+          nonCollapsible
+          inline
+        />
+      </div>
+    </div>
+  ),
 };

--- a/src/components/Analytics/BarGroup/BarGroup.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.tsx
@@ -4,6 +4,7 @@ import { DialAccordion } from '@/components/Accordion/Accordion';
 import { DialAnalyticsBar } from '@/components/Analytics/Bar/Bar';
 import { DialLoader } from '@/components/Loader/Loader';
 import type { AnalyticsBarColorStop } from '@/models/analytics';
+import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DialAnalyticsBarGroupProps {
   /** Title passed to the accordion header. */
@@ -18,10 +19,21 @@ export interface DialAnalyticsBarGroupProps {
   colorMap?: AnalyticsBarColorStop[];
   /** Whether the accordion is expanded initially. Defaults to `true`. */
   defaultExpanded?: boolean;
+  /**
+   * Renders the group permanently expanded: the content is always visible and
+   * the accordion header has no toggle or chevron icon.
+   */
+  nonCollapsible?: boolean;
   /** Renders a loader in place of the bars while the data is being fetched. */
   isLoading?: boolean;
   /** Invoked with the entry key and value when a bar is clicked. When set, each bar becomes an interactive button. */
   onBarClick?: (key: string, value: number) => void;
+  /** Renders every bar on a single row (50% title, 50% bar + value). */
+  inline?: boolean;
+  /** Additional CSS classes for each bar's title label. */
+  barTitleClassName?: string;
+  /** Additional CSS classes for each bar's value label. */
+  barValueClassName?: string;
   /** Additional CSS classes for the accordion container. */
   className?: string;
 }
@@ -47,8 +59,12 @@ export interface DialAnalyticsBarGroupProps {
  * @param [maxValue] - Upper bound passed to every bar.
  * @param [colorMap] - Color map passed to every bar.
  * @param [defaultExpanded=true] - Whether the accordion is expanded initially.
+ * @param [nonCollapsible] - Renders the group permanently expanded without a toggle or chevron.
  * @param [isLoading] - Renders a loader in place of the bars while the data is being fetched.
  * @param [onBarClick] - Invoked with the entry key and value when a bar is clicked.
+ * @param [inline] - Renders every bar on a single row (50% title, 50% bar + value).
+ * @param [barTitleClassName] - Additional CSS classes for each bar's title label.
+ * @param [barValueClassName] - Additional CSS classes for each bar's value label.
  * @param [className] - Additional CSS classes for the accordion container.
  */
 export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
@@ -58,8 +74,12 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
   maxValue,
   colorMap,
   defaultExpanded = true,
+  nonCollapsible,
   isLoading,
   onBarClick,
+  inline,
+  barTitleClassName,
+  barValueClassName,
   className,
 }) => {
   const entries = Object.entries(data);
@@ -67,11 +87,14 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
   return (
     <DialAccordion
       title={title}
-      description={description ?? `${entries.length} numeric results`}
+      description={description}
       defaultExpanded={defaultExpanded}
+      nonCollapsible={nonCollapsible}
       className={className}
     >
-      <div className="flex flex-col gap-3">
+      <div
+        className={mergeClasses('flex flex-col', inline ? 'gap-2' : 'gap-3')}
+      >
         {isLoading ? (
           <DialLoader fullWidth={false} className="self-center" />
         ) : (
@@ -88,6 +111,9 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
                   value={value}
                   maxValue={maxValue}
                   colorMap={colorMap}
+                  inline={inline}
+                  titleClassName={barTitleClassName}
+                  valueClassName={barValueClassName}
                 />
               </button>
             ) : (
@@ -97,6 +123,9 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
                 value={value}
                 maxValue={maxValue}
                 colorMap={colorMap}
+                inline={inline}
+                titleClassName={barTitleClassName}
+                valueClassName={barValueClassName}
               />
             ),
           )

--- a/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
@@ -290,4 +290,51 @@ describe('DialSchemaRenderer', () => {
     );
     expect(screen.getByTestId('custom-name-field')).toBeInTheDocument();
   });
+
+  it('renders a JSON editor section titled with the key for values absent from the schema', async () => {
+    render(
+      <DialSchemaRenderer
+        schema={simpleSchema}
+        defaultValue={{ name: 'hi', extra: { foo: 'bar' } }}
+      />,
+    );
+
+    expect(screen.getByText('Extra')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('textbox', { name: 'JSON Editor' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render a JSON editor when every key is in the schema', () => {
+    render(
+      <DialSchemaRenderer
+        schema={simpleSchema}
+        defaultValue={{ name: 'hi', count: 5, enabled: true }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('textbox', { name: 'JSON Editor' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('propagates edits to an unknown key through onChange', async () => {
+    const onChange = vi.fn();
+    render(
+      <DialSchemaRenderer
+        schema={simpleSchema}
+        defaultValue={{ name: 'hi', extra: 'old' }}
+        onChange={onChange}
+      />,
+    );
+
+    const textarea = await screen.findByLabelText('JSON content');
+    fireEvent.change(textarea, {
+      target: { value: '"new"' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'hi', extra: 'new' }),
+    );
+  });
 });

--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -331,6 +331,18 @@ export const OneOfDiscriminator: Story = {
   args: { schema: oneOfSchema },
 };
 
+export const AdditionalProperties: Story = {
+  args: {
+    schema: simpleSchema,
+    defaultValue: {
+      name: 'My Config',
+      count: 10,
+      metadata: { owner: 'team-ai', tags: ['prod', 'eu'] },
+      customFlag: true,
+    },
+  },
+};
+
 export const ArrayWithDiscriminator: Story = {
   args: {
     schema: arraySchema,

--- a/src/components/SchemaRenderer/SchemaRenderer.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.tsx
@@ -16,6 +16,7 @@ import {
 import { SchemaSection } from '@/components/SchemaRenderer/components/SchemaSection';
 import { SchemaFieldContent } from '@/components/SchemaRenderer/components/SchemaFieldContent';
 import { SchemaField } from '@/components/SchemaRenderer/components/SchemaField';
+import { SchemaAdditionalPropertiesEditor } from '@/components/SchemaRenderer/components/SchemaAdditionalPropertiesEditor';
 
 /**
  * Renders a JSON Schema as a form UI with collapsible sections, validation, and default values.
@@ -41,6 +42,7 @@ import { SchemaField } from '@/components/SchemaRenderer/components/SchemaField'
  * @param [onChange] - Called with the full form value on every change
  * @param [onPropertyChange] - Called with `(path, value)` for each individual property change
  * @param [onDefaultValues] - Called once on mount with the resolved default values
+ * @param [jsonEditorTheme] - Theme for the JSON editor shown for value keys absent from the schema
  */
 export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
   schema,
@@ -56,6 +58,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
   onDefaultValues,
   renderField,
   skipUntouched = false,
+  jsonEditorTheme,
 }) => {
   const mergedTexts = useMemo(
     () => ({ ...DEFAULT_SCHEMA_TEXTS, ...texts }),
@@ -91,6 +94,13 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
     onChange?.(updated);
     onPropertyChange?.(key, newVal);
   };
+
+  const schemaPropertyKeys = new Set(Object.keys(schema.properties ?? {}));
+
+  // keys present in the value but absent from the schema's declared properties
+  const additionalPropertyKeys = Object.keys(value).filter(
+    (key) => !schemaPropertyKeys.has(key),
+  );
 
   const topLevelProperties = Object.entries(schema.properties ?? {}).filter(
     ([, propSchema]) => !resolveRef(propSchema, schema).isHidden,
@@ -183,6 +193,36 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
                 required={isRequired}
               />
             </SchemaSection>
+          );
+        })}
+        {additionalPropertyKeys.map((key) => {
+          const propLabel = toFieldLabel(key);
+          const editor = (
+            <SchemaAdditionalPropertiesEditor
+              value={value[key]}
+              onChange={(v) => handlePropertyChange(key, v)}
+              theme={jsonEditorTheme}
+            />
+          );
+
+          if (variant === SchemaRendererVariant.Sections) {
+            return (
+              <SchemaSection
+                key={key}
+                title={propLabel}
+                level={0}
+                defaultExpanded={defaultExpanded}
+              >
+                {editor}
+              </SchemaSection>
+            );
+          }
+
+          return (
+            <div key={key} className="flex flex-col gap-3">
+              <h2 className="dial-small-semi-text text-primary">{propLabel}</h2>
+              {editor}
+            </div>
           );
         })}
       </div>

--- a/src/components/SchemaRenderer/components/SchemaAdditionalPropertiesEditor.tsx
+++ b/src/components/SchemaRenderer/components/SchemaAdditionalPropertiesEditor.tsx
@@ -1,0 +1,68 @@
+import { type ComponentType, type FC, useEffect, useState } from 'react';
+import type { DialJsonEditorProps } from '@/components/JsonEditor/JsonEditor';
+import { useSchemaContext } from '@/components/SchemaRenderer/context';
+import { EditorThemes } from '@/types/editor';
+
+export interface SchemaAdditionalPropertiesEditorProps {
+  value: unknown;
+  onChange: (value: unknown) => void;
+  theme?: EditorThemes;
+  height?: number;
+}
+
+/**
+ * Renders a single value key that is not declared in the schema's `properties` as a raw JSON
+ * editor, letting users inspect and manually edit it. The Monaco-based editor is dynamically
+ * imported on the client only, keeping the parent SchemaRenderer SSR-safe.
+ * aliases: SchemaExtraPropertyEditor|SchemaUnknownPropertyEditor
+ *
+ * @param value - The current value of the property (any JSON type)
+ * @param onChange - Called with the parsed value whenever the edited JSON is valid
+ * @param [theme=EditorThemes.dark] - Theme applied to the JSON editor
+ * @param [height=240] - Editor height in pixels
+ */
+export const SchemaAdditionalPropertiesEditor: FC<
+  SchemaAdditionalPropertiesEditorProps
+> = ({ value, onChange, theme = EditorThemes.dark, height = 240 }) => {
+  const { readonly } = useSchemaContext();
+  const [EditorComponent, setEditorComponent] =
+    useState<ComponentType<DialJsonEditorProps> | null>(null);
+  const [text, setText] = useState<string>(() =>
+    JSON.stringify(value, null, 2),
+  );
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      import('@/components/JsonEditor/JsonEditor').then((module) => {
+        setEditorComponent(() => module.DialJsonEditor);
+      });
+    }
+  }, []);
+
+  const handleChange = (next: string | undefined) => {
+    const nextText = next ?? '';
+    setText(nextText);
+
+    try {
+      onChange(JSON.parse(nextText));
+    } catch {
+      // Ignore invalid JSON while the user is typing; propagate only once it parses.
+    }
+  };
+
+  return (
+    <div
+      className="border border-primary rounded"
+      style={{ height: `${height}px` }}
+    >
+      {EditorComponent && (
+        <EditorComponent
+          value={text}
+          currentTheme={theme}
+          onChange={handleChange}
+          options={{ readOnly: readonly }}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/SchemaRenderer/types.ts
+++ b/src/components/SchemaRenderer/types.ts
@@ -1,4 +1,5 @@
 import type React from 'react';
+import type { EditorThemes } from '@/types/editor';
 
 export enum SchemaRendererVariant {
   Sections = 'sections',
@@ -122,6 +123,11 @@ export interface DialSchemaRendererProps {
    * with a field. When `false` (default), all unfilled required fields are highlighted immediately.
    */
   skipUntouched?: boolean;
+  /**
+   * Theme applied to the JSON editor shown for value keys that are not declared in the
+   * schema's `properties`. Defaults to `EditorThemes.dark`.
+   */
+  jsonEditorTheme?: EditorThemes;
   onChange?: (value: Record<string, unknown>) => void;
   onPropertyChange?: (path: string, value: unknown) => void;
   onDefaultValues?: (value: Record<string, unknown>) => void;

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -334,3 +334,61 @@ export const WithSubMenuOptions: Story = {
     </div>
   ),
 };
+
+/**
+ * Splits a dotted label into a secondary-colored namespace part (everything up
+ * to and including the last dot) and a primary-colored name part (everything
+ * after the last dot). This mimics styling being computed by the consumer.
+ */
+const renderDottedLabel = (label: string) => {
+  const lastDot = label.lastIndexOf('.');
+  if (lastDot === -1) {
+    return <span className="text-primary">{label}</span>;
+  }
+
+  const namespace = label.slice(0, lastDot + 1);
+  const name = label.slice(lastDot + 1);
+
+  return (
+    <span className="truncate">
+      <span className="text-secondary">{namespace}</span>
+      <span className="text-primary">{name}</span>
+    </span>
+  );
+};
+
+const dottedLabels = [
+  'someValue.withOption',
+  'secondValue.specificOption',
+  'lastValue.strongText',
+];
+
+const dottedOptions: SelectOption[] = dottedLabels.map((label) => ({
+  value: label,
+  label,
+  labelNode: renderDottedLabel(label),
+}));
+
+export const CustomLabelNode: Story = {
+  name: 'Custom label node',
+  args: {
+    options: dottedOptions,
+    placeholder: 'Select value…',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Options can render a custom `labelNode` while keeping a plain-text `label` ' +
+          'for filtering and accessibility. Here the part before the last dot ' +
+          '(including the dot) is muted (`text-secondary`) and the part after it is ' +
+          'emphasized (`text-primary`). Styling and labels are computed by the consumer.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-[320px]">
+      <DialSelect {...args} />
+    </div>
+  ),
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -396,9 +396,10 @@ export const DialSelect: FC<DialSelectProps> = ({
           )}
           <DialEllipsisTooltip
             text={
-              prefix
+              singleSelectedOption.labelNode ??
+              (prefix
                 ? `${prefix} ${singleSelectedOption.label}`
-                : singleSelectedOption.label
+                : singleSelectedOption.label)
             }
           />
           {singleSelectedOption?.description && (
@@ -553,7 +554,9 @@ export const DialSelect: FC<DialSelectProps> = ({
                           label={
                             <span className="flex w-full flex-1 pl-2 min-w-0 items-center gap-2 text-primary">
                               {opt.icon && <DialIcon icon={opt.icon} />}
-                              <span className="truncate">{opt.label}</span>
+                              <span className="truncate">
+                                {opt.labelNode ?? opt.label}
+                              </span>
                             </span>
                           }
                           checked={selected}
@@ -601,7 +604,9 @@ export const DialSelect: FC<DialSelectProps> = ({
                     >
                       <div className="flex items-center gap-2 w-full">
                         {opt.icon && <DialIcon icon={opt.icon} />}
-                        <DialEllipsisTooltip text={opt.label} />
+                        <DialEllipsisTooltip
+                          text={opt.labelNode ?? opt.label}
+                        />
 
                         {opt.description && (
                           <div className="text-secondary dial-small-text">

--- a/src/components/Select/SelectSubMenuItem.tsx
+++ b/src/components/Select/SelectSubMenuItem.tsx
@@ -58,7 +58,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
       >
         <div className="flex items-center gap-2 w-full min-w-0">
           {opt.icon && <DialIcon icon={opt.icon} />}
-          <DialEllipsisTooltip text={opt.label} />
+          <DialEllipsisTooltip text={opt.labelNode ?? opt.label} />
         </div>
         <IconChevronRight size={14} className="shrink-0" />
       </button>
@@ -91,7 +91,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
               >
                 <div className="flex items-center gap-2 w-full">
                   {child.icon && <DialIcon icon={child.icon} />}
-                  <DialEllipsisTooltip text={child.label} />
+                  <DialEllipsisTooltip text={child.labelNode ?? child.label} />
                 </div>
               </button>
             );

--- a/src/models/select.ts
+++ b/src/models/select.ts
@@ -3,6 +3,12 @@ import type { ReactNode } from 'react';
 export interface SelectOption {
   value: string;
   label: string;
+  /**
+   * Custom node rendered in place of `label` in the option list, trigger and
+   * submenu. `label` is still used for filtering/search matching and as the
+   * accessible name, so keep it as a plain-text representation of `labelNode`.
+   */
+  labelNode?: ReactNode;
   description?: string;
   disabled?: boolean;
   icon?: ReactNode;


### PR DESCRIPTION
**Description and UI changes:**

**1.Bar group style**
<img width="820" height="427" alt="image" src="https://github.com/user-attachments/assets/396edb43-0502-428b-9b4a-aa4423f45442" />
**2.Select with custom ReactNode option**
<img width="421" height="216" alt="image" src="https://github.com/user-attachments/assets/50603dcc-6aec-4e73-b42a-08f242074749" />
**3.Schema renderer (draw JSONeditor for property not from scheme)**
<img width="931" height="590" alt="image" src="https://github.com/user-attachments/assets/bee61b89-977d-42b5-8f7a-ee656fe0cb09" />



Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added