### PR TITLE
fix: fix breadcrumb folder name displaying (Issue #761)

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -287,7 +287,9 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
     expect(rootLi.className).toMatch(/min-w-0/);
     expect(rootLi.className).not.toMatch(/max-w-\[30%\]/);
 
-    const currentText = screen.getByText('Some very long current sub-folder name');
+    const currentText = screen.getByText(
+      'Some very long current sub-folder name',
+    );
     const currentLi = currentText.closest('li') as HTMLElement;
     expect(currentLi.className).toMatch(/shrink/);
     expect(currentLi.className).toMatch(/max-w-\[40%\]/);
@@ -311,7 +313,9 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
       />,
     );
 
-    const penultimateLi = screen.getByText(penultimate).closest('li') as HTMLElement;
+    const penultimateLi = screen
+      .getByText(penultimate)
+      .closest('li') as HTMLElement;
     const lastLi = screen.getByText(last).closest('li') as HTMLElement;
 
     // Both segments must stay in the DOM (visible), not be pushed out by shrink-0 siblings.

--- a/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -270,4 +270,58 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
 
     expect(onBeforeNavigate).toHaveBeenCalled();
   });
+
+  test('root and current items can both shrink/truncate, current item is capped at 40%', () => {
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'Organization', href: '#org' },
+          { label: 'Some very long current sub-folder name' },
+        ]}
+      />,
+    );
+
+    const rootLink = screen.getByRole('link', { name: 'Organization' });
+    const rootLi = rootLink.closest('li') as HTMLElement;
+    expect(rootLi.className).toMatch(/shrink/);
+    expect(rootLi.className).toMatch(/min-w-0/);
+    expect(rootLi.className).not.toMatch(/max-w-\[30%\]/);
+
+    const currentText = screen.getByText('Some very long current sub-folder name');
+    const currentLi = currentText.closest('li') as HTMLElement;
+    expect(currentLi.className).toMatch(/shrink/);
+    expect(currentLi.className).toMatch(/max-w-\[40%\]/);
+  });
+
+  test('deep path with long consecutive folder names: penultimate and last folder are both rendered and can shrink to fit', () => {
+    const penultimate =
+      'Project_Regression_Testing_Artifacts_For_Shared_File_Manager_Workflows_Part_One';
+    const last =
+      'Project_Regression_Testing_Artifacts_For_Shared_File_Manager_Workflows_Part_Two';
+
+    render(
+      <DialBreadcrumb
+        pathItems={[
+          { label: 'My Files', href: '#root' },
+          { label: 'A folder', href: '#a' },
+          { label: 'Nested folder', href: '#b' },
+          { label: penultimate, href: '#c' },
+          { label: last },
+        ]}
+      />,
+    );
+
+    const penultimateLi = screen.getByText(penultimate).closest('li') as HTMLElement;
+    const lastLi = screen.getByText(last).closest('li') as HTMLElement;
+
+    // Both segments must stay in the DOM (visible), not be pushed out by shrink-0 siblings.
+    expect(penultimateLi).toBeInTheDocument();
+    expect(lastLi).toBeInTheDocument();
+
+    // Neither is shrink-0 anymore - both must be able to shrink to fit the available width.
+    expect(penultimateLi.className).not.toMatch(/shrink-0/);
+    expect(lastLi.className).not.toMatch(/shrink-0/);
+    expect(penultimateLi.className).toMatch(/min-w-0/);
+    expect(lastLi.className).toMatch(/min-w-0/);
+  });
 });

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -134,6 +134,7 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
         <DialBreadcrumbItem
           {...item}
           key={`item-${index}`}
+          isFirst={index === 0 && items.length > 1}
           isLast={index === items.length - 1}
           separator={separator}
           labelClassName={labelClassName}
