### PR TITLE
fix: keyboard accessibility for nested dropdown menus

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -765,6 +765,72 @@ describe('Dial UI Kit :: Dropdown', () => {
     );
   });
 
+  test.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('submenu opens with %s', async (_keyName, key) => {
+    const user = userEvent.setup();
+    render(
+      <DialDropdown
+        items={[
+          {
+            key: 'sub',
+            label: 'More',
+            children: [{ key: 'sub-1', label: 'Sub One' }],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+    openByClick();
+
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    subTrigger.focus();
+    await user.keyboard(key);
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Sub One' }),
+    ).toBeInTheDocument();
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Escape closes only submenu and returns focus to its trigger', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DialDropdown
+        items={[
+          {
+            key: 'sub',
+            label: 'More',
+            children: [{ key: 'sub-1', label: 'Sub One' }],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </DialDropdown>,
+    );
+    openByClick();
+
+    const rootTrigger = container.querySelector('[aria-haspopup="menu"]')!;
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    subTrigger.focus();
+    await user.keyboard('{Enter}');
+    const child = await screen.findByRole('menuitem', { name: 'Sub One' });
+    child.focus();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('menuitem', { name: 'Sub One' }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(rootTrigger).toHaveAttribute('aria-expanded', 'true');
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(subTrigger).toHaveFocus();
+  });
+
   test('disabled submenu trigger does not open submenu', async () => {
     const user = userEvent.setup();
     const itemsWithSub: DropdownItem[] = [

--- a/src/utils/sub-menu-floating.tsx
+++ b/src/utils/sub-menu-floating.tsx
@@ -5,6 +5,7 @@ import {
   flip,
   offset,
   shift,
+  useClick,
   useDismiss,
   useFloating,
   useHover,
@@ -46,11 +47,15 @@ export function useSubMenuFloating(
     move: false,
     delay: { open: 80, close: 80 },
   });
-  const dismiss = useDismiss(context, { bubbles: true });
+  const click = useClick(context, { enabled: !disabled });
+  const dismiss = useDismiss(context, {
+    bubbles: { escapeKey: false, outsidePress: true },
+  });
   const role = useRole(context, { role: ariaRole });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     hover,
+    click,
     dismiss,
     role,
   ]);
@@ -98,7 +103,7 @@ export const SubMenuPanel = ({
       context={context}
       modal={false}
       initialFocus={-1}
-      returnFocus={false}
+      returnFocus
     >
       <div
         ref={refs.setFloating}


### PR DESCRIPTION
**Description and UI changes:**

This PR fixes keyboard interaction and focus management for `DropdownSubMenuItem`.

Changes

- Added Enter and Space support for opening submenus.
- Updated Escape handling so it closes only the active submenu while keeping the parent dropdown open.
- Restored focus to the submenu trigger after the submenu closes.
- Preserved outside-click dismissal behavior.
- Added regression tests covering Enter, Space, Escape, parent dropdown state, and focus restoration.

Issues:

- https://github.com/epam/ai-dial-chat/issues/8060
- 
**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)
