### PR TITLE
chore: deprecate FileManager components and hooks, redirect to new package

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,4 +17,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.8.0
     secrets: inherit
     with:
+      docker-build-enabled: false
       node-version: 24

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,5 +17,4 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.8.0
     secrets: inherit
     with:
-      docker-build-enabled: false
       node-version: 24

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,12 @@
 # brace-expansion
 CVE-2026-13149 exp:2026-09-20
+CVE-2026-69152 exp:2026-09-20
+
+# fast-uri
+CVE-2026-18446 exp:2026-09-20
+
+# ip-address
+CVE-2026-69192 exp:2026-09-20
 
 #  tar
 CVE-2026-59873 exp:2026-09-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -5671,9 +5671,9 @@
       "peer": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "shell-quote": "1.10.0",
     "esbuild": "0.28.1",
     "undici": "^6.27.0",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.5"
   },
   "dependencies": {

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -414,6 +414,8 @@ export interface DialFileManagerProps {
  * File Manager layout with a collapsible folders tree, breadcrumb/search header, and a data grid.
  * aliases: FileExplorer|FileBrowser
  *
+ * @deprecated Import `DialFileManager` from `@epam/ai-dial-react-file-manager` instead.
+ *
  * Features:
  * - Global `path` drives both the breadcrumb trail and the visible folder in the grid.
  * - The grid shows children of the current folder. When a search query is present, it scans all nested descendants.

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -66,6 +66,7 @@ export interface FileManagerProviderProps extends Omit<
  * - computed grid rows
  * - new actions
  *
+ * @deprecated Import `FileManagerProvider` from `@epam/ai-dial-react-file-manager` instead.
  */
 export const FileManagerProvider: FC<FileManagerProviderProps> = ({
   managerLabel,

--- a/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
+++ b/src/components/FileManager/components/DestinationFolderPopup/DestinationFolderPopup.tsx
@@ -59,6 +59,8 @@ export interface DestinationFolderPopupProps extends DialFileManagerProps {
  * DestinationFolderPopup
  * aliases: FolderSelector|PathChooser
  *
+ * @deprecated Import `DialDestinationFolderPopup` from `@epam/ai-dial-react-file-manager` instead.
+ *
  * A popup dialog for selecting a destination folder when copying or moving files.
  * Displays a File Manager interface with a footer containing action buttons and
  * a toggle for showing hidden files.

--- a/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
+++ b/src/components/FileManager/components/FoldersTree/FoldersTree.tsx
@@ -56,6 +56,8 @@ export interface DialFoldersTreeProps {
  * DialFoldersTree — A hierarchical folder tree component with nested expand/collapse support, selection highlighting,
  * and optional file display.
  *
+ * @deprecated Import `DialFoldersTree` from `@epam/ai-dial-react-file-manager` instead.
+ *
  * Provides a fully interactive, recursive folder structure with:
  * - Expandable and collapsible items
  * - Optional file visibility

--- a/src/components/FileManager/hooks/use-file-manager-context.ts
+++ b/src/components/FileManager/hooks/use-file-manager-context.ts
@@ -4,6 +4,8 @@ import { FileManagerContext } from '@/components/FileManager/FileManagerContext'
 /**
  * Hook to read the File Manager context.
  * Throws if used outside of the provider.
+ *
+ * @deprecated Import `useFileManagerContext` from `@epam/ai-dial-react-file-manager` instead.
  */
 export const useFileManagerContext = () => {
   const ctx = useContext(FileManagerContext);

--- a/src/components/FileManager/hooks/use-file-manager-tabs.tsx
+++ b/src/components/FileManager/hooks/use-file-manager-tabs.tsx
@@ -2,6 +2,9 @@ import type { TabModel } from '@/models/tab';
 import { DialFileManagerTabs } from '@/types/file-manager';
 import { useMemo, useState } from 'react';
 
+/**
+ * @deprecated Import `useDialFileManagerTabs` from `@epam/ai-dial-react-file-manager` instead.
+ */
 export const useDialFileManagerTabs = (
   tabLabels?: Record<DialFileManagerTabs, string>,
   initialTab: DialFileManagerTabs = DialFileManagerTabs.MyFiles,


### PR DESCRIPTION
…

**Description and UI changes:**

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added