@@ -160,12 +161,13 @@ export const DialBreadcrumb: FC<DialBreadcrumbProps> = ({
         <DialBreadcrumbItem
           {...first}
           key="item-0"
+          isFirst
           separator={separator}
           labelClassName={labelClassName}
           onBeforeNavigate={onBeforeNavigate}
         />
 
-        <li className={mergeClasses(breadcrumbItemBaseClassName)}>
+        <li className={mergeClasses(breadcrumbItemBaseClassName, 'shrink-0')}>
           <DialDropdown
             items={dropdownItems}
             onItemClick={handleDropdownItemClick}

--- a/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
@@ -231,6 +231,31 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
+  test('isFirst renders as a shrinkable item without a fixed max-width cap', () => {
+    render(
+      <ul>
+        <DialBreadcrumbItem label="Root" href="#root" isFirst />
+      </ul>,
+    );
+    const link = screen.getByRole('link', { name: 'Root' });
+    const li = link.closest('li') as HTMLElement;
+    expect(li.className).toMatch(/shrink/);
+    expect(li.className).toMatch(/min-w-0/);
+    expect(li.className).not.toMatch(/max-w-\[30%\]/);
+  });
+
+  test('isLast caps width so the current item never displaces the root', () => {
+    render(
+      <ul>
+        <DialBreadcrumbItem label="Current" isLast />
+      </ul>,
+    );
+    const text = screen.getByText('Current');
+    const li = text.closest('li') as HTMLElement;
+    expect(li.className).toMatch(/shrink/);
+    expect(li.className).toMatch(/max-w-\[40%\]/);
+  });
+
   test('navigation guard prevents default when returning false', async () => {
     const onBeforeNavigate = vi.fn().mockReturnValue(false);
 

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -11,8 +11,7 @@ import type {
 import {
   breadcrumbCurrentClassName,
   breadcrumbItemBaseClassName,
-  breadcrumbItemLastClassName,
-  breadcrumbItemVisibleClassName,
+  breadcrumbItemWidthClassName,
   breadcrumbLinkBaseClassName,
   breadcrumbLinkInteractiveClassName,
   breadcrumbSeparatorClassName,
@@ -30,6 +29,7 @@ export interface DialBreadcrumbItemProps extends Omit<
   iconBefore?: ReactNode;
   labelClassName?: string;
   isLast?: boolean;
+  isFirst?: boolean;
   separator?: ReactNode;
   onBeforeNavigate?: NavigationGuard;
 }
@@ -40,6 +40,7 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
   onClick,
   disabled,
   isLast,
+  isFirst,
   separator = defaultSeparator,
   className,
   iconBefore,
@@ -62,9 +63,15 @@ export const DialBreadcrumbItem: FC<DialBreadcrumbItemProps> = ({
       onClick(e);
     }
   };
+  const widthClassName = isLast
+    ? breadcrumbItemWidthClassName.last
+    : isFirst
+      ? breadcrumbItemWidthClassName.first
+      : breadcrumbItemWidthClassName.middle;
+
   const containerClassName = mergeClasses(
     breadcrumbItemBaseClassName,
-    isLast ? breadcrumbItemLastClassName : breadcrumbItemVisibleClassName,
+    widthClassName,
     className,
   );
   const interactive = (!!href || !!onClick) && !isLast && !disabled;

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,10 +7,16 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 dial-small-text';
+  'flex items-center gap-2 min-w-0 shrink dial-small-text';
 
-export const breadcrumbItemVisibleClassName = 'shrink-0 max-w-[30%]';
-export const breadcrumbItemLastClassName = 'flex-1 min-w-0';
+export const breadcrumbItemWidthClassName: Record<
+  'first' | 'middle' | 'last',
+  string
+> = {
+  first: '',
+  middle: 'max-w-[30%]',
+  last: 'max-w-[40%]',
+};
 
 export const breadcrumbLinkBaseClassName =
   'flex flex-1 items-center gap-1 min-w-0 transition-colors';


### PR DESCRIPTION
**Description and UI changes:**

Root folder name should be displayed always in breadcrumbs

Issues:

- Issue #761

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added