### PR TITLE
feat: add FolderPath component with tests and stories

### DIFF
--- a/src/components/New/FolderPath/FolderPath.spec.tsx
+++ b/src/components/New/FolderPath/FolderPath.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { FolderPath } from './FolderPath';
+
+describe('Dial UI Kit :: FolderPath', () => {
+  test('Should render every segment, in order', () => {
+    render(<FolderPath segments={['Shared', 'Team Space', 'Reports']} />);
+    const nav = screen.getByRole('navigation');
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(nav).toHaveTextContent('SharedTeam SpaceReports');
+  });
+
+  test('Should style only the last segment as the leaf', () => {
+    render(<FolderPath segments={['Shared', 'Team Space', 'Reports']} />);
+    const leaf = screen.getByText('Reports');
+    expect(leaf.tagName).toBe('SPAN');
+    expect(leaf).toHaveClass('dial-small-semi-text');
+
+    expect(screen.getByText('Shared')).not.toHaveClass('dial-small-semi-text');
+    expect(screen.getByText('Team Space')).not.toHaveClass(
+      'dial-small-semi-text',
+    );
+  });
+
+  test('Should render the folder icon exactly once, before the first segment', () => {
+    const { container } = render(
+      <FolderPath segments={['Shared', 'Team Space', 'Reports']} />,
+    );
+    const icons = container.querySelectorAll('svg.tabler-icon-folder');
+    expect(icons).toHaveLength(1);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0].querySelector('svg.tabler-icon-folder')).not.toBeNull();
+    expect(items[1].querySelector('svg.tabler-icon-folder')).toBeNull();
+    expect(items[2].querySelector('svg.tabler-icon-folder')).toBeNull();
+  });
+
+  test('Should mark every segment as disabled/non-interactive', () => {
+    render(<FolderPath segments={['Shared', 'Team Space', 'Reports']} />);
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+    const disabledSpans = screen
+      .getAllByRole('listitem')
+      .map((item) => item.querySelector('[aria-disabled="true"]'));
+    expect(disabledSpans.every(Boolean)).toBe(true);
+  });
+
+  test("Should forward caller className to the breadcrumb's nav element", () => {
+    render(
+      <FolderPath segments={['Shared', 'Reports']} className="custom-path" />,
+    );
+    expect(screen.getByRole('navigation')).toHaveClass('custom-path');
+  });
+});

--- a/src/components/New/FolderPath/FolderPath.stories.tsx
+++ b/src/components/New/FolderPath/FolderPath.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FolderPath, type FolderPathProps } from './FolderPath';
+
+const meta = {
+  title: 'Components_2.0/FolderPath',
+  component: FolderPath,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A read-only, non-clickable folder/location path built on top of DialBreadcrumb. Displays a leading folder icon and styles the last segment as the current/leaf item.',
+      },
+    },
+  },
+  argTypes: {
+    segments: {
+      control: { type: 'object' },
+      description: 'Path segments to display, outermost first',
+    },
+    labelClassName: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes applied to non-leaf segments',
+    },
+    leafClassName: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes applied to the last (leaf) segment',
+    },
+    className: {
+      control: { type: 'text' },
+      description:
+        "Additional CSS classes applied to the breadcrumb's nav element",
+    },
+  },
+  args: {
+    segments: ['Shared with me', 'Team Space', 'Reports'],
+  },
+} satisfies Meta<FolderPathProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TwoSegments: Story = {
+  args: {
+    segments: ['Shared with me', 'Reports'],
+  },
+};
+
+export const LongPathOverflow: Story = {
+  args: {
+    segments: [
+      'Shared with me',
+      'Organization Workspace',
+      'Team Space Alpha',
+      'Projects',
+      'Quarterly Reports',
+      'Reports 2026',
+      'Final Version',
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the total width of the path exceeds its container, DialBreadcrumb scrolls horizontally instead of wrapping.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-[300px]">
+      <FolderPath {...args} />
+    </div>
+  ),
+};

--- a/src/components/New/FolderPath/FolderPath.tsx
+++ b/src/components/New/FolderPath/FolderPath.tsx
@@ -1,0 +1,81 @@
+import { IconChevronRight, IconFolder } from '@tabler/icons-react';
+import type { FC } from 'react';
+
+import { DialBreadcrumb } from '@/components/Breadcrumb/Breadcrumb';
+import { DialIcon } from '@/components/Icon/Icon';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { mergeClasses } from '@/utils/merge-classes';
+
+export interface FolderPathProps {
+  segments: string[];
+  labelClassName?: string;
+  leafClassName?: string;
+  className?: string;
+}
+
+/**
+ * A read-only, non-clickable folder/location path built on top of `DialBreadcrumb`.
+ * aliases: FolderBreadcrumb|LocationPath
+ *
+ * Every segment is disabled (no navigation); the first segment gets a leading
+ * folder icon and the last segment is styled as the current/leaf item.
+ *
+ * @example
+ * ```tsx
+ * <FolderPath segments={['Shared', 'Team Space', 'Reports']} />
+ * ```
+ *
+ * @param segments - Path segments to display, outermost first
+ * @param [labelClassName='dial-small-text'] - Additional CSS classes applied to non-leaf segments
+ * @param [leafClassName='dial-small-semi-text'] - Additional CSS classes applied to the last (leaf) segment
+ * @param [className] - Additional CSS classes applied to the breadcrumb's `<nav>` element.
+ *  `DialBreadcrumb` scrolls horizontally on overflow, so this must not shrink
+ *  the nav to content width (e.g. never `w-auto`).
+ */
+export const FolderPath: FC<FolderPathProps> = ({
+  segments,
+  labelClassName = 'dial-small-text',
+  leafClassName = 'dial-small-semi-text',
+  className,
+}) => {
+  const folderIcon = (
+    <DialIcon
+      icon={<IconFolder size={DIAL_ICON_SIZE.SM} />}
+      className="text-secondary"
+    />
+  );
+  const pathItems = segments.map((seg, i) => ({
+    label:
+      i === segments.length - 1 ? (
+        <span className={leafClassName}>{seg}</span>
+      ) : (
+        seg
+      ),
+    disabled: true,
+    ...(i === 0 ? { iconBefore: folderIcon } : {}),
+  }));
+
+  return (
+    <DialBreadcrumb
+      className={className}
+      separator={
+        <DialIcon
+          icon={
+            <IconChevronRight
+              size={14}
+              // eslint-disable-next-line tailwindcss/no-unnecessary-arbitrary-value -- keep in sync with the source implementation's RTL mirroring
+              className="rtl:scale-x-[-1]"
+            />
+          }
+          className="text-secondary"
+        />
+      }
+      pathItems={pathItems}
+      labelClassName={mergeClasses(
+        labelClassName,
+        'text-secondary',
+        '!cursor-default',
+      )}
+    />
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,3 +276,5 @@ export type {
   CalendarProps,
   CalendarValue,
 } from './components/New/Calendar/Calendar';
+export { FolderPath } from './components/New/FolderPath/FolderPath';
+export type { FolderPathProps } from './components/New/FolderPath/FolderPath';


### PR DESCRIPTION
**Description and UI changes:**

<img width="1034" height="735" alt="image" src="https://github.com/user-attachments/assets/2a977783-578c-4d27-9764-ca2f984045ba" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added