### PR TITLE
fix: add tab aria selected (#784)

### DIFF
--- a/src/components/Tab/Tab.spec.tsx
+++ b/src/components/Tab/Tab.spec.tsx
@@ -11,6 +11,18 @@ describe('Dial UI Kit :: DialTab', () => {
     expect(screen.getByText('Tab 1')).toBeInTheDocument();
   });
 
+  test('exposes the active state through aria-selected', () => {
+    const { rerender } = render(
+      <DialTab tab={baseTab} active onClick={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('tab')).toHaveAttribute('aria-selected', 'true');
+
+    rerender(<DialTab tab={baseTab} active={false} onClick={vi.fn()} />);
+
+    expect(screen.getByRole('tab')).toHaveAttribute('aria-selected', 'false');
+  });
+
   test('calls onClick with tab id', () => {
     const onClick = vi.fn();
     render(<DialTab tab={baseTab} active={false} onClick={onClick} />);

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -88,6 +88,7 @@ export const DialTab: FC<DialTabProps> = ({
   return (
     <button
       role="tab"
+      aria-selected={active}
       className={tabClassName}
       onClick={() => onClick(tab.id)}
       disabled={tab.disabled}


### PR DESCRIPTION
**Description and UI changes:**

Add `aria-selected` property to the **Tab** component.

Issues:

- https://github.com/epam/ai-dial-ui-kit/issues/784

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added