### PR TITLE
feat: support dial:propertyOrder in SchemaRenderer (Issue #799)

### DIFF
--- a/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.spec.tsx
@@ -337,4 +337,51 @@ describe('DialSchemaRenderer', () => {
       expect.objectContaining({ name: 'hi', extra: 'new' }),
     );
   });
+
+  it('orders top-level properties by dial:propertyOrder when declared order disagrees', () => {
+    const schema: JsonSchema = {
+      properties: {
+        a: {
+          title: 'A',
+          type: 'string',
+          'dial:meta': { 'dial:propertyOrder': 1 },
+        },
+        b: {
+          title: 'B',
+          type: 'string',
+          'dial:meta': { 'dial:propertyOrder': 0 },
+        },
+      },
+    };
+    render(
+      <DialSchemaRenderer
+        schema={schema}
+        variant={SchemaRendererVariant.Flat}
+      />,
+    );
+    const labels = screen.getAllByText(/^[AB]$/);
+    expect(labels.map((el) => el.textContent)).toEqual(['B', 'A']);
+  });
+
+  it('falls back to source order for top-level properties without dial:propertyOrder', () => {
+    const schema: JsonSchema = {
+      properties: {
+        a: { title: 'A', type: 'string' },
+        b: {
+          title: 'B',
+          type: 'string',
+          'dial:meta': { 'dial:propertyOrder': 0 },
+        },
+        c: { title: 'C', type: 'string' },
+      },
+    };
+    render(
+      <DialSchemaRenderer
+        schema={schema}
+        variant={SchemaRendererVariant.Flat}
+      />,
+    );
+    const labels = screen.getAllByText(/^[ABC]$/);
+    expect(labels.map((el) => el.textContent)).toEqual(['B', 'A', 'C']);
+  });
 });

--- a/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.stories.tsx
@@ -772,6 +772,41 @@ export const AllOfWithDefaults: Story = {
   },
 };
 
+const propertyOrderSchema: JsonSchema = {
+  properties: {
+    a: {
+      title: 'A',
+      type: 'string',
+      'dial:meta': { 'dial:propertyOrder': 2 },
+    },
+    b: {
+      title: 'B',
+      type: 'object',
+      'dial:meta': { 'dial:propertyOrder': 1 },
+      properties: {
+        d: { title: 'D', type: 'string' },
+        e: { title: 'E', type: 'string' },
+      },
+    },
+    c: {
+      title: 'C',
+      type: 'string',
+      'dial:meta': { 'dial:propertyOrder': 0 },
+    },
+  },
+};
+
+export const PropertyOrderHint: Story = {
+  args: {
+    schema: propertyOrderSchema,
+    defaultValue: {
+      a: 'Value A (dial:propertyOrder: 2)',
+      b: { d: 'Value D', e: 'Value E' },
+      c: 'Value C (dial:propertyOrder: 0)',
+    },
+  },
+};
+
 export const CustomFieldRenderer: Story = {
   args: {
     schema: simpleSchema,

--- a/src/components/SchemaRenderer/SchemaRenderer.tsx
+++ b/src/components/SchemaRenderer/SchemaRenderer.tsx
@@ -12,6 +12,7 @@ import {
   validateRequired,
   toFieldLabel,
   isMissingRequiredValue,
+  sortByPropertyOrder,
 } from '@/components/SchemaRenderer/utils';
 import { SchemaSection } from '@/components/SchemaRenderer/components/SchemaSection';
 import { SchemaFieldContent } from '@/components/SchemaRenderer/components/SchemaFieldContent';
@@ -103,8 +104,10 @@ export const DialSchemaRenderer: FC<DialSchemaRendererProps> = ({
     (key) => !schemaPropertyKeys.has(key),
   );
 
-  const topLevelProperties = Object.entries(schema.properties ?? {}).filter(
-    ([, propSchema]) => !resolveRef(propSchema, schema).isHidden,
+  const topLevelProperties = sortByPropertyOrder(
+    Object.entries(schema.properties ?? {}).filter(
+      ([, propSchema]) => !resolveRef(propSchema, schema).isHidden,
+    ),
   );
   const topLevelRequired = schema.required ?? [];
 

--- a/src/components/SchemaRenderer/components/SchemaObjectEditor.tsx
+++ b/src/components/SchemaRenderer/components/SchemaObjectEditor.tsx
@@ -1,6 +1,10 @@
 import { useSchemaContext } from '@/components/SchemaRenderer/context';
 import type { JsonSchemaDef } from '@/components/SchemaRenderer/types';
-import { resolveRef, toFieldLabel } from '@/components/SchemaRenderer/utils';
+import {
+  resolveRef,
+  sortByPropertyOrder,
+  toFieldLabel,
+} from '@/components/SchemaRenderer/utils';
 import type { FC } from 'react';
 import { SchemaField } from './SchemaField';
 
@@ -42,8 +46,10 @@ export const SchemaObjectEditor: FC<SchemaObjectEditorProps> = ({
 }) => {
   const { rootSchema, texts } = useSchemaContext();
   const resolved = resolveRef(schema, rootSchema);
-  const properties = Object.entries(resolved.properties ?? {}).filter(
-    ([, propSchema]) => !resolveRef(propSchema, rootSchema).isHidden,
+  const properties = sortByPropertyOrder(
+    Object.entries(resolved.properties ?? {}).filter(
+      ([, propSchema]) => !resolveRef(propSchema, rootSchema).isHidden,
+    ),
   );
   const required = resolved.required ?? [];
   const obj = (value as Record<string, unknown>) ?? {};

--- a/src/components/SchemaRenderer/tests/SchemaObjectEditor.spec.tsx
+++ b/src/components/SchemaRenderer/tests/SchemaObjectEditor.spec.tsx
@@ -154,4 +154,61 @@ describe('Dial UI Kit :: SchemaObjectEditor', () => {
     expect(screen.queryByText('Hidden Field')).not.toBeInTheDocument();
     expect(screen.queryByText('Hidden Field 2')).not.toBeInTheDocument();
   });
+
+  test('orders properties by dial:propertyOrder when declared order disagrees', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'string',
+          title: 'A',
+          'dial:meta': { 'dial:propertyOrder': 1 },
+        },
+        b: {
+          type: 'string',
+          title: 'B',
+          'dial:meta': { 'dial:propertyOrder': 0 },
+        },
+      },
+    };
+    renderWithSchema(
+      <SchemaObjectEditor
+        schema={schema}
+        value={{ a: '', b: '' }}
+        onChange={vi.fn()}
+        path={[]}
+        level={0}
+      />,
+      schema,
+    );
+    const labels = screen.getAllByText(/^[AB]$/);
+    expect(labels.map((el) => el.textContent)).toEqual(['B', 'A']);
+  });
+
+  test('falls back to source order for properties without dial:propertyOrder', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        a: { type: 'string', title: 'A' },
+        b: {
+          type: 'string',
+          title: 'B',
+          'dial:meta': { 'dial:propertyOrder': 0 },
+        },
+        c: { type: 'string', title: 'C' },
+      },
+    };
+    renderWithSchema(
+      <SchemaObjectEditor
+        schema={schema}
+        value={{ a: '', b: '', c: '' }}
+        onChange={vi.fn()}
+        path={[]}
+        level={0}
+      />,
+      schema,
+    );
+    const labels = screen.getAllByText(/^[ABC]$/);
+    expect(labels.map((el) => el.textContent)).toEqual(['B', 'A', 'C']);
+  });
 });

