### PR TITLE
feat: add MarkdownEditor component with toolbar and preview modes

### DIFF
--- a/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
@@ -32,23 +32,12 @@ describe('Dial UI Kit :: MarkdownEditor', () => {
     expect(container).toHaveAttribute('data-color-mode', 'light');
   });
 
-  test('Should render placeholder when value is empty', () => {
-    render(
-      <MarkdownEditor value="" placeholder={<span>Start typing here…</span>} />,
-    );
+  test('Should render placeholder text on the underlying textarea', () => {
+    render(<MarkdownEditor value="" placeholder="Start typing here…" />);
 
-    expect(screen.getByText('Start typing here…')).toBeInTheDocument();
-  });
-
-  test('Should not render placeholder when value is provided', () => {
-    render(
-      <MarkdownEditor
-        value="# Hello"
-        placeholder={<span>Start typing here…</span>}
-      />,
-    );
-
-    expect(screen.queryByText('Start typing here…')).not.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Start typing here…'),
+    ).toBeInTheDocument();
   });
 
   test('Should render the formatting toolbar buttons', () => {

--- a/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { EditorThemes } from '@/types/editor';
+import { MarkdownEditor } from './MarkdownEditor';
+
+describe('Dial UI Kit :: MarkdownEditor', () => {
+  test('Should render the Markdown Editor', () => {
+    render(<MarkdownEditor value="# Test" theme={EditorThemes.dark} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('Should call onChange when content changes', async () => {
+    const mockOnChange = vi.fn();
+    render(<MarkdownEditor value="# Initial" onChange={mockOnChange} />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '# Updated' },
+    });
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith('# Updated');
+    });
+  });
+
+  test('Should apply theme via data-color-mode attribute', () => {
+    render(<MarkdownEditor value="# Test" theme={EditorThemes.light} />);
+
+    const container = screen
+      .getByRole('textbox')
+      .closest('[data-color-mode="light"]');
+    expect(container).toHaveAttribute('data-color-mode', 'light');
+  });
+
+  test('Should render placeholder when value is empty', () => {
+    render(
+      <MarkdownEditor value="" placeholder={<span>Start typing here…</span>} />,
+    );
+
+    expect(screen.getByText('Start typing here…')).toBeInTheDocument();
+  });
+
+  test('Should not render placeholder when value is provided', () => {
+    render(
+      <MarkdownEditor
+        value="# Hello"
+        placeholder={<span>Start typing here…</span>}
+      />,
+    );
+
+    expect(screen.queryByText('Start typing here…')).not.toBeInTheDocument();
+  });
+
+  test('Should render the formatting toolbar buttons', () => {
+    render(<MarkdownEditor value="Hello" />);
+
+    expect(
+      screen.getByRole('button', { name: /add bold text/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add italic text/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add strikethrough text/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /text style/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add unordered list/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add ordered list/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /insert a quote/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add a link/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^insert code/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add table/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('Should insert bold markdown syntax when the bold button is clicked', async () => {
+    const mockOnChange = vi.fn();
+    render(<MarkdownEditor value="Hello" onChange={mockOnChange} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, textarea.value.length);
+    fireEvent.select(textarea);
+
+    fireEvent.click(screen.getByRole('button', { name: /add bold text/i }));
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith(expect.stringContaining('**'));
+    });
+  });
+
+  test('Should render the edit/live/preview mode buttons', () => {
+    render(<MarkdownEditor value="Hello" />);
+
+    expect(
+      screen.getByRole('button', { name: /edit code/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /live code/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /preview code/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('Should default to edit mode', () => {
+    const { container } = render(<MarkdownEditor value="Hello" />);
+
+    expect(
+      container.querySelector('.w-md-editor-show-edit'),
+    ).toBeInTheDocument();
+  });
+
+  test('Should respect the defaultPreview prop', () => {
+    const { container } = render(
+      <MarkdownEditor value="Hello" defaultPreview="preview" />,
+    );
+
+    expect(
+      container.querySelector('.w-md-editor-show-preview'),
+    ).toBeInTheDocument();
+  });
+
+  test('Should switch to live mode when the live button is clicked', () => {
+    const { container } = render(<MarkdownEditor value="Hello" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /live code/i }));
+
+    expect(
+      container.querySelector('.w-md-editor-show-live'),
+    ).toBeInTheDocument();
+  });
+
+  test('Should switch to preview mode when the preview button is clicked', () => {
+    const { container } = render(<MarkdownEditor value="Hello" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /preview code/i }));
+
+    expect(
+      container.querySelector('.w-md-editor-show-preview'),
+    ).toBeInTheDocument();
+  });
+
+  test('Should toggle fullscreen mode when the fullscreen button is clicked', () => {
+    const { container } = render(<MarkdownEditor value="Hello" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
+
+    expect(
+      container.querySelector('.w-md-editor-fullscreen'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -42,14 +42,14 @@ const meta = {
       description: 'Callback fired when the editor content changes',
     },
     placeholder: {
-      control: false,
-      description: 'Content to display when the editor value is empty',
+      control: { type: 'text' },
+      description: 'Placeholder text shown when the editor is empty',
     },
   },
   args: {
     value: '# Hello World\n\nThis is a **markdown** editor.',
     height: 300,
-    theme: EditorThemes.dark,
+    theme: EditorThemes.light,
   },
 } satisfies Meta<MarkdownEditorProps>;
 
@@ -79,14 +79,6 @@ export const Default: Story = {
   render: renderWithContainer,
 };
 
-export const LightTheme: Story = {
-  args: {
-    value: '# Hello World\n\nThis is a **markdown** editor with light theme.',
-    theme: EditorThemes.light,
-  },
-  render: renderWithContainer,
-};
-
 export const LivePreview: Story = {
   args: {
     value: '# Hello World\n\nThis is a **markdown** editor with live preview.',
@@ -106,9 +98,7 @@ export const PreviewOnly: Story = {
 export const WithPlaceholder: Story = {
   args: {
     value: '',
-    placeholder: (
-      <span className="italic">Start typing your markdown here…</span>
-    ),
+    placeholder: 'Write instructions',
   },
   render: renderWithContainer,
 };

--- a/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -1,0 +1,146 @@
+import '@uiw/react-markdown-preview/markdown.css';
+import '@uiw/react-md-editor/markdown-editor.css';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { EditorThemes } from '@/types/editor';
+import { MarkdownEditor, type MarkdownEditorProps } from './MarkdownEditor';
+
+const meta = {
+  title: 'Components_2.0/MarkdownEditor',
+  component: MarkdownEditor,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A Markdown editor with a formatting toolbar (bold, italic, strikethrough, text style, lists, quote, link, code, table), an edit/live/preview mode switcher and fullscreen, built on top of `@uiw/react-md-editor`. Note: consumers need to import `@uiw/react-markdown-preview/markdown.css` and `@uiw/react-md-editor/markdown-editor.css` globally.',
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: 'text' },
+      description: 'The current markdown content',
+    },
+    height: {
+      control: { type: 'number' },
+      description: 'Height of the editor in pixels',
+    },
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(EditorThemes),
+      description: 'Theme for the editor',
+    },
+    defaultPreview: {
+      control: { type: 'select' },
+      options: ['edit', 'live', 'preview'],
+      description: 'Initial edit/live/preview mode',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Callback fired when the editor content changes',
+    },
+    placeholder: {
+      control: false,
+      description: 'Content to display when the editor value is empty',
+    },
+  },
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor.',
+    height: 300,
+    theme: EditorThemes.dark,
+  },
+} satisfies Meta<MarkdownEditorProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const renderWithContainer = (args: Story['args']) => {
+  const [value, setValue] = useState(args?.value ?? '');
+  return (
+    <div className="w-[720px]">
+      <MarkdownEditor
+        {...args}
+        value={value}
+        onChange={(val) => {
+          setValue(val);
+          args?.onChange?.(val);
+        }}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor.',
+  },
+  render: renderWithContainer,
+};
+
+export const LightTheme: Story = {
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor with light theme.',
+    theme: EditorThemes.light,
+  },
+  render: renderWithContainer,
+};
+
+export const LivePreview: Story = {
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor with live preview.',
+    defaultPreview: 'live',
+  },
+  render: renderWithContainer,
+};
+
+export const PreviewOnly: Story = {
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor in preview mode.',
+    defaultPreview: 'preview',
+  },
+  render: renderWithContainer,
+};
+
+export const WithPlaceholder: Story = {
+  args: {
+    value: '',
+    placeholder: (
+      <span className="italic">Start typing your markdown here…</span>
+    ),
+  },
+  render: renderWithContainer,
+};
+
+export const CustomHeight: Story = {
+  args: {
+    value: '# Hello World\n\nThis is a **markdown** editor with custom height.',
+    height: 500,
+  },
+  render: renderWithContainer,
+};
+
+export const ComplexMarkdown: Story = {
+  args: {
+    value: `# Markdown Editor
+
+This is a comprehensive markdown editor example.
+
+## Features
+
+- **Bold text**
+- *Italic text*
+- \`Code blocks\`
+
+> This is a blockquote
+
+[Link](https://example.com)
+
+| Column 1 | Column 2 |
+|----------|----------|
+| Data 1   | Data 2   |
+`,
+  },
+  render: renderWithContainer,
+};

--- a/src/components/New/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.tsx
@@ -1,0 +1,74 @@
+import { useMemo, type FC, type ReactNode } from 'react';
+import MDEditor, { type PreviewType } from '@uiw/react-md-editor';
+
+import { EditorThemes } from '@/types/editor';
+import { mergeClasses } from '@/utils/merge-classes';
+import {
+  getMarkdownExtraCommands,
+  getMarkdownFormattingCommands,
+} from './constants';
+
+export interface MarkdownEditorProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  height?: number;
+  theme?: EditorThemes;
+  className?: string;
+  placeholder?: ReactNode;
+  /** Initial edit/live/preview mode; the toolbar lets the user switch it afterwards. */
+  defaultPreview?: PreviewType;
+}
+
+/**
+ * The 2.0 Markdown editor: a formatting toolbar (bold/italic/strikethrough,
+ * text style, lists, quote/link/code, table) plus an edit/live/preview mode
+ * switcher and fullscreen, built on top of `@uiw/react-md-editor`.
+ *
+ * @example
+ * ```tsx
+ * <MarkdownEditor value={value} onChange={setValue} height={400} />
+ * ```
+ *
+ * @param [value] - The current markdown content
+ * @param [onChange] - Callback fired when the editor content changes
+ * @param [height=300] - Height of the editor in pixels
+ * @param [theme='dark'] - Theme for the editor ('light' or 'dark')
+ * @param [className] - Additional CSS classes for the container
+ * @param [placeholder] - Content to display when the editor is empty
+ * @param [defaultPreview='edit'] - Initial edit/live/preview mode
+ */
+export const MarkdownEditor: FC<MarkdownEditorProps> = ({
+  value,
+  onChange,
+  height = 300,
+  theme = EditorThemes.dark,
+  className,
+  placeholder,
+  defaultPreview = 'edit',
+}) => {
+  const showPlaceholder = placeholder !== undefined && !value;
+
+  const commands = useMemo(() => getMarkdownFormattingCommands(), []);
+  const extraCommands = useMemo(() => getMarkdownExtraCommands(), []);
+
+  return (
+    <div
+      data-color-mode={theme}
+      className={mergeClasses('dial-kit-markdown-editor relative', className)}
+    >
+      <MDEditor
+        value={value}
+        onChange={(val) => onChange?.(val || '')}
+        height={height}
+        preview={defaultPreview}
+        commands={commands}
+        extraCommands={extraCommands}
+      />
+      {showPlaceholder && (
+        <div className="pointer-events-none absolute left-0 top-8 px-2 dial-small-text text-secondary opacity-40">
+          {placeholder}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/New/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC, type ReactNode } from 'react';
+import { useMemo, type FC } from 'react';
 import MDEditor, { type PreviewType } from '@uiw/react-md-editor';
 
 import { EditorThemes } from '@/types/editor';
@@ -14,7 +14,7 @@ export interface MarkdownEditorProps {
   height?: number;
   theme?: EditorThemes;
   className?: string;
-  placeholder?: ReactNode;
+  placeholder?: string;
   /** Initial edit/live/preview mode; the toolbar lets the user switch it afterwards. */
   defaultPreview?: PreviewType;
 }
@@ -32,29 +32,27 @@ export interface MarkdownEditorProps {
  * @param [value] - The current markdown content
  * @param [onChange] - Callback fired when the editor content changes
  * @param [height=300] - Height of the editor in pixels
- * @param [theme='dark'] - Theme for the editor ('light' or 'dark')
+ * @param [theme='light'] - Theme for the editor ('light' or 'dark')
  * @param [className] - Additional CSS classes for the container
- * @param [placeholder] - Content to display when the editor is empty
+ * @param [placeholder] - Placeholder text shown when the editor is empty
  * @param [defaultPreview='edit'] - Initial edit/live/preview mode
  */
 export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   value,
   onChange,
   height = 300,
-  theme = EditorThemes.dark,
+  theme = EditorThemes.light,
   className,
   placeholder,
   defaultPreview = 'edit',
 }) => {
-  const showPlaceholder = placeholder !== undefined && !value;
-
   const commands = useMemo(() => getMarkdownFormattingCommands(), []);
   const extraCommands = useMemo(() => getMarkdownExtraCommands(), []);
 
   return (
     <div
       data-color-mode={theme}
-      className={mergeClasses('dial-kit-markdown-editor relative', className)}
+      className={mergeClasses('dial-kit-markdown-editor', className)}
     >
       <MDEditor
         value={value}
@@ -63,12 +61,8 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
         preview={defaultPreview}
         commands={commands}
         extraCommands={extraCommands}
+        textareaProps={{ placeholder }}
       />
-      {showPlaceholder && (
-        <div className="pointer-events-none absolute left-0 top-8 px-2 dial-small-text text-secondary opacity-40">
-          {placeholder}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/New/MarkdownEditor/constants.tsx
+++ b/src/components/New/MarkdownEditor/constants.tsx
@@ -23,13 +23,15 @@ import {
   IconBold,
   IconCode,
   IconColumns2,
+  IconEye,
   IconItalic,
+  IconLayoutColumns,
   IconLink,
   IconList,
   IconListNumbers,
   IconMaximize,
+  IconPencil,
   IconQuote,
-  IconSpacingHorizontal,
   IconStrikethrough,
   IconTextSize,
 } from '@tabler/icons-react';
@@ -80,23 +82,14 @@ export const getMarkdownFormattingCommands = (): ICommand[] => [
 ];
 
 /**
- * Right-hand toolbar: the built-in edit/live/preview mode switcher (all
- * three reuse the same icon in the design; only the active one is
- * highlighted via `.w-md-editor-toolbar li.active`) followed by fullscreen.
+ * Right-hand toolbar: the built-in edit/live/preview mode switcher, each
+ * with a distinct icon so the three states stay distinguishable even before
+ * the active one is highlighted, followed by fullscreen.
  */
 export const getMarkdownExtraCommands = (): ICommand[] => [
-  withIcon(
-    codeEdit,
-    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
-  ),
-  withIcon(
-    codeLive,
-    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
-  ),
-  withIcon(
-    codePreview,
-    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
-  ),
+  withIcon(codeEdit, <IconPencil size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(codeLive, <IconLayoutColumns size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(codePreview, <IconEye size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
   divider,
   withIcon(fullscreen, <IconMaximize size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
 ];

--- a/src/components/New/MarkdownEditor/constants.tsx
+++ b/src/components/New/MarkdownEditor/constants.tsx
@@ -1,0 +1,102 @@
+import {
+  bold,
+  code,
+  codeEdit,
+  codeLive,
+  codePreview,
+  divider,
+  fullscreen,
+  group,
+  heading1,
+  heading2,
+  heading3,
+  italic,
+  link,
+  orderedListCommand,
+  quote,
+  strikethrough,
+  table,
+  unorderedListCommand,
+  type ICommand,
+} from '@uiw/react-md-editor';
+import {
+  IconBold,
+  IconCode,
+  IconColumns2,
+  IconItalic,
+  IconLink,
+  IconList,
+  IconListNumbers,
+  IconMaximize,
+  IconQuote,
+  IconSpacingHorizontal,
+  IconStrikethrough,
+  IconTextSize,
+} from '@tabler/icons-react';
+
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+
+export const MARKDOWN_TOOLBAR_ICON_SIZE = DIAL_ICON_SIZE.MD;
+
+const withIcon = (command: ICommand, icon: ICommand['icon']): ICommand => ({
+  ...command,
+  icon,
+});
+
+/**
+ * Left-hand formatting toolbar, built on top of `@uiw/react-md-editor`'s
+ * built-in commands (which insert/toggle markdown syntax in the underlying
+ * textarea) with icons and grouping matching the design.
+ */
+export const getMarkdownFormattingCommands = (): ICommand[] => [
+  withIcon(bold, <IconBold size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(italic, <IconItalic size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(
+    strikethrough,
+    <IconStrikethrough size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  divider,
+  group([heading1, heading2, heading3], {
+    name: 'heading',
+    groupName: 'heading',
+    icon: <IconTextSize size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+    buttonProps: { 'aria-label': 'Text style', title: 'Text style' },
+  }),
+  divider,
+  withIcon(
+    unorderedListCommand,
+    <IconList size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  withIcon(
+    orderedListCommand,
+    <IconListNumbers size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  divider,
+  withIcon(quote, <IconQuote size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(link, <IconLink size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  withIcon(code, <IconCode size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+  divider,
+  withIcon(table, <IconColumns2 size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+];
+
+/**
+ * Right-hand toolbar: the built-in edit/live/preview mode switcher (all
+ * three reuse the same icon in the design; only the active one is
+ * highlighted via `.w-md-editor-toolbar li.active`) followed by fullscreen.
+ */
+export const getMarkdownExtraCommands = (): ICommand[] => [
+  withIcon(
+    codeEdit,
+    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  withIcon(
+    codeLive,
+    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  withIcon(
+    codePreview,
+    <IconSpacingHorizontal size={MARKDOWN_TOOLBAR_ICON_SIZE} />,
+  ),
+  divider,
+  withIcon(fullscreen, <IconMaximize size={MARKDOWN_TOOLBAR_ICON_SIZE} />),
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,3 +322,7 @@ export { FabButton } from './components/FabButton/FabButton';
 export type { FabButtonProps } from './components/FabButton/FabButton';
 export { ButtonDropdown } from './components/New/ButtonDropdown/ButtonDropdown';
 export type { ButtonDropdownProps } from './components/New/ButtonDropdown/ButtonDropdown';
+export type { MarkdownEditorProps } from './components/New/MarkdownEditor/MarkdownEditor';
+// Markdown Editor (2.0) - lazy loader to avoid loading in SSR
+export const LazyMarkdownEditor = () =>
+  import('./components/New/MarkdownEditor/MarkdownEditor');

--- a/src/styles/markdown-editor.scss
+++ b/src/styles/markdown-editor.scss
@@ -1,38 +1,95 @@
-/* 2.0 MarkdownEditor toolbar restyle, scoped over @uiw/react-md-editor's default CSS */
+/* 2.0 MarkdownEditor: card chrome + toolbar restyle, scoped over @uiw/react-md-editor's default CSS.
+   Colors reference the upcoming design-system tokens directly (var() with the
+   same names/fallbacks as tailwind.config.js) rather than Tailwind's color
+   utilities, since some of those utilities are being retired in that system.
+   Light is the primary theme for now; dark-theme parity is a follow-up. */
 
 .dial-kit-markdown-editor {
+  .w-md-editor {
+    @apply gap-3 rounded-lg border px-4 py-3;
+    border-color: var(--stroke-tertiary, #e0e6f0);
+    background-color: var(--bg-layer-raised, #fcfcfc) !important;
+    /* the base library fakes a border via box-shadow — both this rule and
+       theirs share the same selector, so !important guarantees ours wins
+       regardless of stylesheet import order in the consuming app. */
+    box-shadow: none !important;
+    --md-editor-font-family:
+      ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono',
+      monospace;
+  }
+
   .w-md-editor-toolbar {
-    @apply gap-1 border-b border-primary bg-layer-0 px-3 py-2;
+    @apply gap-1 bg-transparent p-0;
+    /* the base library sets its own `border-bottom` on this same selector;
+       equal specificity means import order decides the winner without
+       !important, so force it explicitly instead of relying on `border-0`. */
+    border: none !important;
+  }
+
+  /* only the top-level bar: the heading dropdown's own toolbar-child list
+     must stay a vertical stack (see the `ul > li { display: block }` rule
+     the base library applies inside `.w-md-editor-toolbar-child`). */
+  .w-md-editor > .w-md-editor-toolbar > ul {
+    @apply flex items-center;
+  }
+
+  .w-md-editor-text,
+  .w-md-editor-preview {
+    @apply p-0;
+  }
+
+  .w-md-editor-text-pre > code,
+  .w-md-editor-text-input {
+    line-height: 20px !important;
+  }
+
+  .w-md-editor-text-input::placeholder {
+    color: var(--text-secondary, #6b7280);
+    opacity: 1;
   }
 
   .w-md-editor-toolbar li > button {
-    @apply flex size-7 items-center justify-center rounded-md text-secondary transition-colors;
+    @apply flex size-7 items-center justify-center rounded-md transition-colors;
+    color: var(--text-secondary, #6b7280);
   }
 
   .w-md-editor-toolbar li > button:hover,
   .w-md-editor-toolbar li > button:focus {
-    @apply bg-control-neutral-hover text-primary;
+    background-color: var(--bg-control-neutral-hover, #e0e6f0);
+    color: var(--text-primary, #161b2d);
   }
 
   .w-md-editor-toolbar li > button:active {
-    @apply bg-control-neutral-active text-primary;
+    background-color: var(--bg-control-neutral-active, #d1dbea);
+    color: var(--text-primary, #161b2d);
   }
 
   .w-md-editor-toolbar li.active > button {
-    @apply bg-accent-primary-alpha text-accent;
+    background-color: var(--bg-control-accent-alpha-hover, #2764d924);
+    color: var(--text-accent, #1d4ed8);
   }
 
   .w-md-editor-toolbar li > button:disabled,
   .w-md-editor-toolbar li > button:disabled:hover {
-    @apply cursor-not-allowed bg-transparent text-control-disable;
+    @apply cursor-not-allowed bg-transparent;
+    color: var(--text-control-disable, #6b7280);
   }
 
   .w-md-editor-toolbar-divider {
-    @apply bg-layer-1;
+    /* a hairline divider is a stroke, not a fill — borrow the border token.
+       the base library sets the same properties on this same selector, so
+       !important is needed here too (see the `.w-md-editor-toolbar` note above). */
+    background-color: var(--stroke-tertiary, #e0e6f0) !important;
+    width: 1px !important;
+    height: 12px !important;
+    margin: 0 12px !important;
   }
 
   .w-md-editor-toolbar-child {
-    @apply rounded-md border border-primary bg-layer-0 shadow-md;
+    @apply rounded-md border shadow-md;
+    border-color: var(--stroke-primary, #6b7280);
+    background-color: var(--bg-layer-raised, #fcfcfc);
+    box-shadow: none !important;
   }
 
   .w-md-editor-toolbar-child .w-md-editor-toolbar li > button {

--- a/src/styles/markdown-editor.scss
+++ b/src/styles/markdown-editor.scss
@@ -1,0 +1,41 @@
+/* 2.0 MarkdownEditor toolbar restyle, scoped over @uiw/react-md-editor's default CSS */
+
+.dial-kit-markdown-editor {
+  .w-md-editor-toolbar {
+    @apply gap-1 border-b border-primary bg-layer-0 px-3 py-2;
+  }
+
+  .w-md-editor-toolbar li > button {
+    @apply flex size-7 items-center justify-center rounded-md text-secondary transition-colors;
+  }
+
+  .w-md-editor-toolbar li > button:hover,
+  .w-md-editor-toolbar li > button:focus {
+    @apply bg-control-neutral-hover text-primary;
+  }
+
+  .w-md-editor-toolbar li > button:active {
+    @apply bg-control-neutral-active text-primary;
+  }
+
+  .w-md-editor-toolbar li.active > button {
+    @apply bg-accent-primary-alpha text-accent;
+  }
+
+  .w-md-editor-toolbar li > button:disabled,
+  .w-md-editor-toolbar li > button:disabled:hover {
+    @apply cursor-not-allowed bg-transparent text-control-disable;
+  }
+
+  .w-md-editor-toolbar-divider {
+    @apply bg-layer-1;
+  }
+
+  .w-md-editor-toolbar-child {
+    @apply rounded-md border border-primary bg-layer-0 shadow-md;
+  }
+
+  .w-md-editor-toolbar-child .w-md-editor-toolbar li > button {
+    @apply size-auto justify-start rounded-md px-2 py-1.5 text-left;
+  }
+}

--- a/src/styles/markdown-editor.scss
+++ b/src/styles/markdown-editor.scss
@@ -1,17 +1,13 @@
 /* 2.0 MarkdownEditor: card chrome + toolbar restyle, scoped over @uiw/react-md-editor's default CSS.
-   Colors reference the upcoming design-system tokens directly (var() with the
-   same names/fallbacks as tailwind.config.js) rather than Tailwind's color
-   utilities, since some of those utilities are being retired in that system.
+   Colors go through the Tailwind token utilities from tailwind.config.js. The one
+   raw var() below is a stroke token used as a background-color, which has no
+   matching `bg-*` utility (see the toolbar-divider note).
    Light is the primary theme for now; dark-theme parity is a follow-up. */
 
 .dial-kit-markdown-editor {
   .w-md-editor {
-    @apply gap-3 rounded-lg border px-4 py-3;
-    border-color: var(--stroke-tertiary, #e0e6f0);
-    background-color: var(--bg-layer-raised, #fcfcfc) !important;
-    /* the base library fakes a border via box-shadow — both this rule and
-       theirs share the same selector, so !important guarantees ours wins
-       regardless of stylesheet import order in the consuming app. */
+    @apply gap-3 rounded-lg border px-4 py-3 border-tertiary !bg-layer-raised;
+
     box-shadow: none !important;
     --md-editor-font-family:
       ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono',
@@ -44,35 +40,41 @@
   }
 
   .w-md-editor-text-input::placeholder {
-    color: var(--text-secondary, #6b7280);
+    @apply text-secondary;
     opacity: 1;
   }
 
   .w-md-editor-toolbar li > button {
-    @apply flex size-7 items-center justify-center rounded-md transition-colors;
-    color: var(--text-secondary, #6b7280);
+    @apply size-[24px] flex flex-row items-center justify-center;
+    @apply rounded-full border border-solid border-transparent;
+    @apply disabled:cursor-not-allowed outline-offset-0;
+    @apply focus-visible:outline focus-visible:outline-focus-black;
   }
 
-  .w-md-editor-toolbar li > button:hover,
+  .w-md-editor-toolbar li > button > svg {
+    @apply size-[16px] text-primary;
+  }
+
   .w-md-editor-toolbar li > button:focus {
-    background-color: var(--bg-control-neutral-hover, #e0e6f0);
-    color: var(--text-primary, #161b2d);
+    @apply enabled:text-accent;
   }
 
   .w-md-editor-toolbar li > button:active {
-    background-color: var(--bg-control-neutral-active, #d1dbea);
-    color: var(--text-primary, #161b2d);
+    @apply bg-control-accent-alpha-active;
   }
 
   .w-md-editor-toolbar li.active > button {
-    background-color: var(--bg-control-accent-alpha-hover, #2764d924);
-    color: var(--text-accent, #1d4ed8);
+    @apply bg-control-accent-alpha-hover text-accent;
+  }
+
+  .w-md-editor-toolbar li.active > button > svg {
+    @apply text-accent;
   }
 
   .w-md-editor-toolbar li > button:disabled,
   .w-md-editor-toolbar li > button:disabled:hover {
     @apply cursor-not-allowed bg-transparent;
-    color: var(--text-control-disable, #6b7280);
+    @apply !text-control-disable-beta;
   }
 
   .w-md-editor-toolbar-divider {
@@ -86,9 +88,7 @@
   }
 
   .w-md-editor-toolbar-child {
-    @apply rounded-md border shadow-md;
-    border-color: var(--stroke-primary, #6b7280);
-    background-color: var(--bg-layer-raised, #fcfcfc);
+    @apply rounded-md border border-primary bg-layer-raised shadow-md;
     box-shadow: none !important;
   }
 

--- a/src/styles/tailwind-entry.scss
+++ b/src/styles/tailwind-entry.scss
@@ -8,6 +8,7 @@
 @import './ag-grid.scss';
 @import './steps.scss';
 @import './pagination.scss';
+@import './markdown-editor.scss';
 
 @layer ui {
   @tailwind base;


### PR DESCRIPTION
**Description and UI changes:**

<img width="897" height="376" alt="image" src="https://github.com/user-attachments/assets/ed0ed812-baa3-48cb-b346-4191295cba77" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added