### PR TITLE
fix: recurse into nested schemas for complex additionalProperties values in SchemaKeyValueEditor (Issue #796)

### DIFF
--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -391,6 +391,112 @@ export const AdditionalProperties: Story = {
   },
 };
 
+const indexesSchema: JsonSchema = {
+  $defs: {
+    TextEmbeddingsIndexerConfig: {
+      title: 'Text Embeddings',
+      type: 'object',
+      properties: {
+        type: {
+          const: 'text_embeddings',
+          default: 'text_embeddings',
+          title: 'Type',
+          type: 'string',
+        },
+        model: {
+          title: 'Model',
+          type: 'string',
+          default: 'text-embedding-3-small',
+        },
+      },
+    },
+    Bm25IndexerConfig: {
+      title: 'BM25',
+      type: 'object',
+      properties: {
+        type: { const: 'bm25', default: 'bm25', title: 'Type', type: 'string' },
+        k1: { title: 'K1', type: 'number', default: 1.2 },
+      },
+    },
+    ChunkIndexConfig: {
+      title: 'Chunk Index',
+      type: 'object',
+      properties: {
+        type: {
+          const: 'chunk',
+          default: 'chunk',
+          title: 'Type',
+          type: 'string',
+        },
+        display_name: { title: 'Display Name', type: 'string' },
+        indexer: {
+          title: 'Indexer',
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              text_embeddings: '#/$defs/TextEmbeddingsIndexerConfig',
+              bm25: '#/$defs/Bm25IndexerConfig',
+            },
+          },
+          oneOf: [
+            { $ref: '#/$defs/TextEmbeddingsIndexerConfig' },
+            { $ref: '#/$defs/Bm25IndexerConfig' },
+          ],
+        },
+        default_limit: { title: 'Default Limit', type: 'integer', default: 7 },
+      },
+      required: ['display_name', 'indexer'],
+    },
+  },
+  properties: {
+    indexes: {
+      title: 'Indexes',
+      description: 'Map of index name to its configuration.',
+      type: 'object',
+      additionalProperties: {
+        discriminator: {
+          propertyName: 'type',
+          mapping: { chunk: '#/$defs/ChunkIndexConfig' },
+        },
+        oneOf: [{ $ref: '#/$defs/ChunkIndexConfig' }],
+      },
+    },
+  },
+};
+
+export const AdditionalPropertiesWithDiscriminator: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Map values are discriminated objects with a nested discriminator field (indexer), ' +
+          'mirroring the real `indexes`/`ChunkIndexConfig` schema. Click "Add field" to add a ' +
+          "third entry and see it pre-seeded with the first variant's defaults at both levels " +
+          '(chunk → text_embeddings), rather than starting as a bare type-selector.',
+      },
+    },
+  },
+  args: {
+    schema: indexesSchema,
+    defaultValue: {
+      indexes: {
+        primary: {
+          type: 'chunk',
+          display_name: 'Primary Index',
+          indexer: { type: 'text_embeddings', model: 'text-embedding-3-small' },
+          default_limit: 7,
+        },
+        'keyword-search': {
+          type: 'chunk',
+          display_name: 'Keyword Search Index',
+          indexer: { type: 'bm25', k1: 1.2 },
+          default_limit: 20,
+        },
+      },
+    },
+  },
+};
+
 export const ArrayWithDiscriminator: Story = {
   args: {
     schema: arraySchema,

--- a/src/components/SchemaRenderer/components/SchemaFieldContent.tsx
+++ b/src/components/SchemaRenderer/components/SchemaFieldContent.tsx
@@ -99,6 +99,8 @@ export const SchemaFieldContent: FC<SchemaFieldContentProps> = ({
           schema={resolved}
           value={value}
           onChange={handleChange}
+          path={path}
+          level={level}
         />
       );
     } else if (hasNoFixedProps && resolved.additionalProperties !== false) {

--- a/src/components/SchemaRenderer/components/SchemaKeyValueEditor.tsx
+++ b/src/components/SchemaRenderer/components/SchemaKeyValueEditor.tsx
@@ -1,12 +1,26 @@
 import { type FC, useState } from 'react';
 import { IconPlus } from '@tabler/icons-react';
 import { DialInput } from '@/components/Input/Input';
+import { DialErrorText } from '@/components/CaptionText/CaptionText';
 import { DialGhostButton } from '@/components/Button/ButtonWrappers';
 import { DialRemoveButton } from '@/components/RemoveButton/RemoveButton';
 import { ElementSize } from '@/types/size';
-import type { JsonSchemaDef } from '@/components/SchemaRenderer/types';
+import {
+  JsonSchemaType,
+  type JsonSchemaDef,
+} from '@/components/SchemaRenderer/types';
 import { useSchemaContext } from '@/components/SchemaRenderer/context';
+import {
+  resolveRef,
+  extractDefaults,
+  buildSummary,
+  validateRequired,
+  isObjectType,
+  getSchemaDefault,
+} from '@/components/SchemaRenderer/utils';
 import { SchemaPrimitiveField } from './SchemaPrimitiveField';
+import { SchemaSection } from './SchemaSection';
+import { SchemaFieldContent } from './SchemaFieldContent';
 
 interface KeyValuePair {
   id: string;
@@ -20,7 +34,16 @@ const createPair = (key: string, value: unknown): KeyValuePair => ({
   value,
 });
 
+const isComplexValueSchema = (schema: JsonSchemaDef): boolean =>
+  Boolean(
+    schema.oneOf ||
+    schema.anyOf ||
+    schema.type === JsonSchemaType.Array ||
+    isObjectType(schema),
+  );
+
 interface KeyValueRowProps {
+  pairId: string;
   pairKey: string;
   pairValue: unknown;
   valueSchema: JsonSchemaDef;
@@ -29,11 +52,14 @@ interface KeyValueRowProps {
   onRemove: () => void;
   keyInputPlaceholder: string;
   removeFieldAriaLabel: string;
+  path: string[];
+  level: number;
   readonly?: boolean;
   inputClassName?: string;
 }
 
 const KeyValueRow: FC<KeyValueRowProps> = ({
+  pairId,
   pairKey,
   pairValue,
   valueSchema,
@@ -42,32 +68,55 @@ const KeyValueRow: FC<KeyValueRowProps> = ({
   onRemove,
   keyInputPlaceholder,
   removeFieldAriaLabel,
+  path,
+  level,
   readonly = false,
   inputClassName,
 }) => {
+  const {
+    rootSchema,
+    texts,
+    defaultExpanded = true,
+    touchedPaths = new Set<string>(),
+    markTouched = () => {},
+    skipUntouched = false,
+  } = useSchemaContext();
   const [keyDraft, setKeyDraft] = useState(pairKey);
+  const isComplex = isComplexValueSchema(valueSchema);
+  const keyTouchedPath = [...path, pairId, 'key'].join('.');
+  const isKeyTouched = !skipUntouched || touchedPaths.has(keyTouchedPath);
+  const showKeyError = isKeyTouched && pairKey === '';
 
-  return (
-    <div className="flex gap-2 items-center">
-      <div className="w-2/5 min-w-0">
+  const keyRow = (
+    <div className="flex gap-2 items-start">
+      <div className={isComplex ? 'flex-1 min-w-0' : 'w-2/5 min-w-0'}>
         <DialInput
           value={keyDraft}
           disabled={readonly}
+          invalid={showKeyError}
           onChange={(v) => setKeyDraft(v ?? '')}
           onBlur={() => {
+            markTouched(keyTouchedPath);
             if (keyDraft !== pairKey) onKeyChange(keyDraft);
           }}
           placeholder={keyInputPlaceholder}
           containerClassName={inputClassName}
         />
-      </div>
-      <div className="flex-1 min-w-0">
-        <SchemaPrimitiveField
-          schema={valueSchema}
-          value={pairValue}
-          onChange={onValueChange}
+        <DialErrorText
+          text={
+            showKeyError ? `${texts.keyColumnHeader} is required` : undefined
+          }
         />
       </div>
+      {!isComplex && (
+        <div className="flex-1 min-w-0">
+          <SchemaPrimitiveField
+            schema={valueSchema}
+            value={pairValue}
+            onChange={onValueChange}
+          />
+        </div>
+      )}
       {!readonly && (
         <DialRemoveButton
           size={ElementSize.Small}
@@ -78,16 +127,52 @@ const KeyValueRow: FC<KeyValueRowProps> = ({
       )}
     </div>
   );
+
+  if (!isComplex) return keyRow;
+
+  const entryPath = [...path, pairKey];
+  const summary = buildSummary(pairValue, valueSchema, rootSchema);
+  const errors = validateRequired(
+    pairValue,
+    valueSchema,
+    rootSchema,
+    entryPath.join('.'),
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      {keyRow}
+      <SchemaSection
+        title={pairKey}
+        level={level}
+        summary={summary}
+        errorCount={errors.length + (showKeyError ? 1 : 0)}
+        defaultExpanded={defaultExpanded}
+      >
+        <SchemaFieldContent
+          schema={valueSchema}
+          value={pairValue}
+          onChange={onValueChange}
+          path={entryPath}
+          level={level + 1}
+        />
+      </SchemaSection>
+    </div>
+  );
 };
 
 export interface SchemaKeyValueEditorProps {
   schema: JsonSchemaDef;
   value: unknown;
   onChange: (value: unknown) => void;
+  path: string[];
+  level: number;
 }
 
 /**
- * Renders an `additionalProperties` object schema as an editable key-value list.
+ * Renders an `additionalProperties` object schema as an editable key-value list. Primitive
+ * values render inline; object/`oneOf`/array values render as a collapsible section recursing
+ * back into `SchemaFieldContent`.
  * aliases: KeyValueSchemaEditor|AdditionalPropertiesEditor
  *
  * @example
@@ -96,26 +181,39 @@ export interface SchemaKeyValueEditorProps {
  *   schema={{ type: 'object', additionalProperties: { type: 'string' } }}
  *   value={{ foo: 'bar' }}
  *   onChange={(v) => console.log(v)}
+ *   path={['metadata']}
+ *   level={1}
  * />
  * ```
  *
  * @param schema - The JSON Schema object definition with `additionalProperties`
  * @param value - Current object value (treated as a key-value map)
  * @param onChange - Called with the updated object when pairs are added, removed, or changed
+ * @param path - Field path segments used for validation error tracking
+ * @param level - Nesting depth passed to child section components
  */
 export const SchemaKeyValueEditor: FC<SchemaKeyValueEditorProps> = ({
   schema,
   value,
   onChange,
+  path,
+  level,
 }) => {
-  const { texts, readonly = false, inputClassName } = useSchemaContext();
+  const {
+    rootSchema,
+    texts,
+    readonly = false,
+    inputClassName,
+  } = useSchemaContext();
 
   const valueSchema: JsonSchemaDef =
     schema.additionalProperties === true || schema.additionalProperties == null
       ? { type: 'string' }
       : typeof schema.additionalProperties === 'object'
-        ? (schema.additionalProperties as JsonSchemaDef)
+        ? resolveRef(schema.additionalProperties as JsonSchemaDef, rootSchema)
         : { type: 'string' };
+
+  const isComplexValue = isComplexValueSchema(valueSchema);
 
   const [pairs, setPairs] = useState<KeyValuePair[]>(() =>
     Object.entries((value as Record<string, unknown>) ?? {}).map(([k, v]) =>
@@ -144,8 +242,15 @@ export const SchemaKeyValueEditor: FC<SchemaKeyValueEditorProps> = ({
     onChange(toObject(updated));
   };
 
+  const buildNewValue = (): unknown => {
+    if (!isComplexValue) return '';
+    return (
+      extractDefaults(valueSchema, rootSchema) ?? getSchemaDefault(valueSchema)
+    );
+  };
+
   const handleAdd = () => {
-    setPairs((prev) => [...prev, createPair('', '')]);
+    setPairs((prev) => [...prev, createPair('', buildNewValue())]);
   };
 
   const handleRemove = (idx: number) => {
@@ -162,7 +267,7 @@ export const SchemaKeyValueEditor: FC<SchemaKeyValueEditorProps> = ({
         </p>
       )}
 
-      {pairs.length > 0 && (
+      {pairs.length > 0 && !isComplexValue && (
         <div className="flex gap-2 mb-1 pr-7">
           <span className="w-2/5 dial-tiny-text text-secondary font-medium">
             {texts.keyColumnHeader}
@@ -176,6 +281,7 @@ export const SchemaKeyValueEditor: FC<SchemaKeyValueEditorProps> = ({
       {pairs.map((pair, i) => (
         <KeyValueRow
           key={pair.id}
+          pairId={pair.id}
           pairKey={pair.key}
           pairValue={pair.value}
           valueSchema={valueSchema}
@@ -184,6 +290,8 @@ export const SchemaKeyValueEditor: FC<SchemaKeyValueEditorProps> = ({
           onRemove={() => handleRemove(i)}
           keyInputPlaceholder={texts.keyInputPlaceholder}
           removeFieldAriaLabel={texts.removeFieldAriaLabel}
+          path={path}
+          level={level}
           readonly={readonly}
           inputClassName={inputClassName}
         />

--- a/src/components/SchemaRenderer/tests/SchemaKeyValueEditor.spec.tsx
+++ b/src/components/SchemaRenderer/tests/SchemaKeyValueEditor.spec.tsx
@@ -1,15 +1,18 @@
-import { type ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import { SchemaRendererContext } from '@/components/SchemaRenderer/context';
-import { DEFAULT_SCHEMA_TEXTS } from '@/components/SchemaRenderer/types';
+import {
+  DEFAULT_SCHEMA_TEXTS,
+  type JsonSchema,
+} from '@/components/SchemaRenderer/types';
 import { SchemaKeyValueEditor } from '@/components/SchemaRenderer/components/SchemaKeyValueEditor';
 
-const renderWithSchema = (ui: ReactElement) =>
+const renderWithSchema = (ui: ReactElement, rootSchema: JsonSchema = {}) =>
   render(
     <SchemaRendererContext.Provider
-      value={{ rootSchema: {}, texts: DEFAULT_SCHEMA_TEXTS }}
+      value={{ rootSchema, texts: DEFAULT_SCHEMA_TEXTS }}
     >
       {ui}
     </SchemaRendererContext.Provider>,
@@ -22,6 +25,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: true }}
         value={{}}
         onChange={vi.fn()}
+        path={[]}
+        level={0}
       />,
     );
     expect(screen.getByText(/No fields yet/)).toBeInTheDocument();
@@ -33,6 +38,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: 'bar' }}
         onChange={vi.fn()}
+        path={[]}
+        level={0}
       />,
     );
     expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
@@ -45,6 +52,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ x: 'y' }}
         onChange={vi.fn()}
+        path={[]}
+        level={0}
       />,
     );
     expect(screen.getByText('Key')).toBeInTheDocument();
@@ -57,6 +66,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: true }}
         value={{}}
         onChange={vi.fn()}
+        path={[]}
+        level={0}
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /add field/i }));
@@ -72,6 +83,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: 'bar' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Remove field' }));
@@ -85,6 +98,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ a: '1', b: '2', c: '3' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     const removeButtons = screen.getAllByRole('button', {
@@ -101,6 +116,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: '' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     fireEvent.change(
@@ -119,6 +136,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: 'bar' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     const keyInput = screen.getByDisplayValue('foo');
@@ -133,6 +152,8 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: 'bar' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     const keyInput = screen.getByDisplayValue('foo');
@@ -149,11 +170,218 @@ describe('Dial UI Kit :: SchemaKeyValueEditor', () => {
         schema={{ type: 'object', additionalProperties: { type: 'string' } }}
         value={{ foo: 'bar' }}
         onChange={onChange}
+        path={[]}
+        level={0}
       />,
     );
     const keyInput = screen.getByDisplayValue('foo');
     await user.click(keyInput);
     await user.tab();
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('shows a key-required error immediately for a new empty-key entry (skipUntouched defaults to false)', () => {
+    renderWithSchema(
+      <SchemaKeyValueEditor
+        schema={{ type: 'object', additionalProperties: true }}
+        value={{}}
+        onChange={vi.fn()}
+        path={[]}
+        level={0}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+    expect(screen.getByText(/Key is required/)).toBeInTheDocument();
+  });
+
+  test('does not show a key-required error until touched when skipUntouched is true', () => {
+    const WithTouchedTracking = () => {
+      const [touchedPaths, setTouchedPaths] = useState<Set<string>>(new Set());
+      const markTouched = (path: string) =>
+        setTouchedPaths((prev) => new Set(prev).add(path));
+      return (
+        <SchemaRendererContext.Provider
+          value={{
+            rootSchema: {},
+            texts: DEFAULT_SCHEMA_TEXTS,
+            skipUntouched: true,
+            touchedPaths,
+            markTouched,
+          }}
+        >
+          <SchemaKeyValueEditor
+            schema={{ type: 'object', additionalProperties: true }}
+            value={{}}
+            onChange={vi.fn()}
+            path={[]}
+            level={0}
+          />
+        </SchemaRendererContext.Provider>
+      );
+    };
+    render(<WithTouchedTracking />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+    expect(screen.queryByText(/Key is required/)).not.toBeInTheDocument();
+
+    const keyInput = screen.getByPlaceholderText(
+      DEFAULT_SCHEMA_TEXTS.keyInputPlaceholder,
+    );
+    fireEvent.blur(keyInput);
+    expect(screen.getByText(/Key is required/)).toBeInTheDocument();
+  });
+
+  describe('discriminated object values', () => {
+    const rootSchema: JsonSchema = {
+      $defs: {
+        VectorIndexConfig: {
+          title: 'Vector Index',
+          type: 'object',
+          properties: {
+            type: { const: 'vector', default: 'vector', type: 'string' },
+            display_name: { title: 'Display Name', type: 'string' },
+          },
+          required: ['display_name'],
+        },
+        KeywordIndexConfig: {
+          title: 'Keyword Index',
+          type: 'object',
+          properties: {
+            type: { const: 'keyword', default: 'keyword', type: 'string' },
+            display_name: { title: 'Display Name', type: 'string' },
+          },
+          required: ['display_name'],
+        },
+      },
+    };
+
+    const additionalProperties = {
+      discriminator: {
+        propertyName: 'type',
+        mapping: {
+          vector: '#/$defs/VectorIndexConfig',
+          keyword: '#/$defs/KeywordIndexConfig',
+        },
+      },
+      oneOf: [
+        { $ref: '#/$defs/VectorIndexConfig' },
+        { $ref: '#/$defs/KeywordIndexConfig' },
+      ],
+    };
+
+    test('renders nested fields instead of a stringified value', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{ type: 'object', additionalProperties }}
+          value={{
+            primary: { type: 'vector', display_name: 'Primary Vector Index' },
+          }}
+          onChange={vi.fn()}
+          path={['indexes']}
+          level={0}
+        />,
+        rootSchema,
+      );
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('Primary Vector Index'),
+      ).toBeInTheDocument();
+    });
+
+    test('pre-seeds the first discriminator variant defaults when adding a new entry', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{ type: 'object', additionalProperties }}
+          value={{}}
+          onChange={vi.fn()}
+          path={['indexes']}
+          level={0}
+        />,
+        rootSchema,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /add field/i }));
+      expect(screen.getByText('Display Name')).toBeInTheDocument();
+    });
+
+    test('shows an error badge when a required nested field is missing', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{ type: 'object', additionalProperties }}
+          value={{ primary: { type: 'vector' } }}
+          onChange={vi.fn()}
+          path={['indexes']}
+          level={0}
+        />,
+        rootSchema,
+      );
+      expect(screen.getByText(/1 error/)).toBeInTheDocument();
+    });
+
+    test('folds a touched empty key into the section error count', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{ type: 'object', additionalProperties }}
+          value={{
+            primary: { type: 'vector', display_name: 'Primary Vector Index' },
+          }}
+          onChange={vi.fn()}
+          path={['indexes']}
+          level={0}
+        />,
+        rootSchema,
+      );
+      const keyInput = screen.getByDisplayValue('primary');
+      fireEvent.change(keyInput, { target: { value: '' } });
+      fireEvent.blur(keyInput);
+      expect(screen.getByText(/1 error/)).toBeInTheDocument();
+    });
+  });
+
+  describe('plain object values (no oneOf/discriminator)', () => {
+    test('renders nested fields instead of a stringified value', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                host: { title: 'Host', type: 'string' },
+                port: { title: 'Port', type: 'integer' },
+              },
+            },
+          }}
+          value={{ primary: { host: 'localhost', port: 5432 } }}
+          onChange={vi.fn()}
+          path={['connections']}
+          level={0}
+        />,
+      );
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('localhost')).toBeInTheDocument();
+    });
+  });
+
+  describe('array values', () => {
+    test('renders an editable list instead of a stringified value', () => {
+      renderWithSchema(
+        <SchemaKeyValueEditor
+          schema={{
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          }}
+          value={{ tags: ['prod', 'eu'] }}
+          onChange={vi.fn()}
+          path={['groups']}
+          level={0}
+        />,
+      );
+      expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('prod')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('eu')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/SchemaRenderer/tests/utils.spec.ts
+++ b/src/components/SchemaRenderer/tests/utils.spec.ts
@@ -313,6 +313,62 @@ describe('extractDefaults', () => {
     expect(result.type).toBe('custom');
     expect(result.variables).toEqual({});
   });
+
+  test('recursively resolves nested discriminator fields to their first variant', () => {
+    const root: JsonSchema = {
+      $defs: {
+        ChunkIndexConfig: {
+          type: 'object',
+          properties: {
+            type: { const: 'chunk', default: 'chunk', type: 'string' },
+            display_name: { type: 'string', title: 'Display Name' },
+            indexer: {
+              discriminator: {
+                propertyName: 'type',
+                mapping: {
+                  text_embeddings: '#/$defs/TextEmbeddingsIndexerConfig',
+                  bm25: '#/$defs/Bm25IndexerConfig',
+                },
+              },
+              oneOf: [
+                { $ref: '#/$defs/TextEmbeddingsIndexerConfig' },
+                { $ref: '#/$defs/Bm25IndexerConfig' },
+              ],
+            },
+          },
+        },
+        TextEmbeddingsIndexerConfig: {
+          type: 'object',
+          properties: {
+            type: {
+              const: 'text_embeddings',
+              default: 'text_embeddings',
+              type: 'string',
+            },
+            model: { type: 'string', default: 'text-embedding-3-small' },
+          },
+        },
+        Bm25IndexerConfig: {
+          type: 'object',
+          properties: {
+            type: { const: 'bm25', default: 'bm25', type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = extractDefaults(
+      { $ref: '#/$defs/ChunkIndexConfig' },
+      root,
+    ) as Record<string, unknown>;
+
+    expect(result.type).toBe('chunk');
+    expect(result.indexer).toEqual({
+      type: 'text_embeddings',
+      model: 'text-embedding-3-small',
+    });
+    expect(result.display_name).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -444,6 +500,39 @@ describe('validateRequired', () => {
     const errors = validateRequired({}, schema, {}, '');
     expect(errors).toHaveLength(1);
     expect(errors[0].path).toBe('visible');
+  });
+
+  test('recursively validates additionalProperties map entries', () => {
+    const schema: JsonSchemaDef = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        required: ['display_name'],
+        properties: { display_name: { type: 'string', title: 'Display Name' } },
+      },
+    };
+    const errors = validateRequired(
+      { primary: {}, secondary: { display_name: 'Secondary' } },
+      schema,
+      {},
+      'indexes',
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('indexes.primary.display_name');
+  });
+
+  test('ignores additionalProperties when it is a boolean or missing', () => {
+    expect(
+      validateRequired({ a: 'x' }, { type: 'object' }, {}, ''),
+    ).toHaveLength(0);
+    expect(
+      validateRequired(
+        { a: 'x' },
+        { type: 'object', additionalProperties: true },
+        {},
+        '',
+      ),
+    ).toHaveLength(0);
   });
 });
 

--- a/src/components/SchemaRenderer/utils.ts
+++ b/src/components/SchemaRenderer/utils.ts
@@ -105,6 +105,25 @@ export function extractDefaults(
     return resolved.default;
   }
 
+  if (resolved.discriminator && resolved.oneOf) {
+    const firstType = Object.keys(resolved.discriminator.mapping)[0];
+    if (firstType) {
+      const variantSchema = resolveRef(
+        { $ref: resolved.discriminator.mapping[firstType] },
+        rootSchema,
+      );
+      const variantDefaults =
+        (extractDefaults(variantSchema, rootSchema, depth + 1) as Record<
+          string,
+          unknown
+        >) ?? {};
+      return {
+        ...variantDefaults,
+        [resolved.discriminator.propertyName]: firstType,
+      };
+    }
+  }
+
   if (isObjectType(resolved)) {
     if (resolved.properties) {
       const obj: Record<string, unknown> = {};
@@ -234,6 +253,26 @@ export function validateRequired(
         );
         errors.push(...childErrors);
       }
+    }
+  }
+
+  if (
+    obj &&
+    resolved.additionalProperties != null &&
+    resolved.additionalProperties !== false &&
+    typeof resolved.additionalProperties === 'object'
+  ) {
+    const entrySchema = resolved.additionalProperties as JsonSchemaDef;
+    for (const [key, entryValue] of Object.entries(obj)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      const childErrors = validateRequired(
+        entryValue,
+        entrySchema,
+        rootSchema,
+        fieldPath,
+        depth + 1,
+      );
+      errors.push(...childErrors);
     }
   }
 


### PR DESCRIPTION
**Description and UI changes:**

Fixes `SchemaKeyValueEditor` rendering `[object Object]` for map (`additionalProperties`) values whose schema is complex (object/`oneOf`/`$ref`) instead of a simple type. The value schema is now resolved via `resolveRef` and, for non-primitive values, recurses back into `SchemaFieldContent` inside a collapsible `SchemaSection` — mirroring how `SchemaArrayEditor` already handles arrays of discriminated objects. Also:
- `extractDefaults` now recursively resolves nested `oneOf`/`discriminator` fields to their first variant, so newly-added map entries are pre-seeded at every level instead of leaving nested discriminated fields unset.
- `validateRequired` now recurses into `additionalProperties` map entries so required-field errors surface correctly.
- A map entry's key input now shows a "Key is required" error (consistent with how other required fields behave, respecting `skipUntouched`) instead of silently dropping unkeyed entries from the emitted value on save.

Issues:

- Issue #796

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added