--- a/src/components/SchemaRenderer/tests/utils.spec.ts
+++ b/src/components/SchemaRenderer/tests/utils.spec.ts
@@ -10,6 +10,7 @@ import {
   detectAnyOfVariant,
   getItemTitle,
   getSchemaDefault,
+  sortByPropertyOrder,
 } from '@/components/SchemaRenderer/utils';
 import type {
   JsonSchema,
@@ -137,6 +138,49 @@ describe('isObjectType', () => {
     expect(
       isObjectType({ properties: { x: { type: 'string' } }, anyOf: [] }),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortByPropertyOrder
+// ---------------------------------------------------------------------------
+
+describe('sortByPropertyOrder', () => {
+  test('orders entries by dial:propertyOrder ascending', () => {
+    const entries: [string, JsonSchemaDef][] = [
+      ['a', { 'dial:meta': { 'dial:propertyOrder': 1 } }],
+      ['b', { 'dial:meta': { 'dial:propertyOrder': 0 } }],
+    ];
+    expect(sortByPropertyOrder(entries).map(([key]) => key)).toEqual([
+      'b',
+      'a',
+    ]);
+  });
+
+  test('falls back to source order for entries without the hint', () => {
+    const entries: [string, JsonSchemaDef][] = [
+      ['a', {}],
+      ['b', { 'dial:meta': { 'dial:propertyOrder': 0 } }],
+      ['c', {}],
+    ];
+    expect(sortByPropertyOrder(entries).map(([key]) => key)).toEqual([
+      'b',
+      'a',
+      'c',
+    ]);
+  });
+
+  test('is a no-op when no entries carry the hint', () => {
+    const entries: [string, JsonSchemaDef][] = [
+      ['a', {}],
+      ['b', {}],
+      ['c', {}],
+    ];
+    expect(sortByPropertyOrder(entries).map(([key]) => key)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
   });
 });
 

--- a/src/components/SchemaRenderer/types.ts
+++ b/src/components/SchemaRenderer/types.ts
@@ -27,6 +27,11 @@ export enum JsonSchemaType {
   Null = 'null',
 }
 
+export interface DialMeta {
+  'dial:propertyOrder'?: number;
+  [key: string]: unknown;
+}
+
 export interface JsonSchemaDef {
   $ref?: string;
   type?: string | string[];
@@ -51,7 +56,7 @@ export interface JsonSchemaDef {
     propertyName: string;
     mapping: Record<string, string>;
   };
-  'dial:meta'?: Record<string, unknown>;
+  'dial:meta'?: DialMeta;
   'dial:resource'?: boolean;
   acceptableResourceTypes?: string[];
   [key: string]: unknown;

--- a/src/components/SchemaRenderer/utils.ts
+++ b/src/components/SchemaRenderer/utils.ts
@@ -51,6 +51,22 @@ export function resolveRef(
   return result;
 }
 
+export function sortByPropertyOrder(
+  entries: [string, JsonSchemaDef][],
+): [string, JsonSchemaDef][] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      const orderA =
+        a.entry[1]['dial:meta']?.['dial:propertyOrder'] ?? Infinity;
+      const orderB =
+        b.entry[1]['dial:meta']?.['dial:propertyOrder'] ?? Infinity;
+      if (orderA !== orderB) return orderA - orderB;
+      return a.index - b.index;
+    })
+    .map(({ entry }) => entry);
+}
+
 export function isMissingRequiredValue(value: unknown): boolean {
   return value === undefined || value === null || value === '';
 }


### PR DESCRIPTION
**Description and UI changes:**

Adds support for the `dial:meta.dial:propertyOrder` JSON Schema extension in `SchemaRenderer`/`SchemaObjectEditor`: properties are now sorted ascending by this hint when present, falling back to source order for properties without it. Includes a new `PropertyOrderHint` Storybook story and unit tests covering the full-hint, partial-hint, and no-hint cases.

Issues:

- Issue #799

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #799)`

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added