### PR TITLE
fix: Switch is shrinking with long caption

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -42,7 +42,7 @@ export const DialSwitch: FC<DialSwitchProps> = ({
   caption,
 }) => {
   const switchClassName = classNames(
-    'flex w-[36px] h-[18px] cursor-pointer items-center gap-1 rounded-full p-0.5 transition-all duration-200',
+    'flex shrink-0 w-[36px] h-[18px] cursor-pointer items-center gap-1 rounded-full p-0.5 transition-all duration-200',
     isOn ? 'flex-row-reverse' : 'flex-row',
     disabled ? 'pointer-events-none' : '',
     disabled


### PR DESCRIPTION
**Description and UI changes:**

Prevent Switch from shrinking in case when long caption passed

Issues:

<img width="538" height="78" alt="Screenshot 2026-07-24 at 16 45 03" src="https://github.com/user-attachments/assets/8abacd31-d156-4bd6-8088-8c3e882d0e6f" />

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added