### PR TITLE
fix: histogram border color for zero value

### DIFF
--- a/src/components/Analytics/Histogram/Histogram.spec.tsx
+++ b/src/components/Analytics/Histogram/Histogram.spec.tsx
@@ -31,12 +31,12 @@ describe('Dial UI Kit :: DialAnalyticsHistogram', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
-  test('renders the zero bucket with no color and a secondary border', () => {
+  test('renders the zero bucket with no color and a primary border', () => {
     render(<DialAnalyticsHistogram title="Distribution" values={[0, 0]} />);
 
     const zero = screen.getByRole('img', { name: '2 out of 2 values' });
     expect(zero.style.backgroundColor).toBe('');
-    expect(zero.className).toMatch(/border-secondary/);
+    expect(zero.className).toMatch(/border-primary/);
     expect(zero.style.height).toBe('100%');
   });
 

--- a/src/components/Analytics/Histogram/Histogram.tsx
+++ b/src/components/Analytics/Histogram/Histogram.tsx
@@ -115,7 +115,7 @@ export const DialAnalyticsHistogram: FC<DialAnalyticsHistogramProps> = ({
                     className={mergeClasses(
                       'flex min-h-2 w-full items-center justify-center rounded-sm border',
                       column.isZeroBucket
-                        ? 'border-secondary'
+                        ? 'border-primary'
                         : colored
                           ? 'border-transparent'
                           : 'border-primary',


### PR DESCRIPTION
**Description and UI changes:**

Changed border color for zero values in histogram (border-secondary -> border-primary)
<img width="154" height="199" alt="Screenshot 2026-07-10 at 16 24 38" src="https://github.com/user-attachments/assets/0305f294-d69d-461d-9573-97835d2bb389" />



Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added