### PR TITLE
fix: fix breadcrumbs sizes (Issue #761)

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -271,7 +271,7 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
     expect(onBeforeNavigate).toHaveBeenCalled();
   });
 
-  test('root and current items can both shrink/truncate, current item is capped at 40%', () => {
+  test('root and current items can both shrink/truncate, current item is capped at 51%', () => {
     render(
       <DialBreadcrumb
         pathItems={[
@@ -292,7 +292,7 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
     );
     const currentLi = currentText.closest('li') as HTMLElement;
     expect(currentLi.className).toMatch(/shrink/);
-    expect(currentLi.className).toMatch(/max-w-\[40%\]/);
+    expect(currentLi.className).toMatch(/max-w-\[51%\]/);
   });
 
   test('deep path with long consecutive folder names: penultimate and last folder are both rendered and can shrink to fit', () => {

--- a/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -271,7 +271,7 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
     expect(onBeforeNavigate).toHaveBeenCalled();
   });
 
-  test('root and current items can both shrink/truncate, current item is capped at 51%', () => {
+  test('root never truncates (shrink-0), current item can shrink and is capped at 51%', () => {
     render(
       <DialBreadcrumb
         pathItems={[
@@ -283,8 +283,7 @@ describe('Dial UI Kit :: DialBreadcrumb (final)', () => {
 
     const rootLink = screen.getByRole('link', { name: 'Organization' });
     const rootLi = rootLink.closest('li') as HTMLElement;
-    expect(rootLi.className).toMatch(/shrink/);
-    expect(rootLi.className).toMatch(/min-w-0/);
+    expect(rootLi.className).toMatch(/shrink-0/);
     expect(rootLi.className).not.toMatch(/max-w-\[30%\]/);
 
     const currentText = screen.getByText(

--- a/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
@@ -231,7 +231,7 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  test('isFirst renders as a shrinkable item without a fixed max-width cap', () => {
+  test('isFirst renders as shrink-0 so the root never truncates', () => {
     render(
       <ul>
         <DialBreadcrumbItem label="Root" href="#root" isFirst />
@@ -239,8 +239,7 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
     );
     const link = screen.getByRole('link', { name: 'Root' });
     const li = link.closest('li') as HTMLElement;
-    expect(li.className).toMatch(/shrink/);
-    expect(li.className).toMatch(/min-w-0/);
+    expect(li.className).toMatch(/shrink-0/);
     expect(li.className).not.toMatch(/max-w-\[30%\]/);
   });
 

--- a/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.spec.tsx
@@ -253,7 +253,7 @@ describe('Dial UI Kit :: DialBreadcrumbItem (final)', () => {
     const text = screen.getByText('Current');
     const li = text.closest('li') as HTMLElement;
     expect(li.className).toMatch(/shrink/);
-    expect(li.className).toMatch(/max-w-\[40%\]/);
+    expect(li.className).toMatch(/max-w-\[51%\]/);
   });
 
   test('navigation guard prevents default when returning false', async () => {

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,7 +7,7 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 shrink dial-small-text';
+  'flex items-center gap-2 mах-w-0 shrink dial-small-text';
 
 export const breadcrumbItemWidthClassName: Record<
   'first' | 'middle' | 'last',

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,15 +7,20 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 mах-w-0 shrink dial-small-text';
+  'flex items-center gap-2 dial-small-text';
 
+/**
+ * Only middle/last items shrink and get a max-width cap. The root (first)
+ * is `shrink-0` with no cap so it never truncates; middle items collapse
+ * first, and the last item (current page) gets the largest remaining share.
+ */
 export const breadcrumbItemWidthClassName: Record<
   'first' | 'middle' | 'last',
   string
 > = {
-  first: '',
-  middle: 'max-w-[30%]',
-  last: 'max-w-[51%]',
+  first: 'shrink-0',
+  middle: 'shrink min-w-0 max-w-[30%]',
+  last: 'shrink min-w-0 max-w-[51%]',
 };
 
 export const breadcrumbLinkBaseClassName =

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,7 +7,7 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 min-w-0 shrink dial-small-text';
+  'flex items-center gap-2 max-w-0 shrink dial-small-text';
 
 export const breadcrumbItemWidthClassName: Record<
   'first' | 'middle' | 'last',
@@ -15,7 +15,7 @@ export const breadcrumbItemWidthClassName: Record<
 > = {
   first: '',
   middle: 'max-w-[30%]',
-  last: 'max-w-[40%]',
+  last: 'max-w-[51%]',
 };
 
 export const breadcrumbLinkBaseClassName =

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -7,7 +7,7 @@ export const breadcrumbListClassName =
   'flex flex-nowrap items-center gap-2 min-w-0 px-0 py-0 whitespace-nowrap';
 
 export const breadcrumbItemBaseClassName =
-  'flex items-center gap-2 max-w-0 shrink dial-small-text';
+  'flex items-center gap-2 min-w-0 shrink dial-small-text';
 
 export const breadcrumbItemWidthClassName: Record<
   'first' | 'middle' | 'last',

--- a/src/components/Breadcrumb/constants.tsx
+++ b/src/components/Breadcrumb/constants.tsx
@@ -9,11 +9,6 @@ export const breadcrumbListClassName =
 export const breadcrumbItemBaseClassName =
   'flex items-center gap-2 dial-small-text';
 
-/**
- * Only middle/last items shrink and get a max-width cap. The root (first)
- * is `shrink-0` with no cap so it never truncates; middle items collapse
- * first, and the last item (current page) gets the largest remaining share.
- */
 export const breadcrumbItemWidthClassName: Record<
   'first' | 'middle' | 'last',
   string


### PR DESCRIPTION
**Description and UI changes:**

First folder name is not displayed fully when selected any sub-folder

Issues:

- Issue #761

<img width="308" height="190" alt="Снимок экрана — 2026-07-15 в 15 44 13" src="https://github.com/user-attachments/assets/7cb14697-0475-4c88-a552-411cd0b93960" />
<img width="311" height="203" alt="Снимок экрана — 2026-07-15 в 15 46 07" src="https://github.com/user-attachments/assets/afdec22f-7689-4c11-aec1-506baadeba08" />
<img width="1218" height="615" alt="Снимок экрана — 2026-07-15 в 15 47 35" src="https://github.com/user-attachments/assets/ae62a42c-629a-4f36-bc88-9cd788c4cd61" />

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added