### PR TITLE
fix: added external_services values in scheme

### DIFF
--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -37,6 +37,25 @@ const simpleSchema: JsonSchema = {
   required: ['name'],
 };
 
+const resourceSchema: JsonSchema = {
+  properties: {
+    name: {
+      title: 'Name',
+      type: 'string',
+      description: 'The name of the connection.',
+    },
+    external_service: {
+      title: 'External Service',
+      type: 'string',
+      description:
+        "Name of an entry in this application's external_services registry to source live auth credentials from",
+      'dial:resource': true,
+      acceptableResourceTypes: ['external_services'],
+    },
+  },
+  required: ['external_service'],
+};
+
 const oneOfSchema: JsonSchema = {
   $defs: {
     EmailNotification: {
@@ -590,6 +609,16 @@ export const HiddenFields: Story = {
 
 export const FlatWithGroups: Story = {
   args: { schema: flatMixedSchema, variant: SchemaRendererVariant.Flat },
+};
+
+export const ResourceField: Story = {
+  args: {
+    schema: resourceSchema,
+    variant: SchemaRendererVariant.Flat,
+    acceptableResourceTypes: {
+      external_services: ['openai-prod', 'anthropic-prod', 'azure-staging'],
+    },
+  },
 };
 
 export const CustomFieldRenderer: Story = {

--- a/src/components/SchemaRenderer/SchemaRenderer.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.tsx
@@ -59,6 +59,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
   renderField,
   skipUntouched = false,
   jsonEditorTheme,
+  acceptableResourceTypes,
 }) => {
   const mergedTexts = useMemo(
     () => ({ ...DEFAULT_SCHEMA_TEXTS, ...texts }),
@@ -116,6 +117,7 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
         defaultExpanded,
         inputClassName,
         jsonEditorTheme,
+        acceptableResourceTypes,
         renderField,
         touchedPaths,
         markTouched,

--- a/src/components/SchemaRenderer/components/SchemaPrimitiveField.tsx
+++ b/src/components/SchemaRenderer/components/SchemaPrimitiveField.tsx
@@ -49,9 +49,48 @@ export const SchemaPrimitiveField: FC<SchemaPrimitiveFieldProps> = ({
   invalid,
 }) => {
   const switchId = useId();
-  const { texts, readonly = false, inputClassName } = useSchemaContext();
+  const {
+    texts,
+    readonly = false,
+    inputClassName,
+    acceptableResourceTypes,
+  } = useSchemaContext();
   const isConst = schema.const !== undefined;
   const hasEnum = Array.isArray(schema.enum) && schema.enum.length > 0;
+
+  const isResourceField =
+    schema['dial:resource'] === true &&
+    Array.isArray(schema.acceptableResourceTypes) &&
+    schema.acceptableResourceTypes.length > 0;
+
+  if (
+    isResourceField &&
+    (schema.type === JsonSchemaType.String || schema.type === undefined)
+  ) {
+    const resourceOptions = (schema.acceptableResourceTypes ?? []).flatMap(
+      (resourceType) => {
+        const entries = acceptableResourceTypes?.[resourceType];
+        return Array.isArray(entries)
+          ? entries.map((entry) => {
+              const strVal = String(entry);
+              return { value: strVal, label: strVal };
+            })
+          : [];
+      },
+    );
+
+    return (
+      <DialSelect
+        options={resourceOptions}
+        value={value != null ? String(value) : undefined}
+        invalid={invalid}
+        disabled={readonly}
+        onChange={(next) => onChange(typeof next === 'string' ? next : next[0])}
+        placeholder={texts.enumSelectPlaceholder}
+        className={inputClassName}
+      />
+    );
+  }
 
   if (isConst) {
     return (

--- a/src/components/SchemaRenderer/context.tsx
+++ b/src/components/SchemaRenderer/context.tsx
@@ -14,6 +14,7 @@ interface SchemaRendererContextValue {
   defaultExpanded?: boolean;
   inputClassName?: string;
   jsonEditorTheme?: EditorThemes;
+  acceptableResourceTypes?: Record<string, unknown>;
   renderField?: (
     path: string[],
     schema: JsonSchemaDef,

--- a/src/components/SchemaRenderer/types.ts
+++ b/src/components/SchemaRenderer/types.ts
@@ -52,6 +52,7 @@ export interface JsonSchemaDef {
   };
   'dial:meta'?: Record<string, unknown>;
   'dial:resource'?: boolean;
+  acceptableResourceTypes?: string[];
   [key: string]: unknown;
 }
 
@@ -128,6 +129,13 @@ export interface DialSchemaRendererProps {
    * schema's `properties`. Defaults to `EditorThemes.dark`.
    */
   jsonEditorTheme?: EditorThemes;
+  /**
+   * Live resource options for schema properties flagged with `dial:resource: true`.
+   * Keyed by the resource type name referenced in a property's `acceptableResourceTypes`
+   * array; each value provides the selectable entries for that resource type (a string
+   * array for string-typed properties).
+   */
+  acceptableResourceTypes?: Record<string, unknown>;
   onChange?: (value: Record<string, unknown>) => void;
   onPropertyChange?: (path: string, value: unknown) => void;
   onDefaultValues?: (value: Record<string, unknown>) => void;


### PR DESCRIPTION
**Description and UI changes:**

Added new prop `acceptableResourceTypes`. This prop allows to draw different components for property using data outside scheme

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added