### PR TITLE
feat: accessibility support for 2.0 controls, Colors 2.0 token cleanup, and new 2.0 components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,13 @@ This file is read by Cursor, Codex, and other agent harnesses alongside project 
 
 ## When to add or update
 
-| Change                      | Also do                                            |
-| --------------------------- | -------------------------------------------------- |
-| New public component        | Storybook story, spec, entry in `src/index.ts`     |
-| Visual / interaction change | Update stories; adjust or add tests                |
-| Peer dependency surface     | Document in README or story descriptions if needed |
-| **Breaking change**         | CHANGELOG.md entry + migration guide (see below)   |
+| Change                      | Also do                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| New public component        | Storybook story, spec, entry in `src/index.ts`                                  |
+| Visual / interaction change | Update stories; adjust or add tests                                             |
+| New interactive control     | Accessible name + target size (see [Accessibility rules](#accessibility-rules)) |
+| Peer dependency surface     | Document in README or story descriptions if needed                              |
+| **Breaking change**         | CHANGELOG.md entry + migration guide (see below)                                |
 
 ## Breaking changes — documentation required
 
@@ -117,6 +118,31 @@ Add a row to the table in `migration-guides/README.md`:
 - Use `mergeClasses` (from `src/utils/merge-classes`) for Tailwind class merging
 - No inline styles or hardcoded values (hex colors, font sizes, etc.)
 - SCSS mixins in `src/styles/` for reusable patterns
+
+## Accessibility rules
+
+Conformance target is **WCAG 2.2 Level AA**, plus **2.5.5 Target Size (Enhanced, AAA)** for interactive controls. See the [Accessibility section of the README](README.md#-accessibility) for the consumer-facing contract and the current exception list.
+
+### Accessible names
+
+- **Icon-only controls must be named.** Resolve the name with `resolveAccessibleName` (`src/utils/accessible-name`), passing candidates in priority order — it returns the first non-empty string. Do not hand-roll the fallback chain.
+- **Never rely on a tooltip alone to name a control.** `DialTooltip` puts its `aria-describedby` on a wrapper `<span>` rather than on the control, and `DialTooltipContent` renders nothing on mobile — so tooltip text never reaches assistive tech. Pass the tooltip to `resolveAccessibleName` as the last candidate.
+- **Only fall back to a tooltip when nothing else names the control.** As an `aria-label` it overrides the element's own content, so a component with a visible label must gate the fallback on that label being absent (see `New/Button`).
+- **Never write `aria-label={props['aria-label']}` after spreading `{...props}`** — the spread already applied it, so the line is a no-op. It has been introduced by copy-paste in four button components; delete it rather than propagating it.
+- **Decorative icons get `aria-hidden="true"`.** Tabler icons render a bare `<svg>` with no `role` and no title, so they need it explicitly.
+
+### Target size
+
+- Add `dial-kit-enhanced-target` to interactive controls that render at **40px or larger**. It grows the pointer target to 44×44 with a transparent pseudo-element and leaves the rendered size untouched, so it is never a visual or breaking change.
+- **Never apply it to `ElementSize.Small` (24px) controls** — the 10px-per-side overhang overlaps adjacent controls in dense toolbars.
+- **Never apply it to `ButtonAppearance.Link`** — exempt under 2.5.5's _Inline_ exception, and it would overlap surrounding copy.
+- A control that cannot conform goes in the README exception table with the reason. Do not silently leave it undocumented.
+
+### Testing a11y
+
+- Assert the **name**, not just the role: `getByRole('button', { name })` or `toHaveAccessibleName(...)`. A bare `getByRole('button')` passes on a button with no accessible name at all, so it cannot catch the defect it looks like it is testing.
+- A test whose assertion still passes with the feature prop removed is not testing that feature — e.g. asserting a button exists proves nothing about its tooltip. Drive the interaction (`user.hover`) and assert the result.
+- jsdom performs no layout, so target-size tests can only assert that `dial-kit-enhanced-target` is applied (and _not_ applied to small/link variants). Verify the geometry by compiling CSS (`npm run build:css`) and reading `dist/index.css`.
 
 ## Development Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions match the git tags on the `development` branch.
 
 ### Breaking Changes
 
+- **`DialSpinner` → `Spinner`** — the spinner is exported as `Spinner` (and `DialSpinnerProps` as `SpinnerProps`), dropping the `Dial*` prefix in line with the 2.0 component naming. Props and behaviour are unchanged; only the import name moves.
+  See [migration guide](migration-guides/0.13.0/spinner-dial-prefix-removal.md).
+- **Border token `focus` → `focus-black`** — the token behind `border-focus` / `outline-focus` was named for its state rather than its value, which left no room for the sibling `focus-blue` token. It is now `focus-black`, backed by `--stroke-focus-black` instead of `--stroke-focus`. The colour is unchanged (`#161B2D`).
+  See [migration guide](migration-guides/0.13.0/focus-border-token-rename.md).
 - **`Notification` (2.0) — live-region role now follows the variant** — the container was hardcoded to `role="alert"` for every variant. `role="alert"` is implicitly `aria-live="assertive"` and interrupts the screen reader, which is wrong for routine feedback and for section messages that are static page content. `error` and `warning` keep `role="alert"`; `info`, `success`, and `loading` now use the polite `role="status"`. Pass an explicit `role` to override.
   Consumers asserting `getByRole('alert')` on a non-error notification must query `status` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ Versions match the git tags on the `development` branch.
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Breaking Changes
+
+- **`Notification` (2.0) — live-region role now follows the variant** — the container was hardcoded to `role="alert"` for every variant. `role="alert"` is implicitly `aria-live="assertive"` and interrupts the screen reader, which is wrong for routine feedback and for section messages that are static page content. `error` and `warning` keep `role="alert"`; `info`, `success`, and `loading` now use the polite `role="status"`. Pass an explicit `role` to override.
+  Consumers asserting `getByRole('alert')` on a non-error notification must query `status` instead.
+
+### Fixed
+
+- **`Notification` (2.0)** — the variant icon is hidden from assistive tech. The `loading` spinner carries its own `role="status"`, so it previously formed a live region nested inside the notification's, announcing the content twice.
+- **`FolderPath`** — the `<nav>` landmark is named "Folder path" instead of inheriting `DialBreadcrumb`'s "Breadcrumb" default, which misdescribed a path with no navigable segments. Added an `ariaLabel` prop to override. Decorative folder and separator icons are now `aria-hidden`.
+- **`InlineSelect`** — the trigger now exposes `aria-expanded`, so screen readers can tell whether the dropdown is open, and accepts an `ariaLabel` prop naming the control (previously it announced only its current value).
+- **`ButtonDropdown` (2.0)** — the trigger button now carries `aria-haspopup` and `aria-expanded` itself. `DialDropdown` sets them on a non-focusable wrapper `<span>`, so assistive tech never reached them.
+- **`Calendar` (2.0)** — day cells are named with their full date (e.g. "Sunday, 15 March 2026") instead of a bare day number; the popover is a named dialog; and the field `label` is associated with the `div[role="button"]` trigger, which `<label htmlFor>` cannot label.
+- **`FabButton`, `DialIconButton`, `IconButton` (2.0)** — an icon-only button with only `tooltipProps` is now named from the tooltip text. A tooltip's `aria-describedby` lands on a wrapper element and is suppressed on mobile, so it never reached assistive tech.
+
+### Added
+
+- **Enhanced pointer targets** — standard-size buttons expose a 44×44 pointer target (WCAG 2.5.5, Level AAA) via the `dial-kit-enhanced-target` utility, with no change to their rendered size. See the [Accessibility section of the README](README.md#-accessibility) for the documented exceptions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The AI DIAL UI Kit is an production-ready React component library designed to st
   - [Development Setup](#development-setup)
   - [Project Structure](#project-structure)
 - [🎨 Theming & Customization](#-theming--customization)
+- [♿ Accessibility](#-accessibility)
+  - [Naming icon-only controls](#naming-icon-only-controls)
+  - [Target size (WCAG 2.5.5, Level AAA)](#target-size-wcag-255-level-aaa)
 - [📖 Storybook](#-storybook)
   - [Development Mode](#development-mode)
   - [Production Build](#production-build)
@@ -169,6 +172,37 @@ The library uses CSS custom properties for comprehensive theming. Override these
 ```
 
 Full list of variables is available [here](tailwind.config.js)
+
+## ♿ Accessibility
+
+### Naming icon-only controls
+
+`DialFabButton`, `DialIconButton`, and `IconButton` render no text, so they need an
+explicit accessible name. Pass `aria-label`; if you pass only a string
+`tooltipProps.tooltip`, it is used as the label instead. Do not rely on the tooltip
+alone to convey the name — a tooltip's `aria-describedby` lands on a wrapper element
+rather than on the control, and tooltips are suppressed entirely on mobile.
+
+### Target size (WCAG 2.5.5, Level AAA)
+
+Standard-size buttons render at 40×40 but expose a **44×44 pointer target** via the
+`dial-kit-enhanced-target` utility, which grows the target with a transparent
+pseudo-element. The visible control is unchanged, so layouts keep their existing
+metrics. WCAG 2.5.5 measures the region that accepts a pointer action, not the
+visible decoration.
+
+These controls are **documented exceptions** and meet Level AA (2.5.8, 24×24) but
+not AAA:
+
+| Control | Size | Why it is excluded |
+| --- | --- | --- |
+| `ElementSize.Small` variants | 24×24 | A 44px target overhangs 10px per side and would overlap adjacent controls in dense toolbars |
+| `ButtonAppearance.Link` | content | Exempt under the 2.5.5 *Inline* exception; expanding it would overlap surrounding copy |
+| `DialCloseButton` | icon-sized | Renders `h-auto w-auto`, so its target follows the caller's icon size |
+| `DialInfoButton` | 24×24 | Fixed small affordance, same overlap constraint as small variants |
+
+Give small-variant controls at least 20px of surrounding space if you need to reach
+AAA in a specific layout, or use the standard size instead.
 
 ## 📖 Storybook
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ explicit accessible name. Pass `aria-label`; if you pass only a string
 alone to convey the name — a tooltip's `aria-describedby` lands on a wrapper element
 rather than on the control, and tooltips are suppressed entirely on mobile.
 
+`InfoButton` names itself from `caption` for the same reason. Pass a short
+`aria-label` when the caption is a full sentence, so the name stays scannable.
+
 ### Target size (WCAG 2.5.5, Level AAA)
 
 Standard-size buttons render at 40×40 but expose a **44×44 pointer target** via the
@@ -199,7 +202,7 @@ not AAA:
 | `ElementSize.Small` variants | 24×24 | A 44px target overhangs 10px per side and would overlap adjacent controls in dense toolbars |
 | `ButtonAppearance.Link` | content | Exempt under the 2.5.5 *Inline* exception; expanding it would overlap surrounding copy |
 | `DialCloseButton` | icon-sized | Renders `h-auto w-auto`, so its target follows the caller's icon size |
-| `DialInfoButton` | 24×24 | Fixed small affordance, same overlap constraint as small variants |
+| `DialInfoButton`, `InfoButton` | 24×24 | Fixed small affordance, same overlap constraint as small variants |
 
 Give small-variant controls at least 20px of surrounding space if you need to reach
 AAA in a specific layout, or use the standard size instead.

--- a/migration-guides/0.13.0/focus-border-token-rename.md
+++ b/migration-guides/0.13.0/focus-border-token-rename.md
@@ -1,0 +1,106 @@
+# Migrating the `focus` border token → `focus-black` — v0.12.x → v0.13.0
+
+## Why this changed
+
+The border token was named `focus` — after the *state* it is used in rather than the *value* it holds. That naming left nowhere to put a second focus colour, so when the blue focus ring arrived it had to be `focus-blue`, an odd sibling to a token whose name implied it covered all focus styling.
+
+Both tokens are now named for their colour: `focus-black` and `focus-blue`. The rendered colour of `focus-black` is identical to the old `focus` (`#161B2D`, grey-1000) — this is a naming change, not a visual one.
+
+## What changed
+
+| Before                       | After                              |
+| ---------------------------- | ---------------------------------- |
+| CSS variable `--stroke-focus` | `--stroke-focus-black`             |
+| `border-focus`               | `border-focus-black`               |
+| `outline-focus`              | `outline-focus-black`              |
+| `divide-focus`               | `divide-focus-black`               |
+| `stroke-focus` (SVG)         | `stroke-focus-black`               |
+
+The token feeds Tailwind's `borderColor`, `outlineColor`, `divideColor`, and `stroke` scales, so every utility built on it moves together.
+
+**Not affected:**
+
+- `controls-focus` / `--controls-stroke-focus` — a separate token, unchanged.
+- `focus-blue` / `--stroke-focus-blue` — unchanged.
+- Tailwind's `focus:` and `focus-visible:` **variants** — unrelated to the token. `focus-visible:outline-focus` becomes `focus-visible:outline-focus-black`; the `focus-visible:` prefix stays exactly as it is.
+
+## Step-by-step migration
+
+### 1. Find all usages
+
+```bash
+grep -rEn "(border|outline|divide|stroke)-focus\b|--stroke-focus\b" src/
+```
+
+The `\b` matters: without it the search also flags `focus-blue` and `--stroke-focus-blue`, which do not change.
+
+### 2. Rename the utilities
+
+**Before:**
+
+```tsx
+<button className="focus-visible:outline focus-visible:outline-focus" />
+```
+
+**After:**
+
+```tsx
+<button className="focus-visible:outline focus-visible:outline-focus-black" />
+```
+
+The same applies inside SCSS `@apply` directives:
+
+```scss
+/* Before */
+.my-input:focus-visible {
+  @apply border-focus;
+}
+
+/* After */
+.my-input:focus-visible {
+  @apply border-focus-black;
+}
+```
+
+### 3. Rename the CSS variable override
+
+Only relevant if you theme the token. Update the custom property name wherever you set it:
+
+**Before:**
+
+```css
+:root {
+  --stroke-focus: #1a1a2e;
+}
+```
+
+**After:**
+
+```css
+:root {
+  --stroke-focus-black: #1a1a2e;
+}
+```
+
+An override left on `--stroke-focus` is **silently ignored** — the utility falls back to the built-in `#161B2D` with no error. This is the one failure mode that neither `typecheck` nor the compiler will catch, so grep for it explicitly.
+
+### 4. Verify
+
+```bash
+npm run typecheck
+npm run test
+```
+
+`typecheck` does not see Tailwind class strings, so also confirm the utilities resolve in the compiled output:
+
+```bash
+npm run build:css
+grep -c "stroke-focus-black" dist/index.css
+```
+
+A stale `border-focus` compiles to nothing at all — the element simply loses its focus border, which is easy to miss without a visual pass. Check focus states in Storybook by tabbing through affected controls.
+
+## Notes
+
+- `ringColor` is **not** wired to this token scale, so `ring-focus-black` does not resolve — just as `ring-focus` did not before. Use `outline-focus-black` for focus rings.
+- The colour value is unchanged, so a correctly-migrated codebase should be pixel-identical to 0.12.x.

--- a/migration-guides/0.13.0/focus-border-token-rename.md
+++ b/migration-guides/0.13.0/focus-border-token-rename.md
@@ -2,19 +2,19 @@
 
 ## Why this changed
 
-The border token was named `focus` — after the *state* it is used in rather than the *value* it holds. That naming left nowhere to put a second focus colour, so when the blue focus ring arrived it had to be `focus-blue`, an odd sibling to a token whose name implied it covered all focus styling.
+The border token was named `focus` — after the _state_ it is used in rather than the _value_ it holds. That naming left nowhere to put a second focus colour, so when the blue focus ring arrived it had to be `focus-blue`, an odd sibling to a token whose name implied it covered all focus styling.
 
 Both tokens are now named for their colour: `focus-black` and `focus-blue`. The rendered colour of `focus-black` is identical to the old `focus` (`#161B2D`, grey-1000) — this is a naming change, not a visual one.
 
 ## What changed
 
-| Before                       | After                              |
-| ---------------------------- | ---------------------------------- |
-| CSS variable `--stroke-focus` | `--stroke-focus-black`             |
-| `border-focus`               | `border-focus-black`               |
-| `outline-focus`              | `outline-focus-black`              |
-| `divide-focus`               | `divide-focus-black`               |
-| `stroke-focus` (SVG)         | `stroke-focus-black`               |
+| Before                        | After                  |
+| ----------------------------- | ---------------------- |
+| CSS variable `--stroke-focus` | `--stroke-focus-black` |
+| `border-focus`                | `border-focus-black`   |
+| `outline-focus`               | `outline-focus-black`  |
+| `divide-focus`                | `divide-focus-black`   |
+| `stroke-focus` (SVG)          | `stroke-focus-black`   |
 
 The token feeds Tailwind's `borderColor`, `outlineColor`, `divideColor`, and `stroke` scales, so every utility built on it moves together.
 

--- a/migration-guides/0.13.0/spinner-dial-prefix-removal.md
+++ b/migration-guides/0.13.0/spinner-dial-prefix-removal.md
@@ -1,0 +1,69 @@
+# Migrating `DialSpinner` → `Spinner` — v0.12.x → v0.13.0
+
+## Why this changed
+
+The spinner is part of the 2.0 component set, which drops the `Dial*` prefix. Keeping `DialSpinner` alongside the unprefixed 2.0 components made the export list read as two conventions at once, with no signal about which era a component belongs to.
+
+This is a **rename only**. The component's props, defaults, DOM, roles, and styling are untouched.
+
+## What changed
+
+| Before             | After          |
+| ------------------ | -------------- |
+| `DialSpinner`      | `Spinner`      |
+| `DialSpinnerProps` | `SpinnerProps` |
+
+Unchanged: `size` (default `40`), `className`, `fullWidth` (default `false`), `ariaLabel` (default `"Loading"`), the outer `role="status"` container, and the inner `role="img"` ring.
+
+The Storybook entry also moved from `DIAL/Status/Spinner` to `Components_2_0/Spinner`. This affects story URLs only, not consumers of the package.
+
+## Step-by-step migration
+
+### 1. Find all usages
+
+```bash
+grep -rn "DialSpinner" src/
+```
+
+### 2. Rename the import and the JSX tag
+
+**Before:**
+
+```tsx
+import { DialSpinner, type DialSpinnerProps } from '@epam/ai-dial-ui-kit';
+
+const Busy: FC<DialSpinnerProps> = (props) => <DialSpinner {...props} />;
+
+<DialSpinner size={24} fullWidth ariaLabel="Loading results" />;
+```
+
+**After:**
+
+```tsx
+import { Spinner, type SpinnerProps } from '@epam/ai-dial-ui-kit';
+
+const Busy: FC<SpinnerProps> = (props) => <Spinner {...props} />;
+
+<Spinner size={24} fullWidth ariaLabel="Loading results" />;
+```
+
+If `Spinner` collides with a local component of the same name, alias the import rather than renaming your own:
+
+```tsx
+import { Spinner as DialSpinner } from '@epam/ai-dial-ui-kit';
+```
+
+### 3. Verify
+
+```bash
+npm run typecheck
+npm run test
+```
+
+`typecheck` catches every usage — there is no runtime-only path to miss, since the old name is removed from the barrel and the import fails to resolve.
+
+## Notes
+
+- Tests that render the spinner need no assertion changes: it still exposes `role="status"` on the container and `role="img"` with the `ariaLabel` name on the ring.
+- `DialLoader` is a different component and is **not** renamed.
+- `Notification`'s `loading` variant renders this spinner internally; no consumer change is needed there.

--- a/migration-guides/README.md
+++ b/migration-guides/README.md
@@ -16,6 +16,8 @@ migration-guides/
 | ------- | ----- | ------- |
 | 0.11.0 | [dropdown-menu-prop-flatten](0.11.0/dropdown-menu-prop-flatten.md) | `DialDropdown`/`DialDropdownIcon` `menu` prop replaced with flat `items`, `onItemClick`, `menuHeader`, `menuFooter` props |
 | 0.12.0 | [legacy-typography-classes-removal](0.12.0/legacy-typography-classes-removal.md) | Legacy `dial-h*`, `dial-body`, `dial-small*`, `dial-tiny*`, `dial-caption` classes removed in favor of the `dial-*-text` scale |
+| 0.13.0 | [spinner-dial-prefix-removal](0.13.0/spinner-dial-prefix-removal.md) | `DialSpinner`/`DialSpinnerProps` renamed to `Spinner`/`SpinnerProps` |
+| 0.13.0 | [focus-border-token-rename](0.13.0/focus-border-token-rename.md) | Border token `focus` renamed to `focus-black` (`--stroke-focus` → `--stroke-focus-black`) |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1275,13 +1275,13 @@
       "peer": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1623,13 +1623,13 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -8790,9 +8790,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9716,9 +9716,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -91,7 +91,12 @@ export const DialButton: FC<DialButtonProps> = ({
     size === ElementSize.Small ? 'dial-tiny-semi-text' : 'dial-small-semi-text',
     appearance !== ButtonAppearance.Link &&
       (size === ElementSize.Small ? 'h-[24px] px-2' : 'h-[40px] px-3'),
-    'disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus outline-offset-0',
+    // A link-appearance button sits inline in text, where WCAG 2.5.5 exempts
+    // it and an expanded target would overlap the surrounding copy.
+    size !== ElementSize.Small &&
+      appearance !== ButtonAppearance.Link &&
+      'dial-kit-enhanced-target',
+    'disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus-black outline-offset-0',
     className,
   );
 

--- a/src/components/Button/__tests__/Button.spec.tsx
+++ b/src/components/Button/__tests__/Button.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 import { DialButton } from '../Button';
 import { ButtonAppearance, ButtonVariant } from '@/index';
+import { ElementSize } from '@/types/size';
 
 describe('Dial UI Kit :: DialButton', () => {
   test('Should render with string label and be accessible by role', () => {
@@ -92,7 +93,7 @@ describe('Dial UI Kit :: DialButton', () => {
     const button = screen.getByRole('button', { name: 'Focus test' });
     expect(button).toHaveClass(
       'focus-visible:outline',
-      'focus-visible:outline-focus',
+      'focus-visible:outline-focus-black',
       'outline-offset-0',
     );
   });
@@ -196,4 +197,32 @@ describe('Dial UI Kit :: DialButton', () => {
       expect(btn).toHaveClass(expectedClass);
     },
   );
+
+  test('Should enhance the pointer target at standard size', () => {
+    render(<DialButton label="Save" />);
+
+    expect(screen.getByRole('button')).toHaveClass('dial-kit-enhanced-target');
+  });
+
+  test('Should not enhance the pointer target at small size', () => {
+    render(<DialButton label="Save" size={ElementSize.Small} />);
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
+  });
+
+  test('Should not enhance the pointer target for link appearance', () => {
+    render(
+      <DialButton
+        label="Save"
+        variant={ButtonVariant.Primary}
+        appearance={ButtonAppearance.Link}
+      />,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
+  });
 });

--- a/src/components/Button/constants.ts
+++ b/src/components/Button/constants.ts
@@ -26,4 +26,5 @@ export const variantClassMap: Record<ButtonVariant, Record<string, string>> = {
   [ButtonVariant.Tertiary]: {
     [ButtonAppearance.Ghost]: 'dial-tertiary-ghost-button',
   },
+  [ButtonVariant.Static]: {},
 };

--- a/src/components/DropdownIcon/DropdownIcon.tsx
+++ b/src/components/DropdownIcon/DropdownIcon.tsx
@@ -97,7 +97,7 @@ export const DialDropdownIcon: FC<DialDropdownIconProps> = ({
         className={mergeClasses(
           'group flex items-center justify-center rounded border border-transparent bg-layer-4 text-primary',
           'enabled:hover:bg-accent-primary-alpha enabled:active:bg-controls-accent-primary-alpha-active',
-          'focus-visible:border-focus focus-visible:outline-none disabled:cursor-not-allowed disabled:text-controls-secondary-disable disabled:opacity-75',
+          'focus-visible:border-focus-black focus-visible:outline-none disabled:cursor-not-allowed disabled:text-controls-secondary-disable disabled:opacity-75',
           isSmall ? 'h-8 px-2' : 'h-10 px-2',
           !showCaret ? squareSizeClass : undefined,
           buttonClassName,

--- a/src/components/FabButton/FabButton.spec.tsx
+++ b/src/components/FabButton/FabButton.spec.tsx
@@ -1,50 +1,109 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import { FabButton } from './FabButton';
 
 describe('Dial UI Kit :: DialFabButton', () => {
   test('Should render with icon and be accessible by role', () => {
-    render(<FabButton icon={<div>icon</div>} />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    render(<FabButton icon={<div>icon</div>} aria-label="Fab" />);
+
+    expect(screen.getByRole('button', { name: 'Fab' })).toBeInTheDocument();
     expect(screen.getByText('icon')).toBeInTheDocument();
+  });
+
+  test('Should render a decorative default icon when none is provided', () => {
+    const { container } = render(<FabButton aria-label="Scroll to bottom" />);
+
+    const defaultIcon = container.querySelector('svg');
+    expect(defaultIcon).toBeInTheDocument();
+    expect(defaultIcon).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('button')).toHaveAccessibleName('Scroll to bottom');
+  });
+
+  test('Should use the aria-label as the accessible name', () => {
+    render(<FabButton aria-label="Scroll to bottom" />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Scroll to bottom');
+  });
+
+  test('Should fall back to the tooltip text as the accessible name', () => {
+    render(<FabButton tooltipProps={{ tooltip: 'Scroll to bottom' }} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Scroll to bottom');
+  });
+
+  test('Should prefer the aria-label over the tooltip text', () => {
+    render(
+      <FabButton
+        aria-label="Scroll to bottom"
+        tooltipProps={{ tooltip: 'Tooltip text' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Scroll to bottom');
+  });
+
+  test('Should default the type to button to avoid form submission', () => {
+    render(<FabButton aria-label="Fab" />);
+
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
 
   test('Should call onClick when clicked', () => {
     const onClick = vi.fn();
     render(<FabButton icon={<div>icon</div>} onClick={onClick} />);
+
     fireEvent.click(screen.getByRole('button'));
+
     expect(onClick).toHaveBeenCalled();
   });
 
   test('Should be disabled when disabled prop is true', () => {
     render(<FabButton icon={<div>icon</div>} disabled />);
+
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
   test('Should not call onClick when disabled', () => {
     const onClick = vi.fn();
     render(<FabButton icon={<div>icon</div>} disabled onClick={onClick} />);
+
     fireEvent.click(screen.getByRole('button'));
+
     expect(onClick).not.toHaveBeenCalled();
   });
 
   test('Should apply custom CSS class', () => {
     render(<FabButton icon={<div>icon</div>} className="custom-fab-class" />);
+
     expect(screen.getByRole('button')).toHaveClass('custom-fab-class');
   });
 
   test('Should always have dial-fab-button class', () => {
     render(<FabButton icon={<div>icon</div>} />);
+
     expect(screen.getByRole('button')).toHaveClass('dial-kit-fab-button');
   });
 
-  test('Should render tooltip when tooltipProps provided', () => {
+  test('Should enhance the pointer target to meet WCAG 2.5.5', () => {
+    render(<FabButton aria-label="Scroll to bottom" />);
+
+    expect(screen.getByRole('button')).toHaveClass('dial-kit-enhanced-target');
+  });
+
+  test('Should show the tooltip on hover when tooltipProps provided', async () => {
+    const user = userEvent.setup();
     render(
       <FabButton
         icon={<div>icon</div>}
         tooltipProps={{ tooltip: 'Test tooltip' }}
       />,
     );
-    expect(screen.getByRole('button')).toBeInTheDocument();
+
+    await user.hover(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test tooltip')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/FabButton/FabButton.stories.tsx
+++ b/src/components/FabButton/FabButton.stories.tsx
@@ -52,6 +52,21 @@ export const WithTooltip: Story = {
   },
 };
 
+export const TooltipAsAccessibleName: Story = {
+  args: {
+    'aria-label': undefined,
+    tooltipProps: { tooltip: 'Scroll to bottom' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The button is icon-only, so it needs an accessible name. With no `aria-label`, a string `tooltipProps.tooltip` is used as the label — the tooltip itself is not announced by screen readers and is hidden on mobile.',
+      },
+    },
+  },
+};
+
 export const AllStates: Story = {
   render: () => (
     <div className="flex flex-col gap-4">

--- a/src/components/FabButton/FabButton.tsx
+++ b/src/components/FabButton/FabButton.tsx
@@ -10,6 +10,7 @@ import {
   type DialTooltipProps,
 } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
+import { resolveAccessibleName } from '@/utils/accessible-name';
 import { IconArrowNarrowDown } from '@tabler/icons-react';
 
 type TooltipProps = Omit<DialTooltipProps, 'children'>;
@@ -37,6 +38,10 @@ export interface FabButtonProps extends DetailedHTMLProps<
  *
  * inherits all properties from `ButtonHTMLAttributes<HTMLButtonElement>`
  *
+ * The button is icon-only, so it needs an accessible name: pass `aria-label`,
+ * or a string `tooltipProps.tooltip`, which is used as the label when no
+ * `aria-label` is given.
+ *
  * @param icon - Icon to display inside the button
  * @param [tooltipProps] - Optional tooltip configuration
  */
@@ -49,7 +54,8 @@ export const FabButton: FC<FabButtonProps> = ({
 }) => {
   const btnClassName = mergeClasses(
     'flex items-center justify-center rounded-full size-[40px]',
-    'dial-kit-fab-button disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus outline-offset-0',
+    'dial-kit-enhanced-target',
+    'dial-kit-fab-button disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus-black outline-offset-0',
     className,
   );
 
@@ -58,9 +64,14 @@ export const FabButton: FC<FabButtonProps> = ({
       {...props}
       type={type}
       className={btnClassName}
-      aria-label={props['aria-label']}
+      aria-label={resolveAccessibleName(
+        props['aria-label'],
+        tooltipProps?.tooltip,
+      )}
     >
-      {icon || <IconArrowNarrowDown size={24} stroke={1.5} />}
+      {icon || (
+        <IconArrowNarrowDown size={24} stroke={1.5} aria-hidden="true" />
+      )}
     </button>
   );
 

--- a/src/components/IconButton/IconButton.spec.tsx
+++ b/src/components/IconButton/IconButton.spec.tsx
@@ -1,23 +1,63 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
+import { ElementSize } from '@/types/size';
 import { DialIconButton } from './IconButton';
 
 describe('Dial UI Kit :: DialIconButton', () => {
   test('Should render with string label and be accessible by role', () => {
     render(<DialIconButton icon={<div>icon</div>} />);
+
     expect(screen.getByRole('button')).toBeInTheDocument();
     expect(screen.getByText('icon')).toBeInTheDocument();
+  });
+
+  test('Should use the aria-label as the accessible name', () => {
+    render(<DialIconButton icon={<div>icon</div>} aria-label="Delete" />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete');
+  });
+
+  test('Should fall back to the tooltip text as the accessible name', () => {
+    render(
+      <DialIconButton
+        icon={<div>icon</div>}
+        tooltipProps={{ tooltip: 'Delete' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete');
+  });
+
+  test('Should prefer the aria-label over the tooltip text', () => {
+    render(
+      <DialIconButton
+        icon={<div>icon</div>}
+        aria-label="Delete"
+        tooltipProps={{ tooltip: 'Tooltip text' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete');
+  });
+
+  test('Should default the type to button to avoid form submission', () => {
+    render(<DialIconButton icon={<div>icon</div>} />);
+
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
 
   test('Should call onClick when clicked', () => {
     const onClick = vi.fn();
     render(<DialIconButton icon={<div>icon</div>} onClick={onClick} />);
+
     fireEvent.click(screen.getByRole('button'));
+
     expect(onClick).toHaveBeenCalled();
   });
 
   test('Should be disabled when disabled prop is true', () => {
     render(<DialIconButton icon={<div>icon</div>} disabled />);
+
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
@@ -25,7 +65,28 @@ describe('Dial UI Kit :: DialIconButton', () => {
     render(
       <DialIconButton icon={<div>icon</div>} className="custom-button-class" />,
     );
+
     const button = screen.getByRole('button');
     expect(button).toHaveClass('custom-button-class');
+  });
+
+  test('Should enhance the pointer target at standard size', () => {
+    render(<DialIconButton icon={<div>icon</div>} aria-label="Delete" />);
+
+    expect(screen.getByRole('button')).toHaveClass('dial-kit-enhanced-target');
+  });
+
+  test('Should not enhance the pointer target at small size', () => {
+    render(
+      <DialIconButton
+        icon={<div>icon</div>}
+        aria-label="Delete"
+        size={ElementSize.Small}
+      />,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
   });
 });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -12,6 +12,7 @@ import {
   type DialTooltipProps,
 } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
+import { resolveAccessibleName } from '@/utils/accessible-name';
 import { ElementSize } from '@/types/size';
 
 type TooltipProps = Omit<DialTooltipProps, 'children'>;
@@ -50,6 +51,10 @@ export interface DialIconButtonProps extends DetailedHTMLProps<
  *
  * inherits all properties from the `ButtonHTMLAttributes<HTMLButtonElement>`
  *
+ * The button is icon-only, so it needs an accessible name: pass `aria-label`,
+ * or a string `tooltipProps.tooltip`, which is used as the label when no
+ * `aria-label` is given.
+ *
  * @param [variant] - Defines the visual style of the button
  * @param [appearance=ButtonAppearance.Solid] - Defines the type of the button
  * @param [size=ElementSize.Standard] - Defines the size of the button
@@ -68,8 +73,10 @@ export const DialIconButton: FC<DialIconButtonProps> = ({
 }) => {
   const btnClassName = mergeClasses(
     variant && getButtonClassNames(variant, appearance),
-    size === ElementSize.Small ? 'h-[24px] w-[24px]' : 'h-[40px] w-[40px]',
-    'dial-icon-button disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus outline-offset-0 disabled:text-controls-secondary-disable',
+    size === ElementSize.Small
+      ? 'h-[24px] w-[24px]'
+      : 'h-[40px] w-[40px] dial-kit-enhanced-target',
+    'dial-icon-button disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-focus-black outline-offset-0 disabled:text-controls-secondary-disable',
     className,
   );
 
@@ -78,7 +85,10 @@ export const DialIconButton: FC<DialIconButtonProps> = ({
       {...props}
       type={type}
       className={btnClassName}
-      aria-label={props['aria-label']}
+      aria-label={resolveAccessibleName(
+        props['aria-label'],
+        tooltipProps?.tooltip,
+      )}
     >
       {icon}
     </button>

--- a/src/components/New/Button/Button.stories.tsx
+++ b/src/components/New/Button/Button.stories.tsx
@@ -103,7 +103,7 @@ export const Focus: Story = {
     docs: {
       description: {
         story:
-          'Keyboard focus state — a 1px outline painted with the `--stroke-focus` token.',
+          'Keyboard focus state — a 1px outline painted with the `--stroke-focus-black` token.',
       },
     },
   },

--- a/src/components/New/Button/Button.tsx
+++ b/src/components/New/Button/Button.tsx
@@ -13,6 +13,7 @@ import {
 import { ButtonAppearance, ButtonVariant } from '@/types/button';
 import { ElementSize } from '@/types/size';
 import { mergeClasses } from '@/utils/merge-classes';
+import { resolveAccessibleName } from '@/utils/accessible-name';
 import { getButtonClassNames } from './utils';
 
 type TooltipProps = Omit<DialTooltipProps, 'children'>;
@@ -56,6 +57,11 @@ export interface ButtonProps extends DetailedHTMLProps<
  *
  * inherits all properties from the `ButtonHTMLAttributes<HTMLButtonElement>`
  *
+ * The accessible name is taken from a string `label` first, then `aria-label`,
+ * then — only for a button with no `label` at all — a string
+ * `tooltipProps.tooltip`. Pass `aria-label` when `label` is a ReactNode, since
+ * an icon-only button is otherwise unnamed.
+ *
  * @param [label] - The content of the button. Can be any React node.
  * @param [variant] - Defines the visual style of the button
  * @param [appearance=ButtonAppearance.Solid] - Defines the type of the button
@@ -86,15 +92,28 @@ export const Button: FC<ButtonProps> = ({
     size === ElementSize.Small ? 'h-[24px] gap-1' : 'h-[40px] gap-2',
     appearance !== ButtonAppearance.Link &&
       (size === ElementSize.Small ? 'px-2' : 'px-4'),
+    // A link-appearance button sits inline in text, where WCAG 2.5.5 exempts
+    // it and an expanded target would overlap the surrounding copy.
+    size !== ElementSize.Small &&
+      appearance !== ButtonAppearance.Link &&
+      'dial-kit-enhanced-target',
     className,
   );
+
+  // A tooltip only names the button when nothing else does: as an `aria-label`
+  // it would otherwise override a visible `label` that is a ReactNode.
+  const tooltipFallback = label ? undefined : tooltipProps?.tooltip;
 
   const button = (
     <button
       {...props}
       type={type}
       className={btnClassName}
-      aria-label={(typeof label === 'string' && label) || props['aria-label']}
+      aria-label={resolveAccessibleName(
+        typeof label === 'string' ? label : undefined,
+        props['aria-label'],
+        tooltipFallback,
+      )}
     >
       <DialIcon icon={iconBefore} />
       {label && <span className={textClassName}>{label}</span>}

--- a/src/components/New/Button/__tests__/Button.spec.tsx
+++ b/src/components/New/Button/__tests__/Button.spec.tsx
@@ -142,6 +142,70 @@ describe('Dial UI Kit :: DialButton', () => {
     expect(screen.getByText('React Node Label')).toBeInTheDocument();
   });
 
+  test('Should name an icon-only button from the tooltip text', () => {
+    render(
+      <Button
+        iconBefore={<span>Icon</span>}
+        tooltipProps={{ tooltip: 'Save' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Save');
+  });
+
+  test('Should prefer aria-label over the tooltip text on an icon-only button', () => {
+    render(
+      <Button
+        iconBefore={<span>Icon</span>}
+        aria-label="Save draft"
+        tooltipProps={{ tooltip: 'Save' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Save draft');
+  });
+
+  test('Should not let the tooltip override a ReactNode label', () => {
+    render(
+      <Button
+        label={<span>Visible label</span>}
+        tooltipProps={{ tooltip: 'Tooltip text' }}
+      />,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveAttribute('aria-label');
+    expect(button).toHaveAccessibleName('Visible label');
+  });
+
+  test('Should enhance the pointer target at standard size', () => {
+    render(<Button label="Save" />);
+
+    expect(screen.getByRole('button')).toHaveClass('dial-kit-enhanced-target');
+  });
+
+  test('Should not enhance the pointer target at small size', () => {
+    render(<Button label="Save" size={ElementSize.Small} />);
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
+  });
+
+  test('Should not enhance the pointer target for link appearance', () => {
+    render(
+      <Button
+        label="Save"
+        variant={ButtonVariant.Primary}
+        appearance={ButtonAppearance.Link}
+      />,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
+  });
+
   test('Should have correct button type', () => {
     render(<Button label="Type test" />);
     const button = screen.getByRole('button', { name: 'Type test' });

--- a/src/components/New/ButtonDropdown/ButtonDropdown.spec.tsx
+++ b/src/components/New/ButtonDropdown/ButtonDropdown.spec.tsx
@@ -29,6 +29,21 @@ describe('Dial UI Kit :: DialButtonDropdown', () => {
     const button = screen.getByRole('button', { name: 'Menu' });
     expect(button).toBeInTheDocument();
     expect(button).toHaveClass('dial-kit-neutral-outlined-button');
+
+    const icon = button.querySelector('svg');
+    expect(icon).toHaveClass('transition-transform');
+    expect(icon).not.toHaveClass('rotate-180');
+  });
+
+  test('Should rotate the chevron while the dropdown is open', () => {
+    render(<ButtonDropdown title="Menu" items={items} />);
+    const button = screen.getByRole('button', { name: 'Menu' });
+
+    fireEvent.click(button);
+    expect(button.querySelector('svg')).toHaveClass('rotate-180');
+
+    fireEvent.click(button);
+    expect(button.querySelector('svg')).not.toHaveClass('rotate-180');
   });
 
   test('Should toggle dropdown on button click', () => {
@@ -82,5 +97,24 @@ describe('Dial UI Kit :: DialButtonDropdown', () => {
     );
     const button = screen.getByRole('button', { name: 'Button Variant Test' });
     expect(button).toHaveClass('dial-kit-neutral-outlined-button');
+  });
+
+  test('Should expose the menu popup on the button itself', () => {
+    render(<ButtonDropdown title="Menu" items={items} />);
+
+    // DialDropdown sets these on a wrapper span, which assistive tech never
+    // reaches — they have to be on the focusable button.
+    const button = screen.getByRole('button', { name: 'Menu' });
+    expect(button).toHaveAttribute('aria-haspopup', 'menu');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('Should reflect the open state on the button', () => {
+    render(<ButtonDropdown title="Menu" items={items} />);
+    const button = screen.getByRole('button', { name: 'Menu' });
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/src/components/New/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/New/ButtonDropdown/ButtonDropdown.tsx
@@ -52,10 +52,6 @@ export const ButtonDropdown: FC<ButtonDropdownProps> = ({
           iconAfter={icon}
           variant={variant || ButtonVariant.Primary}
           appearance={appearance || ButtonAppearance.Solid}
-          // `DialDropdown` puts these on the wrapper `<span>` it renders around
-          // the trigger. That span is neither focusable nor exposed as a
-          // control, so a screen reader on this button would otherwise never
-          // learn that it opens a menu, nor whether the menu is open.
           aria-haspopup="menu"
           aria-expanded={isDropdownOpen}
         />

--- a/src/components/New/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/New/ButtonDropdown/ButtonDropdown.tsx
@@ -5,7 +5,7 @@ import { DialDropdown } from '@/components/Dropdown/Dropdown';
 import type { DropdownItem } from '@/models/dropdown';
 import { ButtonAppearance, ButtonVariant } from '@/types/button';
 import { Button } from '../Button/Button';
-import { buttonChevronDown, buttonChevronUp } from './constants';
+import { getButtonChevron } from './constants';
 
 export interface ButtonDropdownProps extends Omit<
   DialButtonProps,
@@ -38,7 +38,7 @@ export const ButtonDropdown: FC<ButtonDropdownProps> = ({
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const icon = useMemo(() => {
-    return isDropdownOpen ? buttonChevronUp : buttonChevronDown;
+    return getButtonChevron(isDropdownOpen);
   }, [isDropdownOpen]);
 
   return (
@@ -52,6 +52,12 @@ export const ButtonDropdown: FC<ButtonDropdownProps> = ({
           iconAfter={icon}
           variant={variant || ButtonVariant.Primary}
           appearance={appearance || ButtonAppearance.Solid}
+          // `DialDropdown` puts these on the wrapper `<span>` it renders around
+          // the trigger. That span is neither focusable nor exposed as a
+          // control, so a screen reader on this button would otherwise never
+          // learn that it opens a menu, nor whether the menu is open.
+          aria-haspopup="menu"
+          aria-expanded={isDropdownOpen}
         />
       </DialDropdown>
     </div>

--- a/src/components/New/ButtonDropdown/constants.tsx
+++ b/src/components/New/ButtonDropdown/constants.tsx
@@ -1,5 +1,11 @@
 import { DIAL_ICON_SIZE } from '@/constants/icon';
-import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import { mergeClasses } from '@/utils/merge-classes';
+import { IconChevronDown } from '@tabler/icons-react';
 
-export const buttonChevronDown = <IconChevronDown size={DIAL_ICON_SIZE.SM} />;
-export const buttonChevronUp = <IconChevronUp size={DIAL_ICON_SIZE.SM} />;
+export const getButtonChevron = (isOpen: boolean) => (
+  <IconChevronDown
+    size={DIAL_ICON_SIZE.SM}
+    aria-hidden
+    className={mergeClasses('transition-transform', isOpen && 'rotate-180')}
+  />
+);

--- a/src/components/New/Calendar/Calendar.spec.tsx
+++ b/src/components/New/Calendar/Calendar.spec.tsx
@@ -35,7 +35,9 @@ describe('Dial UI Kit :: Calendar', () => {
       fireEvent.click(screen.getByRole('button', { name: '11 Mar 2026' }));
       expect(screen.getByText('March 2026')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', { name: '15' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Sunday, 15 March 2026' }),
+      );
       expect(onChange).toHaveBeenCalledWith(new Date(2026, 2, 15));
       expect(screen.queryByText('March 2026')).not.toBeInTheDocument();
     });
@@ -163,6 +165,68 @@ describe('Dial UI Kit :: Calendar', () => {
       expect(
         screen.getByRole('button', { name: 'Select day' }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    test('Should name each day cell with its full date', () => {
+      render(
+        <Calendar mode={CalendarMode.Date} value={new Date(2026, 2, 11)} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '11 Mar 2026' }));
+
+      expect(
+        screen.getByRole('button', { name: 'Sunday, 1 March 2026' }),
+      ).toBeInTheDocument();
+    });
+
+    test('Should distinguish days spilling over from an adjacent month', () => {
+      render(
+        <Calendar mode={CalendarMode.Date} value={new Date(2026, 2, 11)} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '11 Mar 2026' }));
+
+      expect(
+        screen.getByRole('button', { name: 'Saturday, 28 February 2026' }),
+      ).toBeInTheDocument();
+    });
+
+    test('Should name the popover so it is not announced as an unlabelled dialog', () => {
+      render(<Calendar mode={CalendarMode.Date} label="Start date" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Start date/ }));
+
+      expect(
+        screen.getByRole('dialog', { name: 'Start date' }),
+      ).toBeInTheDocument();
+    });
+
+    test('Should name the trigger from both the label and the current value', () => {
+      render(
+        <Calendar
+          mode={CalendarMode.Date}
+          label="Start date"
+          value={new Date(2026, 2, 11)}
+        />,
+      );
+
+      // `<label htmlFor>` is inert on a div[role="button"], so without the
+      // explicit wiring the field name would be missing entirely.
+      expect(
+        screen.getByRole('button', { name: 'Start date 11 Mar 2026' }),
+      ).toBeInTheDocument();
+    });
+
+    test('Should hide the decorative weekday header row from assistive tech', () => {
+      render(
+        <Calendar mode={CalendarMode.Date} value={new Date(2026, 2, 11)} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '11 Mar 2026' }));
+
+      expect(screen.getByText('Mon')).toHaveAttribute('aria-hidden', 'true');
     });
   });
 

--- a/src/components/New/Calendar/Calendar.tsx
+++ b/src/components/New/Calendar/Calendar.tsx
@@ -12,7 +12,14 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { IconChevronDown } from '@tabler/icons-react';
-import { type FC, type ReactNode, useEffect, useMemo, useState } from 'react';
+import {
+  type FC,
+  type ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react';
 
 import { DialLabel } from '@/components/Label/Label';
 import { StaticIconButton } from '@/components/New/IconButton/IconButtonWrappers';
@@ -37,6 +44,7 @@ import {
 } from './constants';
 import {
   formatDateLabel,
+  formatDayAriaLabel,
   formatMonthLabel,
   formatTimeLabel,
   getMonthGrid,
@@ -74,6 +82,14 @@ interface CalendarPopoverFieldProps {
   trigger: ReactNode;
   panelClassName?: string;
   panel: (close: () => void) => ReactNode;
+  /**
+   * Ids naming the trigger. The trigger is a `div[role="button"]`, which is not
+   * a labelable element, so the `<label htmlFor>` above it is inert — the name
+   * has to be wired up explicitly.
+   */
+  labelledBy?: string;
+  /** Accessible name for the popover, which is exposed as `role="dialog"`. */
+  panelLabel: string;
 }
 
 const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
@@ -83,6 +99,8 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
   trigger,
   panelClassName,
   panel,
+  labelledBy,
+  panelLabel,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -112,10 +130,11 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-disabled={disabled}
+        aria-labelledby={labelledBy}
         tabIndex={disabled ? -1 : 0}
         className={mergeClasses(
           calendarFieldBaseClassName,
-          'focus-visible:outline focus-visible:outline-focus',
+          'focus-visible:outline focus-visible:outline-focus-black',
           invalid && calendarFieldInvalidClassName,
           disabled && calendarFieldDisabledClassName,
         )}
@@ -135,6 +154,7 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
             <div
               ref={refs.setFloating}
               style={floatingStyles}
+              aria-label={panelLabel}
               className={mergeClasses(calendarPopoverClassName, panelClassName)}
               {...getFloatingProps()}
             >
@@ -252,6 +272,14 @@ export const Calendar: FC<CalendarProps> = ({
   const resolvedPlaceholder =
     placeholder ?? calendarModeDefaultPlaceholder[mode];
   const dateValue = value instanceof Date ? value : null;
+
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const labelId = `${fieldId}-label`;
+  // Name the trigger from the label *and* its own content, so the field name
+  // and the current value are both announced. Without the self-reference the
+  // label would replace the value rather than precede it.
+  const triggerLabelledBy = label ? `${labelId} ${fieldId}` : undefined;
   const [visibleMonth, setVisibleMonth] = useState(
     () => dateValue ?? new Date(),
   );
@@ -307,9 +335,9 @@ export const Calendar: FC<CalendarProps> = ({
 
     return (
       <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-        {label && <DialLabel label={label} htmlFor={id} />}
+        {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
         <TimeField
-          id={id}
+          id={fieldId}
           value={timeValue}
           onChange={(next) => onChange?.(next)}
           disabled={disabled}
@@ -326,11 +354,13 @@ export const Calendar: FC<CalendarProps> = ({
 
     return (
       <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-        {label && <DialLabel label={label} htmlFor={id} />}
+        {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
         <CalendarPopoverField
-          id={id}
+          id={fieldId}
           disabled={disabled}
           invalid={invalid}
+          labelledBy={triggerLabelledBy}
+          panelLabel={label ?? resolvedPlaceholder}
           trigger={
             <>
               <span
@@ -343,12 +373,17 @@ export const Calendar: FC<CalendarProps> = ({
               </span>
               <IconChevronDown
                 size={DIAL_ICON_SIZE.MD}
+                aria-hidden="true"
                 className={calendarFieldIconClassName}
               />
             </>
           }
           panel={(close) => (
-            <div role="listbox" className="flex flex-col gap-0.5">
+            <div
+              role="listbox"
+              aria-label={label ?? resolvedPlaceholder}
+              className="flex flex-col gap-0.5"
+            >
               {weekdayOptions.map((option) => (
                 <button
                   key={option.value}
@@ -357,7 +392,7 @@ export const Calendar: FC<CalendarProps> = ({
                   aria-selected={option.value === weekdayValue}
                   className={mergeClasses(
                     'flex w-full items-center rounded-lg px-3 py-2 text-left dial-small-text text-primary hover:bg-accent-primary-alpha',
-                    'focus-visible:outline focus-visible:outline-focus',
+                    'focus-visible:outline focus-visible:outline-focus-black',
                     option.value === weekdayValue && 'bg-accent-primary-alpha',
                   )}
                   onClick={() => {
@@ -377,11 +412,13 @@ export const Calendar: FC<CalendarProps> = ({
 
   return (
     <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-      {label && <DialLabel label={label} htmlFor={id} />}
+      {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
       <CalendarPopoverField
-        id={id}
+        id={fieldId}
         disabled={disabled}
         invalid={invalid}
+        labelledBy={triggerLabelledBy}
+        panelLabel={label ?? resolvedPlaceholder}
         trigger={
           <>
             <span
@@ -419,9 +456,15 @@ export const Calendar: FC<CalendarProps> = ({
             </div>
 
             <div className="grid grid-cols-7 gap-y-1 text-center">
+              {/*
+                Abbreviations ("Mo", "Tu") that are not associated with their
+                columns, so they read as loose text. Each day button already
+                announces its own weekday, making these purely visual.
+              */}
               {weekdayShortLabels.map((weekday) => (
                 <div
                   key={weekday}
+                  aria-hidden="true"
                   className="dial-tiny-text py-1 text-secondary"
                 >
                   {weekday}
@@ -439,6 +482,9 @@ export const Calendar: FC<CalendarProps> = ({
                     key={day.toISOString()}
                     type="button"
                     disabled={dayDisabled}
+                    // The visible text is just the day number, which announces
+                    // as a bare "15" with no month, year, or weekday.
+                    aria-label={formatDayAriaLabel(day, locale)}
                     aria-pressed={selected}
                     aria-current={isToday ? 'date' : undefined}
                     className={mergeClasses(

--- a/src/components/New/Calendar/Calendar.tsx
+++ b/src/components/New/Calendar/Calendar.tsx
@@ -21,7 +21,7 @@ import {
   useState,
 } from 'react';
 
-import { DialLabel } from '@/components/Label/Label';
+import { Label } from '@/components/New/Label/Label';
 import { StaticIconButton } from '@/components/New/IconButton/IconButtonWrappers';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { CalendarMode } from '@/types/calendar';
@@ -335,7 +335,7 @@ export const Calendar: FC<CalendarProps> = ({
 
     return (
       <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-        {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
+        {label && <Label id={labelId} label={label} htmlFor={fieldId} />}
         <TimeField
           id={fieldId}
           value={timeValue}
@@ -354,7 +354,7 @@ export const Calendar: FC<CalendarProps> = ({
 
     return (
       <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-        {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
+        {label && <Label id={labelId} label={label} htmlFor={fieldId} />}
         <CalendarPopoverField
           id={fieldId}
           disabled={disabled}
@@ -412,7 +412,7 @@ export const Calendar: FC<CalendarProps> = ({
 
   return (
     <div className={mergeClasses('flex flex-col gap-y-3', className)}>
-      {label && <DialLabel id={labelId} label={label} htmlFor={fieldId} />}
+      {label && <Label id={labelId} label={label} htmlFor={fieldId} />}
       <CalendarPopoverField
         id={fieldId}
         disabled={disabled}

--- a/src/components/New/Calendar/constants.tsx
+++ b/src/components/New/Calendar/constants.tsx
@@ -28,25 +28,26 @@ export const calendarPopoverClassName =
   'z-[53] flex w-[248px] flex-col gap-4 rounded-lg bg-layer-raised px-3 py-4 shadow-md';
 
 export const calendarDayButtonBaseClassName =
-  'flex size-8 items-center justify-center rounded-full dial-small-text text-primary hover:bg-control-accent-alpha-hover hover:text-primary focus:outline-none focus-visible:outline focus-visible:outline-focus';
+  'flex size-8 items-center justify-center rounded-full dial-small-text text-primary hover:bg-control-accent-alpha-hover hover:text-primary focus:outline-none focus-visible:outline focus-visible:outline-focus-black';
 
 export const calendarDaySelectedClassName =
   'bg-control-accent text-control-permanent';
 
 export const calendarDayTodayClassName = 'text-accent dial-small-semi-text';
 
-export const calendarDayOutsideClassName = 'text-control-disable';
+export const calendarDayOutsideClassName = 'text-control-disable-alpha';
 
 export const calendarFieldIconClassName = 'text-secondary';
 
 export const calendarIcon = (
   <IconCalendar
     size={DIAL_ICON_SIZE.MD}
+    aria-hidden="true"
     className={calendarFieldIconClassName}
   />
 );
 
 export const calendarNavIcons = {
-  prev: <IconChevronLeft size={DIAL_ICON_SIZE.SM} />,
-  next: <IconChevronRight size={DIAL_ICON_SIZE.SM} />,
+  prev: <IconChevronLeft size={DIAL_ICON_SIZE.SM} aria-hidden="true" />,
+  next: <IconChevronRight size={DIAL_ICON_SIZE.SM} aria-hidden="true" />,
 };

--- a/src/components/New/Calendar/utils.spec.ts
+++ b/src/components/New/Calendar/utils.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatDayAriaLabel } from './utils';
+
+describe('Dial UI Kit :: Calendar utils :: formatDayAriaLabel', () => {
+  test('Should include the weekday, day, long month and year', () => {
+    const result = formatDayAriaLabel(new Date(2026, 2, 15), 'en-GB');
+
+    expect(result).toBe('Sunday, 15 March 2026');
+  });
+
+  test('Should name the month a day belongs to, not the grid it appears in', () => {
+    const result = formatDayAriaLabel(new Date(2026, 1, 28), 'en-GB');
+
+    expect(result).toBe('Saturday, 28 February 2026');
+  });
+
+  test('Should localize the weekday and month names', () => {
+    const result = formatDayAriaLabel(new Date(2026, 2, 15), 'de-DE');
+
+    expect(result).toBe('Sonntag, 15. März 2026');
+  });
+});

--- a/src/components/New/Calendar/utils.ts
+++ b/src/components/New/Calendar/utils.ts
@@ -52,6 +52,23 @@ export const formatDateLabel = (date: Date, locale: string): string =>
     year: 'numeric',
   });
 
+/**
+ * Full label for a day cell in the month grid, e.g. `"Wednesday 11 March 2026"`.
+ *
+ * A day button renders only its number, so on its own it announces as "15" with
+ * no month, year, or weekday context — and a cell spilling over from an
+ * adjacent month is indistinguishable from one in the visible month. The
+ * weekday and long month also keep this distinct from `formatDateLabel`, which
+ * names the trigger.
+ */
+export const formatDayAriaLabel = (date: Date, locale: string): string =>
+  date.toLocaleDateString(locale, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
 export const formatTimeLabel = (date: Date): string =>
   `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 

--- a/src/components/New/CaptionText/CaptionText.spec.tsx
+++ b/src/components/New/CaptionText/CaptionText.spec.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { CaptionText } from './CaptionText';
+
+describe('Dial UI Kit :: DialCaptionText', () => {
+  test('Should render text when provided', () => {
+    render(<CaptionText text="This is an text" />);
+    expect(screen.getByText('This is an text')).toBeInTheDocument();
+  });
+
+  test('Should render nothing when text is not provided', () => {
+    const { container } = render(<CaptionText />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('Should pass through span props and merge className', () => {
+    render(
+      <CaptionText
+        text="With extra props"
+        className="extra-class"
+        aria-label="caption-label"
+      />,
+    );
+
+    const el = screen.getByText('With extra props');
+
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent('With extra props');
+    expect(el).toHaveAttribute('aria-label', 'caption-label');
+    expect(el.className).toContain('dial-tiny-text');
+    expect(el.className).toContain('extra-class');
+  });
+
+  test('Should pass through span props and merge className', () => {
+    render(
+      <CaptionText
+        text="With extra props"
+        className="extra-class"
+        aria-label="caption-label"
+      />,
+    );
+
+    const el = screen.getByText('With extra props');
+
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent('With extra props');
+    expect(el).toHaveAttribute('aria-label', 'caption-label');
+    expect(el.className).toContain('dial-tiny-text');
+    expect(el.className).toContain('extra-class');
+  });
+});

--- a/src/components/New/CaptionText/CaptionText.stories.tsx
+++ b/src/components/New/CaptionText/CaptionText.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CaptionType } from '@/types/caption';
+import { CaptionText } from './CaptionText';
+
+const meta = {
+  title: 'Components_2_0/CaptionText',
+  component: CaptionText,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A component for displaying messages with consistent styling.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: [CaptionType.Error, CaptionType.Description],
+      description: 'The visual style variant of the caption text.',
+    },
+    text: {
+      control: { type: 'text' },
+      description: 'The message text to display',
+    },
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes merged with base classes.',
+    },
+    'aria-label': {
+      control: { type: 'text' },
+      description: 'ARIA label to improve accessibility.',
+    },
+  },
+  args: {
+    text: 'Field is required. Please provide a valid input to proceed.',
+  },
+} satisfies Meta<typeof CaptionText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CustomClassName: Story = {
+  args: {
+    text: 'This is an error with custom class',
+    className: 'border border-secondary p-2',
+  },
+};
+
+export const AriaAttributes: Story = {
+  args: {
+    text: 'Error with aria attributes',
+    'aria-label': 'Error message',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: CaptionType.Error,
+  },
+};

--- a/src/components/New/CaptionText/CaptionText.tsx
+++ b/src/components/New/CaptionText/CaptionText.tsx
@@ -1,0 +1,49 @@
+import { mergeClasses } from '@/utils/merge-classes';
+import type { FC, HTMLAttributes } from 'react';
+import { CaptionType } from '@/types/caption';
+
+export interface CaptionTextProps extends HTMLAttributes<HTMLSpanElement> {
+  text?: string;
+  variant?: CaptionType;
+}
+
+/**
+ * A component for displaying caption text with consistent styling
+ * aliases: HelperText|ValidationText
+ *
+ * @example
+ * ```tsx
+ * <CaptionText text="This field is required" variant={CaptionType.Error} />
+ * ```
+ *
+ * @param [text] - The text to display. If undefined or empty, nothing is rendered
+ * @param [variant] - The variant of the caption text, e.g., error or description.
+ */
+export const CaptionText: FC<CaptionTextProps> = ({
+  text,
+  className,
+  variant = CaptionType.Description,
+  ...props
+}) => {
+  if (!text) return null;
+
+  return (
+    <span
+      {...props}
+      role="alert"
+      className={mergeClasses(
+        'dial-tiny-text',
+        variant === CaptionType.Error ? 'text-error' : 'text-secondary',
+        className,
+      )}
+    >
+      {text}
+    </span>
+  );
+};
+
+export const ErrorText: FC<Omit<CaptionTextProps, 'variant'>> = ({
+  ...props
+}) => {
+  return <CaptionText {...props} variant={CaptionType.Error} />;
+};

--- a/src/components/New/FolderPath/FolderPath.spec.tsx
+++ b/src/components/New/FolderPath/FolderPath.spec.tsx
@@ -51,4 +51,36 @@ describe('Dial UI Kit :: FolderPath', () => {
     );
     expect(screen.getByRole('navigation')).toHaveClass('custom-path');
   });
+
+  test('Should name the landmark as a folder path rather than a breadcrumb', () => {
+    render(<FolderPath segments={['Shared', 'Reports']} />);
+
+    // DialBreadcrumb defaults to "Breadcrumb", which misdescribes a path whose
+    // segments are all disabled and non-navigable.
+    expect(
+      screen.getByRole('navigation', { name: 'Folder path' }),
+    ).toBeInTheDocument();
+  });
+
+  test('Should let the caller rename the landmark', () => {
+    render(
+      <FolderPath segments={['Shared', 'Reports']} ariaLabel="Source folder" />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Source folder' }),
+    ).toBeInTheDocument();
+  });
+
+  test('Should hide decorative icons from assistive tech', () => {
+    const { container } = render(
+      <FolderPath segments={['Shared', 'Team', 'Reports']} />,
+    );
+
+    const icons = container.querySelectorAll('svg');
+    expect(icons.length).toBeGreaterThan(0);
+    icons.forEach((icon) =>
+      expect(icon).toHaveAttribute('aria-hidden', 'true'),
+    );
+  });
 });

--- a/src/components/New/FolderPath/FolderPath.tsx
+++ b/src/components/New/FolderPath/FolderPath.tsx
@@ -11,6 +11,7 @@ export interface FolderPathProps {
   labelClassName?: string;
   leafClassName?: string;
   className?: string;
+  ariaLabel?: string;
 }
 
 /**
@@ -31,16 +32,20 @@ export interface FolderPathProps {
  * @param [className] - Additional CSS classes applied to the breadcrumb's `<nav>` element.
  *  `DialBreadcrumb` scrolls horizontally on overflow, so this must not shrink
  *  the nav to content width (e.g. never `w-auto`).
+ * @param [ariaLabel='Folder path'] - Accessible name for the underlying `<nav>`.
+ *  `DialBreadcrumb` would otherwise name it "Breadcrumb", which misdescribes a
+ *  path with no navigable items; override it when a page shows more than one.
  */
 export const FolderPath: FC<FolderPathProps> = ({
   segments,
   labelClassName = 'dial-small-text',
   leafClassName = 'dial-small-semi-text',
   className,
+  ariaLabel = 'Folder path',
 }) => {
   const folderIcon = (
     <DialIcon
-      icon={<IconFolder size={DIAL_ICON_SIZE.SM} />}
+      icon={<IconFolder size={DIAL_ICON_SIZE.SM} aria-hidden="true" />}
       className="text-secondary"
     />
   );
@@ -58,11 +63,13 @@ export const FolderPath: FC<FolderPathProps> = ({
   return (
     <DialBreadcrumb
       className={className}
+      ariaLabel={ariaLabel}
       separator={
         <DialIcon
           icon={
             <IconChevronRight
               size={14}
+              aria-hidden="true"
               // eslint-disable-next-line tailwindcss/no-unnecessary-arbitrary-value -- keep in sync with the source implementation's RTL mirroring
               className="rtl:scale-x-[-1]"
             />

--- a/src/components/New/IconButton/IconButton.spec.tsx
+++ b/src/components/New/IconButton/IconButton.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
+import { ElementSize } from '@/types/size';
 import { IconButton } from './IconButton';
 
 describe('Dial UI Kit :: DialIconButton', () => {
@@ -27,5 +28,42 @@ describe('Dial UI Kit :: DialIconButton', () => {
     );
     const button = screen.getByRole('button');
     expect(button).toHaveClass('custom-button-class');
+  });
+
+  test('Should use the aria-label as the accessible name', () => {
+    render(<IconButton icon={<div>icon</div>} aria-label="Delete" />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete');
+  });
+
+  test('Should fall back to the tooltip text as the accessible name', () => {
+    render(
+      <IconButton
+        icon={<div>icon</div>}
+        tooltipProps={{ tooltip: 'Delete' }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Delete');
+  });
+
+  test('Should enhance the pointer target at standard size', () => {
+    render(<IconButton icon={<div>icon</div>} aria-label="Delete" />);
+
+    expect(screen.getByRole('button')).toHaveClass('dial-kit-enhanced-target');
+  });
+
+  test('Should not enhance the pointer target at small size', () => {
+    render(
+      <IconButton
+        icon={<div>icon</div>}
+        aria-label="Delete"
+        size={ElementSize.Small}
+      />,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
   });
 });

--- a/src/components/New/IconButton/IconButton.tsx
+++ b/src/components/New/IconButton/IconButton.tsx
@@ -11,6 +11,7 @@ import {
   type DialTooltipProps,
 } from '@/components/Tooltip/Tooltip';
 import { mergeClasses } from '@/utils/merge-classes';
+import { resolveAccessibleName } from '@/utils/accessible-name';
 import { ElementSize } from '@/types/size';
 import { getButtonClassNames } from '../Button/utils';
 
@@ -50,6 +51,10 @@ export interface IconButtonProps extends DetailedHTMLProps<
  *
  * inherits all properties from the `ButtonHTMLAttributes<HTMLButtonElement>`
  *
+ * The button is icon-only, so it needs an accessible name: pass `aria-label`,
+ * or a string `tooltipProps.tooltip`, which is used as the label when no
+ * `aria-label` is given.
+ *
  * @param [variant] - Defines the visual style of the button
  * @param [appearance=ButtonAppearance.Solid] - Defines the type of the button
  * @param [size=ElementSize.Standard] - Defines the size of the button
@@ -69,7 +74,9 @@ export const IconButton: FC<IconButtonProps> = ({
   const btnClassName = mergeClasses(
     'dial-kit-base-icon-button dial-kit-base-button',
     variant && getButtonClassNames(variant, appearance),
-    size === ElementSize.Small ? 'size-[24px]' : 'size-[40px]',
+    size === ElementSize.Small
+      ? 'size-[24px]'
+      : 'size-[40px] dial-kit-enhanced-target',
     className,
   );
 
@@ -78,7 +85,10 @@ export const IconButton: FC<IconButtonProps> = ({
       {...props}
       type={type}
       className={btnClassName}
-      aria-label={props['aria-label']}
+      aria-label={resolveAccessibleName(
+        props['aria-label'],
+        tooltipProps?.tooltip,
+      )}
     >
       {icon}
     </button>

--- a/src/components/New/InfoButton/InfoButton.spec.tsx
+++ b/src/components/New/InfoButton/InfoButton.spec.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import { InfoButton } from './InfoButton';
+
+describe('Dial UI Kit :: InfoButton', () => {
+  test('Should render nothing without a caption', () => {
+    const { container } = render(<InfoButton />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('Should use the caption as the accessible name', () => {
+    render(<InfoButton caption="Digits only" />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Digits only');
+  });
+
+  test('Should let aria-label override the caption', () => {
+    render(
+      <InfoButton
+        caption="Only digits, no spaces or country prefix"
+        aria-label="Phone number help"
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Phone number help',
+    );
+  });
+
+  test('Should hide the decorative icon from assistive tech', () => {
+    const { container } = render(<InfoButton caption="Digits only" />);
+
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+
+  test('Should show the caption in a tooltip on hover', async () => {
+    const user = userEvent.setup();
+    render(<InfoButton caption="Digits only" />);
+
+    await user.hover(screen.getByRole('button'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Digits only');
+  });
+
+  test('Should not enhance the pointer target of the small affordance', () => {
+    render(<InfoButton caption="Digits only" />);
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-enhanced-target',
+    );
+  });
+
+  test('Should call onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<InfoButton caption="Digits only" onClick={onClick} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/New/InfoButton/InfoButton.stories.ts
+++ b/src/components/New/InfoButton/InfoButton.stories.ts
@@ -16,7 +16,12 @@ const meta: Meta<typeof InfoButton> = {
   argTypes: {
     caption: {
       control: { type: 'text' },
-      description: 'Text to display inside the info button',
+      description:
+        'Tooltip text, and the fallback accessible name of the button',
+    },
+    'aria-label': {
+      control: { type: 'text' },
+      description: 'Accessible name; takes precedence over `caption`',
     },
   },
 } satisfies Meta<InfoButtonProps>;
@@ -27,5 +32,16 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     caption: 'Info',
+  },
+};
+
+/**
+ * A long caption still works as a tooltip, but a short `aria-label` keeps the
+ * announced name scannable.
+ */
+export const ExplicitAccessibleName: Story = {
+  args: {
+    caption: 'Only digits, without spaces or a country prefix',
+    'aria-label': 'Phone number help',
   },
 };

--- a/src/components/New/InfoButton/InfoButton.stories.ts
+++ b/src/components/New/InfoButton/InfoButton.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InfoButton, type InfoButtonProps } from './InfoButton';
+
+const meta: Meta<typeof InfoButton> = {
+  title: 'Components_2_0/InfoButton',
+  component: InfoButton,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A contextual feedback component for displaying important messages with optional close button.',
+      },
+    },
+  },
+  argTypes: {
+    caption: {
+      control: { type: 'text' },
+      description: 'Text to display inside the info button',
+    },
+  },
+} satisfies Meta<InfoButtonProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    caption: 'Info',
+  },
+};

--- a/src/components/New/InfoButton/InfoButton.tsx
+++ b/src/components/New/InfoButton/InfoButton.tsx
@@ -1,14 +1,15 @@
 import { IconInfoCircle } from '@tabler/icons-react';
 import type { FC } from 'react';
 
-import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
 import { IconButton } from '../IconButton/IconButton';
-import { mergeClasses } from '../../../utils/merge-classes';
 
 export interface InfoButtonProps {
   caption?: string;
   onClick?: () => void;
+  'aria-label'?: string;
 }
 /**
  * An Info button component with a customizable icon and accessible label.
@@ -20,31 +21,37 @@ export interface InfoButtonProps {
  * />
  * ```
  *
- * @param [caption] - Text to display inside the info button
+ * The button is icon-only, so it needs an accessible name. `caption` is used as
+ * the name because a tooltip alone never reaches assistive tech — pass a short
+ * `aria-label` when the caption is a long sentence.
+ *
+ * @param [caption] - Text shown in the tooltip, and the fallback accessible name
  * @param [onClick] - Click handler for the info button
+ * @param [aria-label] - Accessible name; takes precedence over `caption`
  */
-export const InfoButton: FC<InfoButtonProps> = ({ caption, onClick }) => {
+export const InfoButton: FC<InfoButtonProps> = ({
+  caption,
+  onClick,
+  'aria-label': ariaLabel,
+}) => {
   if (!caption) return null;
+
   const infoButtonClassName = mergeClasses(
-    'size-[20px] flex items-center justify-center text-secondary hover:text-control-blue-hover active:text-control-blue-active',
+    'text-secondary hover:text-control-blue-hover active:text-control-blue-active',
     'focus-visible:outline focus-visible:outline-focus-black',
   );
-  const button = (
+
+  return (
     <IconButton
-      aria-label={caption}
+      aria-label={ariaLabel}
       className={infoButtonClassName}
-      icon={<IconInfoCircle size={DIAL_ICON_SIZE.SM} />}
+      icon={<IconInfoCircle size={DIAL_ICON_SIZE.SM} aria-hidden="true" />}
       onClick={onClick}
+      size={ElementSize.Small}
+      tooltipProps={{
+        tooltip: caption,
+        triggerClassName: 'flex justify-center items-center',
+      }}
     />
-  );
-  return caption ? (
-    <DialTooltip
-      tooltip={caption}
-      triggerClassName="flex justify-center items-center"
-    >
-      {button}
-    </DialTooltip>
-  ) : (
-    button
   );
 };

--- a/src/components/New/InfoButton/InfoButton.tsx
+++ b/src/components/New/InfoButton/InfoButton.tsx
@@ -1,0 +1,50 @@
+import { IconInfoCircle } from '@tabler/icons-react';
+import type { FC } from 'react';
+
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { IconButton } from '../IconButton/IconButton';
+import { mergeClasses } from '../../../utils/merge-classes';
+
+export interface InfoButtonProps {
+  caption?: string;
+  onClick?: () => void;
+}
+/**
+ * An Info button component with a customizable icon and accessible label.
+ *
+ * @example
+ * ```tsx
+ * <InfoButton
+ *   caption="Info"
+ * />
+ * ```
+ *
+ * @param [caption] - Text to display inside the info button
+ * @param [onClick] - Click handler for the info button
+ */
+export const InfoButton: FC<InfoButtonProps> = ({ caption, onClick }) => {
+  if (!caption) return null;
+  const infoButtonClassName = mergeClasses(
+    'size-[20px] flex items-center justify-center text-secondary hover:text-control-blue-hover active:text-control-blue-active',
+    'focus-visible:outline focus-visible:outline-focus-black',
+  );
+  const button = (
+    <IconButton
+      aria-label={caption}
+      className={infoButtonClassName}
+      icon={<IconInfoCircle size={DIAL_ICON_SIZE.SM} />}
+      onClick={onClick}
+    />
+  );
+  return caption ? (
+    <DialTooltip
+      tooltip={caption}
+      triggerClassName="flex justify-center items-center"
+    >
+      {button}
+    </DialTooltip>
+  ) : (
+    button
+  );
+};

--- a/src/components/New/InlineSelect/InlineSelect.spec.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.spec.tsx
@@ -48,7 +48,7 @@ describe('Dial UI Kit :: DialInlineSelectTrigger', () => {
 
   test('Should apply small size classes', () => {
     render(<InlineSelectTrigger label="Option A" size={ElementSize.Small} />);
-    expect(screen.getByRole('button')).toHaveClass('h-[24px]');
+    expect(screen.getByRole('button')).toHaveClass('h-[32px]');
   });
 
   test('Should apply default (standard) size classes', () => {

--- a/src/components/New/InlineSelect/InlineSelect.spec.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.spec.tsx
@@ -111,4 +111,33 @@ describe('Dial UI Kit :: DialInlineSelect', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
   });
+
+  test('Should reflect the open state on the trigger', () => {
+    render(<InlineSelect items={items} />);
+    const trigger = screen.getByRole('button');
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Should announce the field name alongside the selected value', () => {
+    render(<InlineSelect items={items} ariaLabel="Sort by" />);
+
+    // An aria-label replaces the button content, so the value has to be folded
+    // in or the control announces only "Sort by".
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      `Sort by ${String(items[0].label)}`,
+    );
+  });
+
+  test('Should fall back to the selected value when no field name is given', () => {
+    render(<InlineSelect items={items} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      String(items[0].label),
+    );
+  });
 });

--- a/src/components/New/InlineSelect/InlineSelect.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.tsx
@@ -25,19 +25,26 @@ export interface InlineSelectTriggerProps extends ButtonHTMLAttributes<HTMLButto
 export const InlineSelectTrigger: FC<InlineSelectTriggerProps> = ({
   label,
   size,
-  isOpen,
+  isOpen = false,
+  'aria-label': ariaLabel,
   ...rest
 }) => {
   const className =
-    size === ElementSize.Small ? 'h-[24px] px-2' : 'h-[40px] px-3';
+    size === ElementSize.Small
+      ? 'h-[24px] px-2'
+      : 'h-[40px] px-3 dial-kit-enhanced-target';
 
   return (
     <button
       type="button"
       aria-haspopup="menu"
+      aria-expanded={isOpen}
+      // An `aria-label` replaces the button's content rather than adding to it,
+      // so the selected value has to be folded in or it stops being announced.
+      aria-label={ariaLabel ? `${ariaLabel} ${label}` : undefined}
       className={mergeClasses(
-        'dial-small-paragraph-text focus-visible:outline focus-visible:outline-focus',
-        'flex items-center gap-1 rounded-full text-primary disabled:text-controls-disable',
+        'dial-small-paragraph-text focus-visible:outline focus-visible:outline-focus-black',
+        'flex items-center gap-1 rounded-full text-primary disabled:text-control-disable-beta',
         'hover:bg-control-accent-alpha-hover focus-visible:outline-offset-2 active:bg-control-accent-alpha-active',
         className,
         rest.className,
@@ -73,6 +80,11 @@ export interface InlineSelectProps {
   matchReferenceWidth?: boolean;
   /** Additional CSS classes applied to the dropdown overlay. */
   listClassName?: string;
+  /**
+   * Accessible name for the trigger. Without it the control announces only its
+   * current value ("Option A"), never what is being selected.
+   */
+  ariaLabel?: string;
 }
 
 /**
@@ -96,6 +108,7 @@ export const InlineSelect: FC<InlineSelectProps> = ({
   placement = 'bottom-end',
   matchReferenceWidth = false,
   listClassName,
+  ariaLabel,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [uncontrolledSelectedKey, setUncontrolledSelectedKey] = useState(
@@ -134,6 +147,7 @@ export const InlineSelect: FC<InlineSelectProps> = ({
         size={size}
         isOpen={isOpen}
         disabled={disabled}
+        aria-label={ariaLabel}
       />
     </DialDropdown>
   );

--- a/src/components/New/InlineSelect/InlineSelect.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.tsx
@@ -31,8 +31,8 @@ export const InlineSelectTrigger: FC<InlineSelectTriggerProps> = ({
 }) => {
   const className =
     size === ElementSize.Small
-      ? 'h-[24px] px-2'
-      : 'h-[40px] px-3 dial-kit-enhanced-target';
+      ? 'h-[32px]'
+      : 'h-[40px] dial-kit-enhanced-target';
 
   return (
     <button
@@ -43,7 +43,7 @@ export const InlineSelectTrigger: FC<InlineSelectTriggerProps> = ({
       // so the selected value has to be folded in or it stops being announced.
       aria-label={ariaLabel ? `${ariaLabel} ${label}` : undefined}
       className={mergeClasses(
-        'dial-small-paragraph-text focus-visible:outline focus-visible:outline-focus-black',
+        'dial-small-paragraph-text px-3 focus-visible:outline focus-visible:outline-focus-black',
         'flex items-center gap-1 rounded-full text-primary disabled:text-control-disable-beta',
         'hover:bg-control-accent-alpha-hover focus-visible:outline-offset-2 active:bg-control-accent-alpha-active',
         className,

--- a/src/components/New/Input/Button/InputButton.tsx
+++ b/src/components/New/Input/Button/InputButton.tsx
@@ -1,0 +1,57 @@
+import classNames from 'classnames';
+import type { FC, ReactNode } from 'react';
+
+import { ElementSize } from '@/types/size';
+import { IconButton } from '../../IconButton/IconButton';
+import { inputButtonClassName } from './constants';
+
+export interface InputButtonProps {
+  icon: ReactNode;
+  disabled?: boolean;
+  onClick?: () => void;
+  size?: ElementSize;
+  className?: string;
+}
+/**
+ * An Input button component with a customizable icon and accessible label.
+ *
+ * @example
+ * ```tsx
+ * <InputButton
+ *   icon={<IconInfoCircle size={16} />}
+ * />
+ * ```
+ *
+ * @param [icon] - Icon to display inside the input button
+ * @param [onClick] - Click handler for the info button
+ * @param [disabled] - Whether the button is disabled
+ * @param [size] - Size of the input button, which adjusts the icon size and padding. Uses the {@link ElementSize} enum.
+ */
+export const InputButton: FC<InputButtonProps> = ({
+  icon,
+  onClick,
+  disabled,
+  size = ElementSize.Standard,
+  className,
+}) => {
+  return (
+    <div
+      className={classNames(
+        'border-l border-tertiary',
+        size === ElementSize.Standard ? 'size-[40px]' : 'size-[24px]',
+      )}
+    >
+      <IconButton
+        className={classNames(
+          inputButtonClassName,
+          size === ElementSize.Small && 'p-1',
+          className,
+        )}
+        icon={icon}
+        onClick={onClick}
+        disabled={disabled}
+        size={size}
+      />
+    </div>
+  );
+};

--- a/src/components/New/Input/Button/constants.ts
+++ b/src/components/New/Input/Button/constants.ts
@@ -1,0 +1,2 @@
+export const inputButtonClassName =
+  'bg-layer-4 flex items-center justify-center enabled:text-secondary enabled:hover:text-accent-primary enabled:active:bg-controls-accent-primary-alpha-active enabled:hover:bg-accent-primary-alpha enabled:active:text-accent-primary';

--- a/src/components/New/Input/Input.spec.tsx
+++ b/src/components/New/Input/Input.spec.tsx
@@ -1,0 +1,254 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { Input } from './Input';
+
+describe('Dial UI Kit :: DialInput', () => {
+  test('renders with default props', () => {
+    const { getByPlaceholderText } = render(
+      <Input id="test-input" placeholder="Enter text" />,
+    );
+    expect(getByPlaceholderText('Enter text')).toBeInTheDocument();
+  });
+
+  test('calls onChange when value changes', () => {
+    const handleChange = vi.fn();
+    const { getByPlaceholderText } = render(
+      <Input
+        id="test-input-change"
+        placeholder="Type value here"
+        onChange={handleChange}
+      />,
+    );
+    const input = getByPlaceholderText('Type value here');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    expect(handleChange).toHaveBeenCalledWith('hello');
+  });
+
+  test('renders input with placeholder', () => {
+    const { getByPlaceholderText } = render(
+      <Input id="icon-input" placeholder="With icon" />,
+    );
+    expect(getByPlaceholderText('With icon')).toBeInTheDocument();
+  });
+
+  test('renders iconBefore and iconAfter', () => {
+    const before = <span>B</span>;
+    const after = <span>A</span>;
+    const { container } = render(
+      <Input
+        id="icon-input"
+        placeholder="With icon"
+        iconBefore={before}
+        iconAfter={after}
+      />,
+    );
+    // Check for the text content of the icons
+    expect(container.textContent).toContain('B');
+    expect(container.textContent).toContain('A');
+  });
+
+  test('calls onChange when input changes', () => {
+    const handleChange = vi.fn();
+    const { getByPlaceholderText } = render(
+      <Input id="icon-input" placeholder="Type here" onChange={handleChange} />,
+    );
+    const input = getByPlaceholderText('Type here');
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(handleChange).toHaveBeenCalledWith('test');
+  });
+
+  test('renders with min and max attributes for number input', () => {
+    const { getByPlaceholderText } = render(
+      <Input
+        id="test-number"
+        type="number"
+        placeholder="Enter number"
+        min={0}
+        max={100}
+      />,
+    );
+    const input = getByPlaceholderText('Enter number');
+    expect(input).toHaveAttribute('min', '0');
+    expect(input).toHaveAttribute('max', '100');
+  });
+
+  test('renders prefix and suffix text', () => {
+    const { container } = render(
+      <Input id="test-input" placeholder="Amount" prefix="$" postfix="USD" />,
+    );
+    expect(container.textContent).toContain('USD');
+  });
+
+  test('renders prefix input', () => {
+    render(
+      <Input
+        id="test-input"
+        placeholder="domain"
+        prefix="https://"
+        value="123"
+      />,
+    );
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+
+    expect(screen.getByDisplayValue('https://')).toBeInTheDocument();
+  });
+
+  test('handleKeyDown blocks non-numeric keys on number input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('');
+      return (
+        <Input
+          id="num"
+          placeholder="num"
+          type="number"
+          value={val}
+          onChange={(v) => {
+            setVal(v ?? '');
+            onChange(v);
+          }}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('num');
+
+    await user.type(input, 'a');
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.type(input, '5');
+    expect(onChange).toHaveBeenLastCalledWith('5');
+    expect((input as HTMLInputElement).value).toBe('5');
+  });
+
+  test('handleKeyDown returns early for non-numeric inputs (type="text")', async () => {
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('');
+      return (
+        <Input
+          id="plain"
+          placeholder="plain"
+          type="text"
+          value={val}
+          onChange={(v) => setVal(v ?? '')}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('plain') as HTMLInputElement;
+
+    await user.type(input, 'a1');
+    expect(input.value).toBe('a1');
+  });
+  test('allowed navigation keys are not blocked on number input', async () => {
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('12');
+      return (
+        <Input
+          id="num-allowed"
+          placeholder="num-allowed"
+          type="number"
+          value={val}
+          onChange={(v) => setVal(v ?? '')}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText(
+      'num-allowed',
+    ) as HTMLInputElement;
+
+    await user.type(input, '{ArrowLeft}');
+    expect(input.value).toBe('12');
+
+    await user.type(input, '7');
+    expect(input.value).toBe('127');
+  });
+
+  test('prevents typing when result would be below min (range check on keyDown)', async () => {
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('');
+      return (
+        <Input
+          id="min-guard"
+          placeholder="min-guard"
+          type="number"
+          min={10}
+          value={val}
+          onChange={(v) => setVal(v ?? '')}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('min-guard') as HTMLInputElement;
+
+    await user.type(input, '5');
+    expect(input.value).toBe('');
+  });
+
+  test('prevents typing when result would be above max (range check on keyDown)', async () => {
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('100');
+      return (
+        <Input
+          id="max-guard"
+          placeholder="max-guard"
+          type="number"
+          max={100}
+          value={val}
+          onChange={(v) => setVal(v ?? '')}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('max-guard') as HTMLInputElement;
+
+    await user.type(input, '1');
+    expect(input.value).toBe('100');
+  });
+
+  test('uses cursor position to build newValue; blocks when inserted digit violates range', async () => {
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [val, setVal] = useState('150');
+      return (
+        <Input
+          id="cursor-range"
+          placeholder="cursor-range"
+          max={180}
+          value={val}
+          onChange={(v) => setVal(v ?? '')}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText(
+      'cursor-range',
+    ) as HTMLInputElement;
+
+    input.focus();
+    input.setSelectionRange(1, 1);
+    await user.type(input, '9');
+
+    expect(input.value).toBe('150');
+  });
+});

--- a/src/components/New/Input/Input.spec.tsx
+++ b/src/components/New/Input/Input.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
+import { ElementSize } from '@/types/size';
 import { Input } from './Input';
 
 describe('Dial UI Kit :: DialInput', () => {
@@ -222,6 +223,89 @@ describe('Dial UI Kit :: DialInput', () => {
 
     await user.type(input, '1');
     expect(input.value).toBe('100');
+  });
+
+  describe('size', () => {
+    // jsdom does no layout, so the height itself is not observable here — the
+    // variant classes are. `npm run build:css` compiles them to 40px/24px.
+    const getField = () => screen.getByLabelText('input-container');
+
+    test('renders the standard height by default', () => {
+      render(<Input id="default-size" placeholder="Placeholder" />);
+
+      // The 40px height comes from `.dial-kit-input` itself
+      expect(getField()).toHaveClass('dial-kit-input', 'gap-x-2', 'pl-3');
+      expect(getField()).not.toHaveClass('dial-kit-input-small');
+    });
+
+    test('renders the small variant when size is small', () => {
+      render(
+        <Input
+          id="small-size"
+          placeholder="Placeholder"
+          size={ElementSize.Small}
+        />,
+      );
+
+      expect(getField()).toHaveClass('dial-kit-input-small', 'gap-x-1', 'pl-2');
+      expect(getField()).not.toHaveClass('py-2');
+    });
+
+    test('passes the size down to the prefix field', () => {
+      render(
+        <Input
+          id="small-prefix"
+          placeholder="domain"
+          prefix="https://"
+          size={ElementSize.Small}
+        />,
+      );
+
+      const fields = screen.getAllByLabelText('input-container');
+      expect(fields).toHaveLength(2);
+      fields.forEach((field) =>
+        expect(field).toHaveClass('dial-kit-input-small'),
+      );
+    });
+
+    test('passes the size down to the input button, and lets it opt out', () => {
+      const { rerender } = render(
+        <Input
+          id="small-button"
+          placeholder="Placeholder"
+          size={ElementSize.Small}
+          inputButtonProps={{ icon: <span>i</span> }}
+        />,
+      );
+      expect(screen.getByRole('button')).toHaveClass('size-[24px]');
+
+      rerender(
+        <Input
+          id="small-button"
+          placeholder="Placeholder"
+          size={ElementSize.Small}
+          inputButtonProps={{
+            icon: <span>i</span>,
+            size: ElementSize.Standard,
+          }}
+        />,
+      );
+      expect(screen.getByRole('button')).toHaveClass('size-[40px]');
+    });
+
+    test('does not forward size to the native input as an attribute', () => {
+      render(
+        <Input
+          id="no-native-size"
+          placeholder="Placeholder"
+          size={ElementSize.Small}
+        />,
+      );
+
+      expect(screen.getByPlaceholderText('Placeholder')).not.toHaveAttribute(
+        'size',
+      );
+    });
   });
 
   test('uses cursor position to build newValue; blocks when inserted digit violates range', async () => {

--- a/src/components/New/Input/Input.stories.tsx
+++ b/src/components/New/Input/Input.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Input, type InputProps } from './Input';
 import { inputBaseArgTypes } from '@/constants/storybook/input';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ElementSize } from '@/types/size';
 
 const InteractiveInput = (args: InputProps) => {
   const [value, setValue] = useState(args.value || '');
@@ -33,6 +34,11 @@ const meta = {
   },
   argTypes: {
     ...inputBaseArgTypes,
+    size: {
+      control: { type: 'inline-radio' },
+      options: [ElementSize.Standard, ElementSize.Small],
+      description: 'Field height: standard is 40px, small is 24px',
+    },
   },
   args: {
     id: 'story-input',
@@ -40,6 +46,7 @@ const meta = {
     placeholder: 'Placeholder',
     disabled: false,
     invalid: false,
+    size: ElementSize.Standard,
   },
   render: InteractiveInput,
 } satisfies Meta<InputProps>;
@@ -83,6 +90,14 @@ export const BothIcons: Story = {
   },
 };
 
+export const Small: Story = {
+  args: {
+    placeholder: 'Search...',
+    size: ElementSize.Small,
+    iconBefore: <IconSearch size={DIAL_ICON_SIZE.SM} />,
+  },
+};
+
 export const Disabled: Story = {
   args: {
     placeholder: 'Disable input',
@@ -95,6 +110,72 @@ export const Invalid: Story = {
     placeholder: 'Invalid input',
     value: 'Invalid value',
     invalid: true,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => {
+    const sizes = [
+      { size: ElementSize.Standard, label: 'Standard (40px)' },
+      { size: ElementSize.Small, label: 'Small (24px)' },
+    ];
+
+    return (
+      <div className="flex flex-col size-full items-center">
+        <h2 className="text-primary font-semibold mb-8">Input sizes</h2>
+
+        <div className="flex flex-col gap-y-8">
+          {sizes.map(({ size, label }) => {
+            const iconSize =
+              size === ElementSize.Small
+                ? DIAL_ICON_SIZE.SM
+                : DIAL_ICON_SIZE.MD;
+
+            return (
+              <div key={size} className="flex flex-col gap-y-3">
+                <div className="text-primary font-semibold">{label}</div>
+
+                <div className="flex flex-row items-start gap-x-6">
+                  <InteractiveInput
+                    id={`${size}-plain`}
+                    size={size}
+                    placeholder="Placeholder"
+                  />
+
+                  <InteractiveInput
+                    id={`${size}-icons`}
+                    size={size}
+                    placeholder="Search..."
+                    iconBefore={<IconSearch size={iconSize} />}
+                    iconAfter={<IconEye size={iconSize} />}
+                  />
+
+                  <InteractiveInput
+                    id={`${size}-max`}
+                    size={size}
+                    value="Text"
+                    prefix="prefix"
+                    postfix="postfix"
+                    caption="Caption text"
+                    inputButtonProps={{
+                      icon: <IconSearch size={iconSize} />,
+                      onClick: () => alert('Input button clicked'),
+                    }}
+                  />
+
+                  <InteractiveInput
+                    id={`${size}-disabled`}
+                    size={size}
+                    value="Text"
+                    disabled
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
   },
 };
 

--- a/src/components/New/Input/Input.stories.tsx
+++ b/src/components/New/Input/Input.stories.tsx
@@ -1,0 +1,287 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconEye, IconSearch } from '@tabler/icons-react';
+import { useState } from 'react';
+import { Input, type InputProps } from './Input';
+import { inputBaseArgTypes } from '@/constants/storybook/input';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+
+const InteractiveInput = (args: InputProps) => {
+  const [value, setValue] = useState(args.value || '');
+
+  return (
+    <Input
+      {...args}
+      value={value}
+      onChange={(newValue) => setValue(newValue ?? '')}
+      // eslint-disable-next-line no-console
+      onBlur={({ target }) => console.log(target.value)}
+    />
+  );
+};
+
+const meta = {
+  title: 'Components_2_0/Input',
+  component: Input,
+  tags: ['input'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'An input component with various states and icon support.',
+      },
+    },
+  },
+  argTypes: {
+    ...inputBaseArgTypes,
+  },
+  args: {
+    id: 'story-input',
+    type: 'text',
+    placeholder: 'Placeholder',
+    disabled: false,
+    invalid: false,
+  },
+  render: InteractiveInput,
+} satisfies Meta<InputProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text...',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    placeholder: 'Enter text...',
+    value: 'Sample text',
+  },
+};
+
+export const IconBefore: Story = {
+  args: {
+    placeholder: 'Search...',
+    iconBefore: <IconSearch size={DIAL_ICON_SIZE.MD} />,
+  },
+};
+
+export const IconAfter: Story = {
+  args: {
+    placeholder: 'Password',
+    type: 'password',
+    iconAfter: <IconEye size={DIAL_ICON_SIZE.MD} />,
+  },
+};
+
+export const BothIcons: Story = {
+  args: {
+    placeholder: 'Search...',
+    iconBefore: <IconSearch size={DIAL_ICON_SIZE.MD} />,
+    iconAfter: <IconEye size={DIAL_ICON_SIZE.MD} />,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disable input',
+    disabled: true,
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    placeholder: 'Invalid input',
+    value: 'Invalid value',
+    invalid: true,
+  },
+};
+
+export const MaxView: Story = {
+  render: () => {
+    const props: InputProps = {
+      placeholder: 'Placeholder',
+      iconBefore: <IconSearch size={DIAL_ICON_SIZE.MD} />,
+      postfix: 'postfix',
+      prefix: 'prefix',
+      caption: 'Caption text',
+      iconAfter: <IconEye size={DIAL_ICON_SIZE.MD} />,
+      inputButtonProps: {
+        icon: <IconSearch size={DIAL_ICON_SIZE.MD} />,
+        onClick: () => alert('Input button clicked'),
+      },
+    };
+
+    return (
+      <div className="flex flex-col size-full items-center">
+        <h2 className="text-primary font-semibold mb-8">Inputs</h2>
+
+        <div className="flex-1 min-h-0 flex flex-col gap-y-6">
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Default
+            </div>
+            <InteractiveInput id="default-input" {...props} />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Filled
+            </div>
+            <InteractiveInput id="field-input" value="Text" {...props} />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Error
+            </div>
+            <InteractiveInput
+              id="error-input"
+              invalid={true}
+              value="Text"
+              error="Error message"
+              {...props}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Disabled filled
+            </div>
+            <InteractiveInput
+              id="disable-input"
+              disabled={true}
+              value="Text"
+              {...props}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Disabled empty
+            </div>
+            <InteractiveInput id="disable-input" disabled={true} {...props} />
+          </div>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    pseudo: {
+      hover: ['.dial-input-for-hover'],
+      focus: ['.dial-input-for-focus'],
+    },
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => {
+    return (
+      <div className="flex flex-col size-full items-center">
+        <h2 className="text-primary font-semibold mb-8">Inputs</h2>
+
+        <div className="flex-1 min-h-0 flex flex-col gap-y-6">
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Default
+            </div>
+            <InteractiveInput
+              id="default-input"
+              placeholder="Placeholder"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Filled
+            </div>
+            <InteractiveInput
+              id="field-input"
+              placeholder="Placeholder"
+              value="Text"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Hover
+            </div>
+            <InteractiveInput
+              id="hover-input"
+              containerClassName="dial-input-for-hover"
+              placeholder="Placeholder"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Focus/Active
+            </div>
+            <InteractiveInput
+              id="focus-input"
+              containerClassName="dial-input-for-focus"
+              placeholder="Placeholder"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Error
+            </div>
+            <InteractiveInput
+              id="error-input"
+              placeholder="Placeholder"
+              invalid={true}
+              value="Text"
+              error="Error message"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Disabled filled
+            </div>
+            <InteractiveInput
+              id="disable-input"
+              placeholder="Placeholder"
+              disabled={true}
+              value="Text"
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="text-primary font-semibold mb-2 w-[150px]">
+              Disabled empty
+            </div>
+            <InteractiveInput
+              id="disable-input"
+              placeholder="Placeholder"
+              disabled={true}
+              iconBefore={<IconSearch size={DIAL_ICON_SIZE.MD} />}
+              iconAfter={<IconEye size={DIAL_ICON_SIZE.MD} />}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    pseudo: {
+      hover: ['.dial-input-for-hover'],
+      focus: ['.dial-input-for-focus'],
+    },
+  },
+};

--- a/src/components/New/Input/Input.tsx
+++ b/src/components/New/Input/Input.tsx
@@ -66,6 +66,7 @@ export interface InputProps extends Omit<
  * />
  * ```
  *
+ * @param [size=ElementSize.Standard] - The size of the input, which can be 'small', 'standard', or 'large'.
  * @param [invalid] - Whether the input has validation errors (applies error styling)
  * @param [iconAfter] - Icon or element to display after the input
  * @param [iconBefore] - Icon or element to display before the input

--- a/src/components/New/Input/Input.tsx
+++ b/src/components/New/Input/Input.tsx
@@ -1,0 +1,260 @@
+import {
+  useEffect,
+  useRef,
+  type ChangeEvent,
+  type FC,
+  type InputHTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+} from 'react';
+
+import { useMergeRefs } from '@floating-ui/react';
+
+import { DialIcon } from '@/components/Icon/Icon';
+import { type DialLabelProps } from '@/components/Label/Label';
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
+import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
+import { CaptionText, ErrorText } from '../CaptionText/CaptionText';
+import { Label } from '../Label/Label';
+import { InputButton, type InputButtonProps } from './Button/InputButton';
+import { handleKeyDown } from './utils';
+
+// `size` shadows the native input attribute (a character-width number) on
+// purpose: every 2.0 control sizes itself through the ElementSize enum.
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'onChange' | 'size'
+> {
+  labelProps?: DialLabelProps;
+  inputButtonProps?: InputButtonProps;
+
+  size?: ElementSize;
+
+  invalid?: boolean;
+  error?: string;
+  caption?: string;
+  tooltipText?: string;
+
+  iconBefore?: ReactNode;
+  iconAfter?: ReactNode;
+
+  prefix?: string;
+  postfix?: string;
+
+  inputRef?: Ref<HTMLInputElement>;
+
+  onChange?: (value?: string) => void;
+
+  containerClassName?: string;
+  wrapperClassName?: string;
+}
+
+/**
+ * A flexible input component with icon support and various styling options
+ * aliases: TextField|FormInput
+ *
+ * @example
+ * ```tsx
+ * <Input
+ *   id="search"
+ *   placeholder="Search..."
+ *   iconBefore={<SearchIcon />}
+ *   iconAfter={<ClearIcon />}
+ *   onChange={(value) => console.log(value)}
+ * />
+ * ```
+ *
+ * @param [invalid] - Whether the input has validation errors (applies error styling)
+ * @param [iconAfter] - Icon or element to display after the input
+ * @param [iconBefore] - Icon or element to display before the input
+ * @param [textBeforeInput] - Text to display before the input
+ * @param [suffix] - Text to display inside the input on the right
+ * @param [containerClassName] - Additional CSS classes to apply to the container div
+ * @param [wrapperClassName] - Additional CSS classes to apply to the input wrapper div
+ * @param [className] - Additional CSS classes to apply to the input element
+ * @param [inputRef] - Ref to access the underlying input element
+ * @param [error] - Error message to display below the input (also adds error styling)
+ * @param [caption] - Helper text to display below the input
+ * @param [onChange] - Callback function called when the input value changes
+ */
+export const Input: FC<InputProps> = ({
+  labelProps,
+  error,
+  caption,
+  id,
+  containerClassName,
+  size = ElementSize.Standard,
+  ...props
+}) => {
+  return (
+    <div
+      className={mergeClasses(
+        'flex flex-col',
+        size === ElementSize.Small ? 'gap-1' : 'gap-2',
+        containerClassName,
+      )}
+    >
+      {labelProps && <Label {...labelProps} htmlFor={id} />}
+
+      <div className="flex flex-col gap-1">
+        <InputWrapper id={id} size={size} {...props} />
+        <ErrorText text={error} />
+        {!error && <CaptionText text={caption} />}
+      </div>
+    </div>
+  );
+};
+
+type InputWrapperProps = Omit<
+  InputProps,
+  'labelProps' | 'containerClassName' | 'errorText'
+>;
+
+const InputWrapper: FC<InputWrapperProps> = ({
+  invalid,
+  disabled,
+  prefix,
+  className,
+  postfix,
+  iconBefore,
+  iconAfter,
+  wrapperClassName,
+  type,
+  inputRef,
+  value,
+  tooltipText,
+  min,
+  onChange,
+  max,
+  inputButtonProps,
+  size = ElementSize.Standard,
+  ...props
+}) => {
+  const isSmall = size === ElementSize.Small;
+  const innerRef = useRef<HTMLInputElement | null>(null);
+  const ref = useMergeRefs([inputRef, innerRef]);
+
+  const isNumericInput =
+    type === 'number' || min !== undefined || max !== undefined;
+
+  // Prevent mouse wheel from changing numeric input values only.
+  useEffect(() => {
+    const el = innerRef.current;
+    if (!el || !isNumericInput || disabled) return;
+
+    const stopScroll = (e: Event) => {
+      e.preventDefault();
+    };
+
+    el.addEventListener('wheel', stopScroll, { passive: false });
+
+    return () => {
+      el.removeEventListener('wheel', stopScroll);
+    };
+  }, [disabled, isNumericInput, type]);
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    handleKeyDown(e, type, min, max);
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.currentTarget.value;
+
+    if (isNumericInput && newValue !== '') {
+      const numericValue = parseFloat(newValue);
+
+      // If it's not a valid number (except for partial inputs like "-" or ".")
+      if (isNaN(numericValue) && newValue !== '-' && newValue !== '.') {
+        return;
+      }
+
+      // Check range constraints for complete numbers
+      if (!isNaN(numericValue)) {
+        if (min !== undefined && numericValue < +min) {
+          return;
+        }
+        if (max !== undefined && numericValue > +max) {
+          return;
+        }
+      }
+    }
+
+    onChange?.(!newValue ? void 0 : newValue);
+  };
+
+  const input = () => {
+    return (
+      <div
+        className={mergeClasses(
+          'dial-kit-input flex flex-row items-center justify-between',
+          isSmall ? 'dial-kit-input-small gap-x-1' : 'gap-x-2 py-2',
+          invalid && 'dial-kit-input-error',
+          disabled && 'dial-kit-input-disable',
+          !prefix && (isSmall ? 'pl-2' : 'pl-3'),
+          !inputButtonProps && (isSmall ? 'pr-2' : 'pr-3'),
+          wrapperClassName,
+        )}
+        aria-label="input-container"
+      >
+        {prefix && (
+          <div className="border-r border-tertiary">
+            <InputWrapper
+              wrapperClassName="!rounded-r-none"
+              className="truncate"
+              value={prefix}
+              disabled
+              size={size}
+              id={`${prefix}_textBefore`}
+            />
+          </div>
+        )}
+
+        <DialIcon icon={iconBefore} />
+
+        <input
+          ref={ref}
+          type={type}
+          autoComplete={type === 'password' ? 'new-password' : 'off'}
+          value={value ?? ''}
+          className={mergeClasses(
+            'border-0 bg-transparent w-full truncate',
+            disabled && 'cursor-not-allowed',
+            className,
+          )}
+          onChange={handleChange}
+          onKeyDown={onKeyDown}
+          min={min}
+          disabled={disabled}
+          max={max}
+          {...props}
+        />
+
+        {postfix && (
+          <p
+            className={mergeClasses(
+              'text-secondary',
+              isSmall ? 'dial-tiny-text' : 'dial-small-text',
+            )}
+          >
+            {' '}
+            {postfix}
+          </p>
+        )}
+
+        <DialIcon icon={iconAfter} />
+
+        {inputButtonProps && (
+          <InputButton size={size} {...inputButtonProps} disabled={disabled} />
+        )}
+      </div>
+    );
+  };
+
+  return disabled && type !== 'password' ? (
+    <DialTooltip tooltip={tooltipText || value}>{input()}</DialTooltip>
+  ) : (
+    input()
+  );
+};

--- a/src/components/New/Input/utils.ts
+++ b/src/components/New/Input/utils.ts
@@ -1,0 +1,83 @@
+import type { KeyboardEvent } from 'react';
+
+const ALLOWED_INPUT_KEYS = [
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Backspace',
+  'Delete',
+  'Tab',
+  'Enter',
+  'Escape',
+  'Home',
+  'End',
+  'Insert',
+];
+
+export const handleKeyDown = (
+  e: KeyboardEvent<HTMLInputElement>,
+  type?: string,
+  min?: number | string,
+  max?: number | string,
+) => {
+  const isNumericInput =
+    type === 'number' || min !== undefined || max !== undefined;
+
+  if (!isNumericInput) return;
+
+  if (ALLOWED_INPUT_KEYS.includes(e.key)) {
+    return;
+  }
+
+  // Allow common keyboard shortcuts (Ctrl+A, Ctrl+C, Ctrl+V, etc.)
+  if (e.ctrlKey || e.metaKey) {
+    return;
+  }
+
+  // Allow minus sign only at the beginning and if not already present
+  if (
+    e.key === '-' &&
+    (e.currentTarget.selectionStart ?? 0) === 0 &&
+    !e.currentTarget.value.includes('-')
+  ) {
+    return;
+  }
+
+  // Allow decimal point for number inputs (but not if it already exists)
+  if (
+    e.key === '.' &&
+    type === 'number' &&
+    !e.currentTarget.value.includes('.')
+  ) {
+    return;
+  }
+
+  // Only allow numeric characters
+  if (!/^[0-9]$/.test(e.key)) {
+    e.preventDefault();
+    return;
+  }
+
+  // Check if the resulting value would be within range
+  if (min !== undefined || max !== undefined) {
+    const currentValue = e.currentTarget.value;
+    const cursorPosition = e.currentTarget.selectionStart || 0;
+    const newValue =
+      currentValue.slice(0, cursorPosition) +
+      e.key +
+      currentValue.slice(cursorPosition);
+    const numericValue = parseFloat(newValue);
+
+    if (!isNaN(numericValue)) {
+      if (min !== undefined && numericValue < +min) {
+        e.preventDefault();
+        return;
+      }
+      if (max !== undefined && numericValue > +max) {
+        e.preventDefault();
+        return;
+      }
+    }
+  }
+};

--- a/src/components/New/Label/Label.spec.tsx
+++ b/src/components/New/Label/Label.spec.tsx
@@ -102,7 +102,13 @@ describe('Dial UI Kit :: Label', () => {
   });
 
   test('Should name the caption info button', () => {
-    render(<Label label="Phone Number" htmlFor="phone-input" caption="Digits only" />);
+    render(
+      <Label
+        label="Phone Number"
+        htmlFor="phone-input"
+        caption="Digits only"
+      />,
+    );
 
     expect(screen.getByRole('button')).toHaveAccessibleName('Digits only');
   });
@@ -116,7 +122,11 @@ describe('Dial UI Kit :: Label', () => {
   test('Should keep the info button outside the label element', () => {
     render(
       <>
-        <Label label="Phone Number" htmlFor="phone-input" caption="Digits only" />
+        <Label
+          label="Phone Number"
+          htmlFor="phone-input"
+          caption="Digits only"
+        />
         <input id="phone-input" type="text" />
       </>,
     );

--- a/src/components/New/Label/Label.spec.tsx
+++ b/src/components/New/Label/Label.spec.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { Label } from './Label';
+
+describe('Dial UI Kit :: Label', () => {
+  test('Should render with label and be accessible by htmlFor', () => {
+    render(
+      <>
+        <Label label="Email Address" htmlFor="email-input" />
+        <input id="email-input" type="text" />
+      </>,
+    );
+    const input = screen.getByLabelText('Email Address');
+    const labelElement = screen.getByText('Email Address').closest('label');
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+    expect(labelElement).toHaveAttribute('for', 'email-input');
+  });
+
+  test('Should not render when label is not provided', () => {
+    const { container } = render(<Label htmlFor="test-input" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('Should display optional text when optional is true', () => {
+    render(<Label label="Optional Field" htmlFor="optional-input" required />);
+    expect(screen.getByText('Optional Field')).toBeInTheDocument();
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  test('Should not display optional text when optional is false', () => {
+    render(
+      <Label
+        label="Required Field"
+        htmlFor="required-input"
+        required={false}
+      />,
+    );
+    expect(screen.getByText('Required Field')).toBeInTheDocument();
+  });
+
+  test('Should apply custom CSS class', () => {
+    render(
+      <Label
+        label="Styled Field"
+        htmlFor="styled-input"
+        className="custom-label-class"
+      />,
+    );
+    const label = screen.getByText('Styled Field').closest('label');
+    expect(label).toHaveClass('custom-label-class');
+  });
+
+  test('Should apply default CSS classes', () => {
+    render(<Label label="Default Field" htmlFor="default-input" />);
+    const label = screen.getByText('Default Field').closest('label');
+    expect(label).toHaveClass('dial-tiny-semi-text', 'text-secondary');
+  });
+
+  test('Should handle empty label string', () => {
+    const { container } = render(<Label label="" htmlFor="empty-input" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('Should work with optional field', () => {
+    render(
+      <Label
+        label="Full Featured"
+        htmlFor="full-input"
+        required
+        className="special-label"
+      />,
+    );
+
+    const label = screen.getByText('Full Featured').closest('label');
+    expect(label).toHaveClass(
+      'special-label',
+      'dial-tiny-semi-text',
+      'text-secondary',
+    );
+    expect(screen.getByText('Full Featured')).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', 'full-input');
+  });
+
+  test('returns null when label is an empty string', () => {
+    const { container } = render(<Label htmlFor="email-input" label="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('Should announce the requirement instead of a bare asterisk', () => {
+    render(
+      <>
+        <Label label="Phone Number" htmlFor="phone-input" required />
+        <input id="phone-input" type="text" />
+      </>,
+    );
+
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('textbox')).toHaveAccessibleName(
+      'Phone Number (required)',
+    );
+  });
+
+  test('Should name the caption info button', () => {
+    render(<Label label="Phone Number" htmlFor="phone-input" caption="Digits only" />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Digits only');
+  });
+
+  test('Should render no info button without a caption', () => {
+    render(<Label label="Phone Number" htmlFor="phone-input" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('Should keep the info button outside the label element', () => {
+    render(
+      <>
+        <Label label="Phone Number" htmlFor="phone-input" caption="Digits only" />
+        <input id="phone-input" type="text" />
+      </>,
+    );
+
+    const label = screen.getByText('Phone Number').closest('label');
+    expect(label).not.toContainElement(screen.getByRole('button'));
+    expect(screen.getByRole('textbox')).toHaveAccessibleName('Phone Number');
+  });
+});

--- a/src/components/New/Label/Label.stories.tsx
+++ b/src/components/New/Label/Label.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Label, type LabelProps } from './Label';
+
+const meta = {
+  title: 'Components_2_0/Label',
+  component: Label,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A field label component that provides consistent styling for form labels with optional indicators and icons.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: { type: 'text' },
+      description: 'The title/label text to display for the field',
+    },
+    htmlFor: {
+      control: { type: 'text' },
+      description: 'The ID of the form element this label is associated with',
+    },
+    required: {
+      control: { type: 'boolean' },
+      description:
+        'Whether the field is required (displays `*` plus visually hidden "(required)" text)',
+    },
+    caption: {
+      control: { type: 'text' },
+      description:
+        'Explanatory text, exposed through an info button next to the label',
+    },
+  },
+  args: {
+    label: 'Field Label',
+    htmlFor: 'field-input',
+    required: false,
+  },
+  render: (args: LabelProps) => {
+    return (
+      <div className="w-80">
+        <Label {...args} />
+      </div>
+    );
+  },
+} satisfies Meta<LabelProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    label: 'Email Address',
+    htmlFor: 'email-input',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Phone Number',
+    htmlFor: 'phone-input',
+    required: true,
+  },
+};
+
+export const Caption: Story = {
+  args: {
+    label: 'Phone Number',
+    htmlFor: 'phone-input',
+    required: true,
+    caption: 'This is a caption for the phone number field',
+  },
+};
+
+export const LongLabel: Story = {
+  args: {
+    label: 'This is a very long field label that might wrap to multiple lines',
+    htmlFor: 'long-label-input',
+    required: true,
+  },
+};

--- a/src/components/New/Label/Label.tsx
+++ b/src/components/New/Label/Label.tsx
@@ -1,0 +1,80 @@
+import { mergeClasses } from '@/utils/merge-classes';
+import type { FC, LabelHTMLAttributes, ReactNode } from 'react';
+
+import { ElementSize } from '../../../types/size';
+import { InfoButton } from '../InfoButton/InfoButton';
+
+type NativeLabelProps = Omit<
+  LabelHTMLAttributes<HTMLLabelElement>,
+  'children' | 'defaultValue' | 'onChange'
+>;
+
+export interface LabelProps extends NativeLabelProps {
+  label?: ReactNode;
+  required?: boolean;
+  caption?: string;
+  size?: ElementSize;
+}
+
+/**
+ * A label component
+ * aliases: FormLabel|RequiredIndicator
+ *
+ * @example
+ * ```tsx
+ * // Basic  label
+ * <Label htmlFor="email-input" label="Email Address" />
+ * ```
+ *
+ * Pass `htmlFor` with the id of the control this labels — without it the label
+ * names nothing. The `caption` info button renders as a sibling of the `<label>`
+ * rather than inside it: a button nested in a label forwards its clicks to the
+ * labelled control and leaks its own text into that control's accessible name.
+ *
+ * @param [label] - The label text to display for the label
+ * @param [required=false] - Whether the field is required. Renders a visual `*`
+ * plus visually hidden text so the requirement is announced too.
+ * @param [caption] - Explanatory text, exposed through an info button next to the label
+ * @param [size] - The size of the label, which can be 'small', 'medium', or 'large'.
+ */
+export const Label: FC<LabelProps> = ({
+  label,
+  required,
+  className,
+  caption,
+  size = ElementSize.Small,
+  ...props
+}) => {
+  if (!label) return null;
+
+  return (
+    <span className="flex items-center gap-0.5">
+      <label
+        {...props}
+        className={mergeClasses(
+          'text-secondary flex items-center gap-0.5',
+          size === ElementSize.Small
+            ? 'dial-tiny-semi-text'
+            : 'dial-small-text',
+          className,
+        )}
+      >
+        {typeof label === 'string' ? (
+          <span className="min-h-4">{label}</span>
+        ) : (
+          label
+        )}
+        {required && (
+          <>
+            <span aria-hidden="true" className="text-error dial-tiny-text">
+              *
+            </span>
+            <span className="sr-only">(required)</span>
+          </>
+        )}
+      </label>
+
+      <InfoButton caption={caption} />
+    </span>
+  );
+};

--- a/src/components/New/Notification/Notification.spec.tsx
+++ b/src/components/New/Notification/Notification.spec.tsx
@@ -6,7 +6,7 @@ import { Notification } from './Notification';
 describe('Dial UI Kit :: Notification', () => {
   test('Should render with message text', () => {
     render(<Notification message="Hello notification" />);
-    expect(screen.getByRole('alert', { name: '' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '' })).toBeInTheDocument();
     expect(screen.getByText('Hello notification')).toBeInTheDocument();
   });
 
@@ -27,13 +27,31 @@ describe('Dial UI Kit :: Notification', () => {
 
   test('Should apply custom className', () => {
     render(<Notification message="Styled" className="custom-alert-class" />);
-    const alert = screen.getByRole('alert');
+    const alert = screen.getByRole('status');
     expect(alert).toHaveClass('custom-alert-class');
   });
 
-  test('Should render role="alert" for accessibility', () => {
-    render(<Notification message="Accessible" />);
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+  test.each([
+    [NotificationVariant.Error, 'alert'],
+    [NotificationVariant.Warning, 'alert'],
+    [NotificationVariant.Info, 'status'],
+    [NotificationVariant.Success, 'status'],
+    [NotificationVariant.Loading, 'status'],
+  ])(
+    'Should expose the %s variant as a %s live region',
+    (variant, expectedRole) => {
+      render(<Notification variant={variant} message="Accessible" />);
+
+      expect(screen.getByRole(expectedRole)).toBeInTheDocument();
+    },
+  );
+
+  test('Should let the caller override the live-region role', () => {
+    // Static page content should not announce itself as an update.
+    render(<Notification message="Static" role="note" />);
+
+    expect(screen.getByRole('note')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   test('Should pass mouse event to onClose handler', () => {
@@ -58,9 +76,20 @@ describe('Dial UI Kit :: Notification', () => {
   });
 
   test('Should render spinner for Loading variant', () => {
+    const { container } = render(
+      <Notification variant={NotificationVariant.Loading} message="Loading…" />,
+    );
+
+    expect(container.querySelector('.animate-spin-steps')).toBeInTheDocument();
+  });
+
+  test('Should not nest the spinner live region inside the notification', () => {
     render(
       <Notification variant={NotificationVariant.Loading} message="Loading…" />,
     );
-    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    // DialSpinner brings its own role="status"; nested live regions announce
+    // their content twice.
+    expect(screen.getAllByRole('status')).toHaveLength(1);
   });
 });

--- a/src/components/New/Notification/Notification.spec.tsx
+++ b/src/components/New/Notification/Notification.spec.tsx
@@ -88,7 +88,7 @@ describe('Dial UI Kit :: Notification', () => {
       <Notification variant={NotificationVariant.Loading} message="Loading…" />,
     );
 
-    // DialSpinner brings its own role="status"; nested live regions announce
+    // Spinner brings its own role="status"; nested live regions announce
     // their content twice.
     expect(screen.getAllByRole('status')).toHaveLength(1);
   });

--- a/src/components/New/Notification/Notification.tsx
+++ b/src/components/New/Notification/Notification.tsx
@@ -15,6 +15,7 @@ import { DialGhostIconButton } from '../../IconButton/IconButtonWrappers';
 import {
   alertBaseClassName,
   notificationVariantClassNameMap,
+  notificationVariantRoleMap,
   variantIcons,
 } from './constants';
 
@@ -39,6 +40,12 @@ export interface NotificationProps extends Omit<
  *
  * Renders a colored container with an icon, message text, and an optional
  * close button.
+ *
+ * The container is a live region whose politeness follows the variant: `error`
+ * and `warning` use `role="alert"` (assertive, interrupts the screen reader),
+ * every other variant uses `role="status"` (polite, queues). Pass an explicit
+ * `role` to override — including for a notification that is static page content
+ * rather than an update.
  *
  * @example
  * ```tsx
@@ -104,8 +111,10 @@ export const Notification: FC<NotificationProps> = ({
 
   return (
     <div
+      // Before the spread, so a consumer can still override it — a notification
+      // rendered as static page content may want no live region at all.
+      role={notificationVariantRoleMap[variant]}
       {...props}
-      role="alert"
       className={mergeClasses(
         alertBaseClassName,
         notificationVariantClassNameMap[variant],
@@ -118,7 +127,15 @@ export const Notification: FC<NotificationProps> = ({
       )}
     >
       <div className="flex items-start gap-3 flex-1 min-w-0">
-        <DialIcon icon={icon} />
+        {/*
+          The variant icon restates what the message already says. It also has
+          to stay out of the accessibility tree because the Loading variant's
+          spinner carries its own `role="status"` — a live region nested inside
+          this one causes the content to be announced twice.
+        */}
+        <span aria-hidden="true" className="flex shrink-0">
+          <DialIcon icon={icon} />
+        </span>
         {title ? (
           <div
             className={mergeClasses(

--- a/src/components/New/Notification/constants.tsx
+++ b/src/components/New/Notification/constants.tsx
@@ -30,5 +30,26 @@ export const notificationVariantClassNameMap: Record<
   [NotificationVariant.Loading]: 'bg-layer-raised text-info',
 };
 
+/**
+ * Live-region role per variant.
+ *
+ * `role="alert"` is implicitly `aria-live="assertive"`: it interrupts whatever a
+ * screen reader is currently saying. That is right for a problem the user must
+ * deal with, and wrong for routine feedback — an assertive info or success
+ * message cuts the user off mid-sentence, and a section message rendered with
+ * the page announces itself on mount even though nothing changed.
+ * `role="status"` is polite and queues instead.
+ */
+export const notificationVariantRoleMap: Record<
+  NotificationVariant,
+  'alert' | 'status'
+> = {
+  [NotificationVariant.Info]: 'status',
+  [NotificationVariant.Success]: 'status',
+  [NotificationVariant.Warning]: 'alert',
+  [NotificationVariant.Error]: 'alert',
+  [NotificationVariant.Loading]: 'status',
+};
+
 export const alertBaseClassName =
   'items-center justify-between rounded-xl relative gap-3 p-3 border flex border-transparent';

--- a/src/components/New/Notification/constants.tsx
+++ b/src/components/New/Notification/constants.tsx
@@ -1,4 +1,4 @@
-import { DialSpinner } from '@/components/Spinner/Spinner';
+import { Spinner } from '@/components/Spinner/Spinner';
 import { NotificationVariant } from '@/types/notification';
 import {
   IconAlertCircleFilled,
@@ -16,7 +16,7 @@ export const variantIcons = (props: {
   error: <IconAlertCircleFilled size={props.size} />,
   warning: <IconAlertTriangleFilled size={props.size} />,
   success: <IconCircleCheckFilled size={props.size} />,
-  loading: <DialSpinner size={props.size} />,
+  loading: <Spinner size={props.size} />,
 });
 
 export const notificationVariantClassNameMap: Record<

--- a/src/components/New/Textarea/Textarea.spec.tsx
+++ b/src/components/New/Textarea/Textarea.spec.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { Textarea } from './Textarea';
+
+describe('Dial UI Kit :: DialTextarea', () => {
+  test('Should render successfully', () => {
+    const { baseElement } = render(<Textarea id="testArea" />);
+    expect(baseElement).toBeTruthy();
+  });
+
+  test('Should set string value', () => {
+    const res = render(<Textarea id="testArea" value="str" />);
+    const input = res.getByDisplayValue('str');
+    expect(input).toBeTruthy();
+    expect(input.id).toBe('testArea');
+  });
+
+  test('Should check invalid true', () => {
+    const res = render(<Textarea id="testArea" value="str" invalid={true} />);
+    const input = res.getByDisplayValue('str');
+    expect(input).toBeTruthy();
+
+    const hasError = input.className.includes('dial-input-error');
+    expect(hasError).toBeTruthy();
+  });
+
+  test('Should check OnChange', () => {
+    let value = 1;
+    const onChange = (v: string) => {
+      value = Number(v);
+    };
+
+    const { baseElement } = render(
+      <Textarea id="testArea" value={value} onChange={onChange} />,
+    );
+    const input = baseElement.getElementsByTagName('textarea')[0];
+
+    expect(input).toBeTruthy();
+    expect(Number(input.value)).toBe(1);
+    fireEvent.change(input, { target: { value: 2 } });
+    expect(value).toBe(2);
+  });
+});

--- a/src/components/New/Textarea/Textarea.spec.tsx
+++ b/src/components/New/Textarea/Textarea.spec.tsx
@@ -20,7 +20,7 @@ describe('Dial UI Kit :: DialTextarea', () => {
     const input = res.getByDisplayValue('str');
     expect(input).toBeTruthy();
 
-    const hasError = input.className.includes('dial-input-error');
+    const hasError = input.className.includes('dial-kit-input-error');
     expect(hasError).toBeTruthy();
   });
 

--- a/src/components/New/Textarea/Textarea.stories.tsx
+++ b/src/components/New/Textarea/Textarea.stories.tsx
@@ -1,0 +1,182 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Textarea, type TextareaProps } from './Textarea';
+
+const InteractiveTextarea = (args: TextareaProps) => {
+  const [value, setValue] = useState(args.value || '');
+
+  return (
+    <div className="w-full text-primary">
+      <Textarea
+        {...args}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Components_2_0/Textarea',
+  component: Textarea,
+  tags: ['textarea'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A flexible textarea component with validation support and consistent styling. Perfect for multi-line text input with error handling and disabled states.',
+      },
+    },
+  },
+  argTypes: {
+    id: {
+      control: 'text',
+      description: 'Unique identifier for the textarea element',
+    },
+    value: {
+      control: 'text',
+      description: 'The current value of the textarea',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text displayed when textarea is empty',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the textarea is disabled',
+    },
+    invalid: {
+      control: 'boolean',
+      description: 'Whether the textarea has validation errors',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes to apply to the textarea',
+    },
+    onChange: {
+      action: 'changed',
+      control: false,
+      description: 'Callback function called when the textarea value changes',
+    },
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: InteractiveTextarea,
+  args: {
+    id: 'default-textarea',
+    placeholder: 'Enter your text here...',
+  },
+};
+
+export const Resize: Story = {
+  render: InteractiveTextarea,
+  args: {
+    id: 'resize-textarea',
+    placeholder: 'Enter text...',
+    value: 'This textarea can be resized',
+    resize: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => {
+    const props = {
+      labelProps: { label: 'Label', required: true },
+      id: 'interactive-textarea',
+      placeholder: 'Enter your text here...',
+      caption:
+        'This is a caption text providing additional information about the textarea.',
+    };
+    return (
+      <div className="flex flex-col size-full items-center">
+        <h2 className="text-primary font-semibold mb-8">Textarea</h2>
+
+        <div className="flex-1 min-h-0 flex flex-col gap-y-6">
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Default
+              </div>
+              <InteractiveTextarea {...props} />
+            </div>
+
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Filled
+              </div>
+              <InteractiveTextarea {...props} value="Text" />
+            </div>
+          </div>
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Hover
+              </div>
+              <InteractiveTextarea
+                {...props}
+                className="dial-input-for-hover"
+              />
+            </div>
+
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Focus/Active
+              </div>
+              <InteractiveTextarea
+                {...props}
+                className="dial-input-for-focus"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Disabled filled
+              </div>
+              <InteractiveTextarea {...props} disabled={true} value="Text" />
+            </div>
+
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Disabled empty
+              </div>
+              <InteractiveTextarea {...props} disabled={true} />
+            </div>
+          </div>
+          <div className="flex flex-row items-center gap-x-6">
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Error
+              </div>
+              <InteractiveTextarea
+                {...props}
+                invalid={true}
+                value="Text"
+                error="Error message"
+              />
+            </div>
+
+            <div className="flex flex-row items-center gap-x-6">
+              <div className="text-primary font-semibold mb-2 w-[150px]">
+                Error without message
+              </div>
+              <InteractiveTextarea {...props} invalid={true} value="Text" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    pseudo: {
+      hover: ['.dial-input-for-hover'],
+      focus: ['.dial-input-for-focus'],
+    },
+  },
+};

--- a/src/components/New/Textarea/Textarea.tsx
+++ b/src/components/New/Textarea/Textarea.tsx
@@ -1,0 +1,87 @@
+import {
+  type DetailedHTMLProps,
+  type FC,
+  type TextareaHTMLAttributes,
+} from 'react';
+
+import { type DialLabelProps } from '@/components/Label/Label';
+import { mergeClasses } from '@/utils/merge-classes';
+import { CaptionText, ErrorText } from '../CaptionText/CaptionText';
+import { Label } from '../Label/Label';
+
+export interface TextareaProps extends DetailedHTMLProps<
+  Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'>,
+  HTMLTextAreaElement
+> {
+  labelProps?: DialLabelProps;
+  invalid?: boolean;
+  containerClassName?: string;
+  resize?: boolean;
+  error?: string;
+  caption?: string;
+  onChange?: (value: string) => void;
+}
+
+/**
+ * A flexible textarea component with validation support and consistent styling
+ * aliases: MultilineInput|TextBox
+ *
+ * @example
+ * ```tsx
+ * <DialTextarea
+ *   id="description"
+ *   placeholder="Enter description..."
+ *   value={value}
+ *   onChange={(value) => setValue(value)}
+ * />
+ * ```
+ * @params Component properties extending:
+ * - {@link TextareaHTMLAttributes<HTMLTextAreaElement>} - Standard textarea attributes (id, value, placeholder, disabled, etc.)
+ * - {@link HTMLTextAreaElement} - The underlying HTML textarea element type
+ *
+ * @param [onChange] - Callback function called when the textarea value changes
+ * @param [labelProps] - Props for the field label, including `label` (label text) and `required` (whether to show required indicator)
+ * @param [className=""] - Additional CSS classes to apply to the textarea element
+ * @param [containerClassName=""] - Additional CSS classes to apply to the container div
+ * @param [invalid=false] - Whether the textarea has validation errors (applies error styling)
+ * @param [resize=false] - Whether the textarea has possibility to resize
+ * @param [error] - Error message to display below the textarea (also adds error styling)
+ * @param [caption] - Optional caption text to display below the textarea
+ */
+export const Textarea: FC<TextareaProps> = ({
+  className = '',
+  value,
+  onChange,
+  error,
+  containerClassName,
+  resize = false,
+  labelProps,
+  caption,
+  id,
+  ...props
+}) => {
+  const textareaClassName = mergeClasses(
+    'dial-kit-textarea dial-kit-input px-3 py-2',
+    props.invalid && 'dial-kit-input-error',
+    props.disabled && 'dial-kit-input-disable',
+    resize ? 'resize' : 'resize-none',
+    className,
+  );
+
+  return (
+    <div className={mergeClasses('flex flex-col gap-2', containerClassName)}>
+      {labelProps && <Label {...labelProps} htmlFor={id} />}
+      <div className="flex flex-col gap-1">
+        <textarea
+          id={id}
+          value={value || ''}
+          className={textareaClassName}
+          onChange={(event) => onChange?.(event.currentTarget.value)}
+          {...props}
+        />
+        <ErrorText text={error} />
+        {!error && <CaptionText text={caption} />}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Notification/constants.tsx
+++ b/src/components/Notification/constants.tsx
@@ -1,4 +1,4 @@
-import { DialSpinner } from '@/components/Spinner/Spinner';
+import { Spinner } from '@/components/Spinner/Spinner';
 import { NotificationVariant } from '@/types/notification';
 import {
   IconAlertCircleFilled,
@@ -16,7 +16,7 @@ export const variantIcons = (props: {
   error: <IconAlertCircleFilled size={props.size} />,
   warning: <IconAlertTriangleFilled size={props.size} />,
   success: <IconCircleCheckFilled size={props.size} />,
-  loading: <DialSpinner size={props.size} />,
+  loading: <Spinner size={props.size} />,
 });
 
 export const notificationVariantClassNameMap: Record<

--- a/src/components/Search/constants.ts
+++ b/src/components/Search/constants.ts
@@ -24,4 +24,11 @@ export const SIZE_CONFIG: Record<
     iconSize: 20,
     iconStroke: 1.5,
   },
+  [ElementSize.Large]: {
+    className: '',
+    wrapperClassName: '',
+    containerClassName: '',
+    iconSize: 0,
+    iconStroke: 0,
+  },
 };

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -208,7 +208,7 @@ export const DialSlider: FC<DialSliderProps> = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
           className={mergeClasses(
-            'dial-small-text absolute -translate-x-1/2 flex size-[38px] cursor-grab select-none items-center justify-center rounded-full bg-layer-3 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-focus',
+            'dial-small-text absolute -translate-x-1/2 flex size-[38px] cursor-grab select-none items-center justify-center rounded-full bg-layer-3 text-primary shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-black',
             thumbClassName,
           )}
           style={{ left: `${percent}%` }}

--- a/src/components/Spinner/Spinner.spec.tsx
+++ b/src/components/Spinner/Spinner.spec.tsx
@@ -1,49 +1,49 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
-import { DialSpinner } from './Spinner';
+import { Spinner } from './Spinner';
 
-describe('Dial UI Kit :: DialSpinner', () => {
+describe('Dial UI Kit :: Spinner', () => {
   test('renders with role=img and default aria-label', () => {
-    render(<DialSpinner />);
+    render(<Spinner />);
     expect(screen.getByRole('img', { name: 'Loading' })).toBeInTheDocument();
   });
 
   test('renders status container', () => {
-    render(<DialSpinner />);
+    render(<Spinner />);
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   test('does not apply full width by default', () => {
-    render(<DialSpinner />);
+    render(<Spinner />);
     const el = screen.getByRole('status');
     expect(el).not.toHaveClass('size-full');
   });
 
   test('applies full width when fullWidth is true', () => {
-    render(<DialSpinner fullWidth />);
+    render(<Spinner fullWidth />);
     const el = screen.getByRole('status');
     expect(el).toHaveClass('size-full');
   });
 
   test('respects custom aria label', () => {
-    render(<DialSpinner ariaLabel="Busy" />);
+    render(<Spinner ariaLabel="Busy" />);
     expect(screen.getByRole('img', { name: 'Busy' })).toBeInTheDocument();
   });
 
   test('applies custom size via inline style', () => {
-    render(<DialSpinner size={48} />);
+    render(<Spinner size={48} />);
     const ring = screen.getByRole('img');
     expect(ring).toHaveStyle({ width: '48px', height: '48px' });
   });
 
   test('renders with default size of 24px', () => {
-    render(<DialSpinner />);
+    render(<Spinner />);
     const ring = screen.getByRole('img');
     expect(ring).toHaveStyle({ width: '40px', height: '40px' });
   });
 
   test('applies custom className to container', () => {
-    render(<DialSpinner className="custom-class" />);
+    render(<Spinner className="custom-class" />);
     expect(screen.getByRole('status')).toHaveClass('custom-class');
   });
 });

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DialSpinner, type DialSpinnerProps } from './Spinner';
+import { Spinner, type SpinnerProps } from './Spinner';
 
 const meta = {
-  title: 'DIAL/Status/Spinner',
-  component: DialSpinner,
+  title: 'Components_2_0/Spinner',
+  component: Spinner,
   parameters: {
     layout: 'padded',
     docs: {
@@ -33,7 +33,7 @@ const meta = {
     fullWidth: false,
     ariaLabel: 'Loading',
   },
-} satisfies Meta<DialSpinnerProps>;
+} satisfies Meta<SpinnerProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,14 +1,14 @@
 import { mergeClasses } from '@/utils/merge-classes';
 import type { FC } from 'react';
 
-export interface DialSpinnerProps {
+export interface SpinnerProps {
   size?: number;
   className?: string;
   fullWidth?: boolean;
   ariaLabel?: string;
 }
 
-export const DialSpinner: FC<DialSpinnerProps> = ({
+export const Spinner: FC<SpinnerProps> = ({
   size = 40,
   className,
   fullWidth = false,

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -27,7 +27,7 @@ export const DialSpinner: FC<DialSpinnerProps> = ({
         role="img"
         aria-label={ariaLabel}
         style={{ width: size, height: size }}
-        className="rounded-full border-2 border-secondary border-t-accent-primary animate-spin-steps shrink-0"
+        className="rounded-full border-2 border-secondary border-t-info animate-spin-steps shrink-0"
       />
     </div>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ export { DialIcon } from './components/Icon/Icon';
 export { DialNotification } from './components/Notification/Notification.tsx';
 export type { DialNotificationProps } from './components/Notification/Notification.tsx';
 export { DialLoader } from './components/Loader/Loader';
-export { DialSpinner } from './components/Spinner/Spinner';
-export type { DialSpinnerProps } from './components/Spinner/Spinner';
+export { Spinner } from './components/Spinner/Spinner';
+export type { SpinnerProps } from './components/Spinner/Spinner';
 export {
   DialProgressBar,
   DialProgressBarSize,

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,3 +330,7 @@ export type {
   InlineSelectProps,
   InlineSelectTriggerProps,
 } from './components/New/InlineSelect/InlineSelect';
+export { InfoButton } from './components/New/InfoButton/InfoButton';
+export type { InfoButtonProps } from './components/New/InfoButton/InfoButton';
+export type { LabelProps } from './components/New/Label/Label';
+export { Label } from './components/New/Label/Label';

--- a/src/mcp/descriptions/typography.md
+++ b/src/mcp/descriptions/typography.md
@@ -20,9 +20,10 @@ Use these by default. They follow the design system type scale.
 | `.dial-small-paragraph-text`      | normal   | 14px / 24px             |
 | `.dial-small-paragraph-semi-text` | semibold | 14px / 24px             |
 | `.dial-tiny-text`                 | normal   | 12px / 16px             |
+| `.dial-tiny-lead-text`            | normal   | 12px / 16px (+0.03em)   |
 | `.dial-tiny-semi-text`            | semibold | 12px / 16px             |
 | `.dial-caption-text`              | normal   | 10px / 12px             |
-| `.dial-caption-semi-text`         | semibold | 10px / 12px             |
+| `.dial-caption-semi-text`         | semibold | 10px / 12px (+0.06em)   |
 | `.dial-code-text`                 | normal   | 14px / 20px (monospace) |
 
 ## Legacy classes (avoid in new code)

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -84,6 +84,10 @@ const TypographyShowcase = () => (
       />
       <TypographyRow className="dial-tiny-text" label="dial-tiny-text" />
       <TypographyRow
+        className="dial-tiny-lead-text"
+        label="dial-tiny-lead-text"
+      />
+      <TypographyRow
         className="dial-tiny-semi-text"
         label="dial-tiny-semi-text"
       />

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -1,6 +1,6 @@
 @media (hover: hover) {
   .dial-base-button:focus-visible {
-    @apply border-focus;
+    @apply border-focus-black;
   }
 }
 
@@ -10,11 +10,33 @@
   @apply flex flex-row items-center justify-center;
   @apply rounded-full border border-solid border-transparent;
   @apply disabled:cursor-not-allowed outline-offset-0;
-  @apply focus-visible:outline focus-visible:outline-focus;
+  @apply focus-visible:outline focus-visible:outline-focus-black;
 }
 
 .dial-kit-solid-button-disable {
-  @apply text-control-disable bg-none bg-control-disable border-transparent;
+  @apply text-control-disable-alpha bg-none bg-control-disable border-transparent;
+}
+
+/*
+ * WCAG 2.5.5 Target Size (Enhanced, AAA) requires a 44x44 CSS px pointer
+ * target. The criterion measures the region that accepts a pointer action, not
+ * the visible decoration, so this grows the target with a transparent
+ * pseudo-element and leaves the rendered control untouched.
+ *
+ * The pseudo-element never shrinks the target: it is at least 44px on both
+ * axes and at least as large as the control itself, so wide buttons keep their
+ * full width. Only apply it to controls that are 40px or larger — on the 24px
+ * small variants the 10px-per-side overhang would overlap adjacent controls in
+ * dense toolbars.
+ */
+.dial-kit-enhanced-target {
+  @apply relative;
+
+  &::after {
+    content: '';
+    @apply absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2;
+    @apply h-full w-full min-h-[44px] min-w-[44px];
+  }
 }
 
 /* Solid buttons */
@@ -62,7 +84,7 @@
 }
 
 .dial-kit-static-solid-button {
-  @apply dial-kit-base-button text-control-disable bg-transparent;
+  @apply dial-kit-base-button text-control-disable-alpha bg-transparent;
 
   @media (hover: hover) {
     &:hover {
@@ -127,7 +149,12 @@
         @apply enabled:text-accent;
       }
     }
+
+    &:disabled {
+      @apply !text-control-disable-beta;
+    }
   }
+
   @media (hover: hover) {
     &:hover {
       @apply bg-control-accent-alpha-hover;
@@ -151,11 +178,17 @@
   &:active {
     @apply bg-control-error-alpha-active;
   }
+
+  &.dial-kit-base-icon-button {
+    &:disabled {
+      @apply !text-control-disable-beta;
+    }
+  }
 }
 
 .dial-kit-primary-ghost-button:disabled,
 .dial-kit-danger-ghost-button:disabled {
-  @apply text-control-disable bg-transparent;
+  @apply text-control-disable-alpha bg-transparent;
 }
 
 /* Link buttons */
@@ -173,7 +206,7 @@
   }
 
   &:disabled {
-    @apply text-control-disable;
+    @apply text-control-disable-alpha;
   }
 }
 
@@ -192,7 +225,7 @@
   }
 
   &:focus-visible {
-    @apply outline outline-focus outline-offset-0;
+    @apply outline outline-focus-black outline-offset-0;
   }
 }
 

--- a/src/styles/input.scss
+++ b/src/styles/input.scss
@@ -10,7 +10,7 @@
   &:not(:disabled):focus,
   &:not(:disabled):active,
   &:not(:disabled):focus-within {
-    @apply border-focus;
+    @apply border-focus-black;
   }
 
   &:not(:placeholder-shown) {

--- a/src/styles/input.scss
+++ b/src/styles/input.scss
@@ -1,3 +1,48 @@
+.dial-kit-input {
+  @apply border border-tertiary rounded-lg h-[40px];
+  @apply bg-layer-raised truncate dial-small-paragraph-text;
+  @apply w-full;
+
+  &:not(:disabled):hover {
+    @apply border-hover-alpha;
+  }
+
+  &:focus-within,
+  &:active:not(:has(> input:disabled)) {
+    @apply outline outline-focus-blue outline-offset-0;
+  }
+
+  &:not(:placeholder-shown) {
+    @apply text-primary;
+  }
+
+  &:disabled {
+    @apply dial-kit-input-disable;
+    &:not(:placeholder-shown) {
+      @apply placeholder-secondary;
+    }
+  }
+}
+
+/*
+ * Height and typography of the small variant live here rather than as
+ * utilities on the component: these component classes are unlayered while
+ * `@tailwind utilities` sits in `@layer ui`, so an `h-[24px]` utility would
+ * lose the cascade to `.dial-kit-input`. Must stay after the base rule.
+ */
+.dial-kit-input-small {
+  @apply h-[24px] dial-tiny-text;
+}
+
+.dial-kit-input-disable,
+.dial-kit-input-disable:not(:placeholder-shown) {
+  @apply cursor-not-allowed bg-layer-sunken text-control-disable-alpha;
+}
+
+.dial-kit-input-error {
+  @apply border-error;
+}
+
 .dial-input {
   @apply border border-solid border-primary rounded h-[40px];
   @apply bg-transparent truncate dial-small-text;

--- a/src/styles/textarea.scss
+++ b/src/styles/textarea.scss
@@ -13,3 +13,7 @@
     @apply bg-controls-accent-primary;
   }
 }
+
+.dial-kit-textarea {
+  @apply min-h-[120px] whitespace-normal overflow-auto;
+}

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -54,6 +54,10 @@
   @apply font-normal text-[12px]/[16px];
 }
 
+.dial-tiny-lead-text {
+  @apply font-normal text-[12px]/[16px] tracking-[0.03em];
+}
+
 .dial-tiny-semi-text {
   @apply font-semibold text-[12px]/[16px];
 }
@@ -63,7 +67,7 @@
 }
 
 .dial-caption-semi-text {
-  @apply font-semibold text-[10px]/[12px];
+  @apply font-semibold text-[10px]/[12px] tracking-[0.06em];
 }
 
 .dial-code-text {

--- a/src/utils/__tests__/accessible-name.spec.ts
+++ b/src/utils/__tests__/accessible-name.spec.ts
@@ -1,0 +1,55 @@
+import { createElement } from 'react';
+import { describe, expect, test } from 'vitest';
+import { resolveAccessibleName } from '../accessible-name';
+
+describe('Dial UI Kit :: resolveAccessibleName', () => {
+  test('Should return the only candidate when it is a string', () => {
+    const result = resolveAccessibleName('Scroll to bottom');
+
+    expect(result).toBe('Scroll to bottom');
+  });
+
+  test('Should return the first candidate when several are strings', () => {
+    const result = resolveAccessibleName('Scroll to bottom', 'Tooltip text');
+
+    expect(result).toBe('Scroll to bottom');
+  });
+
+  test('Should skip a leading undefined candidate', () => {
+    const result = resolveAccessibleName(undefined, 'Tooltip text');
+
+    expect(result).toBe('Tooltip text');
+  });
+
+  test('Should skip a candidate that is not a string', () => {
+    const result = resolveAccessibleName(42, 'Tooltip text');
+
+    expect(result).toBe('Tooltip text');
+  });
+
+  test('Should skip an element candidate', () => {
+    const element = createElement('span', null, 'Rendered label');
+
+    const result = resolveAccessibleName(element, 'Tooltip text');
+
+    expect(result).toBe('Tooltip text');
+  });
+
+  test('Should skip an empty string candidate', () => {
+    const result = resolveAccessibleName('', 'Tooltip text');
+
+    expect(result).toBe('Tooltip text');
+  });
+
+  test('Should return undefined when no candidate is a non-empty string', () => {
+    const result = resolveAccessibleName(undefined, '', 42);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('Should return undefined when there are no candidates', () => {
+    const result = resolveAccessibleName();
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/utils/accessible-name.ts
+++ b/src/utils/accessible-name.ts
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Picks the first usable accessible name from an ordered list of candidates.
+ *
+ * Only non-empty strings can serve as an `aria-label`, so any candidate that is
+ * a different kind of `ReactNode` (an element, `undefined`, a number) is
+ * skipped. Callers pass candidates in priority order, which lets each component
+ * declare its own naming precedence.
+ *
+ * A tooltip is a common last resort: a control whose only label is a tooltip
+ * would otherwise be unnamed, because `DialTooltip` puts its `aria-describedby`
+ * on a wrapper element rather than on the control itself, and is suppressed on
+ * mobile. Pass the tooltip only when nothing else names the control — as an
+ * `aria-label` it overrides the element's own content.
+ *
+ * @param candidates - Naming candidates, highest priority first
+ * @returns The first non-empty string candidate, or `undefined` if there is none
+ */
+export const resolveAccessibleName = (
+  ...candidates: ReactNode[]
+): string | undefined =>
+  candidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.length > 0,
+  );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,31 +85,21 @@ const backgroundsColorsToRemove = {
   'layer-2': 'var(--bg-layer-2, #EEF1F7)',
   'layer-3': 'var(--bg-layer-3, #FCFCFC)',
   'layer-4': 'var(--bg-layer-4, #D1DBEA)',
-  'layer-5': 'var(--bg-layer-5, #F5F7FA)',
-  'layer-6': 'var(--bg-layer-6, #F8FAFC)',
-  'layer-7': 'var(--bg-layer-7, #00000006)',
-  'layer-8': 'var(--bg-layer-8, #f0f2f5)',
   blackout: 'var(--bg-blackout, #0C101D4D)',
-  overlay: 'var(--bg-overlay, #FCFCFC80)',
   error: 'var(--bg-error, #F3D6D8)',
   warning: 'var(--bg-warning, #FAF0CF)',
   info: 'var(--bg-info, #D6E2F9)',
   success: 'var(--bg-success, #D9F0F1)',
   neutral: 'var(--bg-neutral, #FCFCFC)',
-  inverted: 'var(--bg-inverted, #161B2D)',
   'accent-primary-alpha': 'var(--bg-accent-primary-alpha, #7DA4FF26)',
   'accent-secondary-alpha': 'var(--bg-accent-secondary-alpha, #37BABC2E)',
   'accent-tertiary-alpha': 'var(--bg-accent-tertiary-alpha, #A972FF2E)',
   'accent-primary': 'var(--bg-accent-primary, #5C8DEA)',
   'accent-secondary': 'var(--bg-accent-secondary, #37BABC)',
-  'accent-tertiary': 'var(--bg-accent-tertiary, #A972FF)',
   'red-400': 'var(--bg-red-400, #F76464)',
-  'orange-400': 'var(--bg-orange-400, #D97C27)',
-  'orange-800': 'var(--bg-orange-800, #B25500)',
 
   // controls
 
-  // REMOVED: old names, need to remove
   'controls-accent-primary': 'var(--controls-bg-accent-primary, #124ACE)',
   'controls-accent-primary-hover':
     'var(--controls-bg-accent-primary-hover, #2656D9)',
@@ -127,7 +117,6 @@ const backgroundsColorsToRemove = {
   'controls-error': 'var(--controls-bg-error, #AE2F2F)',
   'controls-error-hover': 'var(--controls-bg-error-hover, #BF3939)',
   'controls-error-active': 'var(--controls-bg-error-active, #CC4545)',
-  'controls-error-alpha-hover': 'var(--controls-bg-alpha-hover, #F764642E)',
   'controls-error-alpha-active':
     'var(--controls-bg-error-alpha-active, #F764645C)',
 
@@ -141,25 +130,13 @@ const backgroundsColorsToRemove = {
     'var(--controls-bg-accent-success-alpha-hover, #37BABC2E)',
   'controls-accent-success-alpha-active':
     'var(--controls-bg-accent-success-alpha-active, #37BABC5C)',
-  'controls-accent': 'var(--controls-bg-accent, #5C8DEA)',
-  'controls-accent-hover': 'var(--controls-bg-accent-hover, #4878D2)',
-  'controls-accent-alpha': 'var(--controls-bg-accent-alpha, #5C8DEA2B)',
   'controls-enable-primary': 'var(--controls-enable-primary, #FCFCFC)',
-};
-
-const controlsBorderColors = {
-  'controls-focus': 'var(--controls-stroke-focus, #EEF1F7)',
 };
 
 const borderColorsToRemove = {
   'accent-primary': 'var(--stroke-accent-primary, #124ACE)',
-  'accent-primary-hover': 'var(--stroke-accent-primary-hover, #7DA4FF)',
   'accent-secondary': 'var(--stroke-accent-secondary, #007274)',
-  'accent-tertiary': 'var(--stroke-accent-tertiary, #7E39EC)',
-  'hover-tint': 'var(--stroke-hover-tint, #0000001f)',
-  hairline: 'var(--stroke-hairline, #0000000d)',
   'controls-accent': 'var(--controls-bg-accent, #5C8DEA)',
-  'accent-primary-hover': 'var(--stroke-accent-primary-hover, #4878d2)',
   hover: 'var(--stroke-hover, #EEF1F7)',
   'red-900': 'var(--red-900, #402027)',
 };
@@ -168,7 +145,6 @@ const textColorsToRemove = {
   'accent-primary': 'var(--text-accent-primary, #7DA4FF)',
   'accent-secondary': 'var(--text-accent-secondary, #37BABC)',
   'accent-tertiary': 'var(--text-accent-tertiary, #A972FF)',
-  'controls-disable': 'var(--controls-text-disable, #0C101D)',
   // Controls
   'controls-permanent': 'var(--controls-text-permanent, #FCFCFC)',
   'controls-accent-disable': 'var(--controls-text-accent-disable, #D1DBEA)',
@@ -180,8 +156,6 @@ const textColorsToRemove = {
     'var(--controls-text-accent-primary-hover, #3664E2)',
   'controls-accent-primary-active':
     'var(--controls-text-accent-primary-active, #7DA4FF)',
-  'controls-primary': 'var(--controls-primary, #FCFCFC)',
-  'controls-disable': 'var(--controls-text-disable, #575F73)',
 };
 
 /** @type {import('tailwindcss').Config} */
@@ -196,17 +170,14 @@ export default {
     borderColor: {
       ...borderColors,
       ...borderColorsToRemove,
-      ...controlsBorderColors,
     },
     stroke: {
       ...borderColors,
       ...borderColorsToRemove,
-      ...controlsBorderColors,
     },
     divideColor: {
       ...borderColors,
       ...borderColorsToRemove,
-      ...controlsBorderColors,
     },
     placeholderColor: placeholderColor,
     textColor: { ...textColors, ...textColorsToRemove, ...controlsTextColors },
@@ -219,7 +190,6 @@ export default {
       outlineColor: {
         ...borderColors,
         ...borderColorsToRemove,
-        ...controlsBorderColors,
       },
       screens: {
         mobile: { max: '768px' },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,7 +66,7 @@ const controlsBgColors = {
   'control-error-alpha-active':
     'var(--bg-control-error-alpha-active, #F7646433)', // red-800 alpha-20
 
-  'control-disable': 'var(--bg-control-disable, #C7CBD4)', // grey-700
+  'control-disable': 'var(--bg-control-disable, #848E9C)', // grey-700
 
   // REMOVED: old names, need to remove
   'controls-accent-primary': 'var(--controls-bg-accent-primary, #124ACE)',
@@ -117,7 +117,8 @@ const borderColors = {
   info: 'var(--stroke-info, #124ACE)', // blue-500
   success: 'var(--stroke-success, #007274)', // green-800
   // controls
-  focus: 'var(--stroke-focus, #161B2D)', // grey-1000
+  'focus-black': 'var(--stroke-focus-black, #161B2D)', // grey-1000
+  'focus-blue': 'var(--stroke-focus-blue, #6785FB)', // blue-200
   'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20
   'error-alpha': 'var(--stroke-error-alpha, #AE2F2F73)', // red-800 alpha-45
 
@@ -142,8 +143,8 @@ const textColors = {
   // COLORS 2.0
   transparent: 'transparent',
   primary: 'var(--text-primary, #161B2D)', // grey-1000
-  secondary: 'var(--text-secondary, #6B7280)', // grey-800
-  tertiary: 'var(--text-tertiary, #C7CBD4)', // grey-700
+  secondary: 'var(--text-secondary, #57647a)', // grey-800
+  tertiary: 'var(--text-tertiary, #848e9c)', // grey-700
   accent: 'var(--text-accent, #1D4ED8)', // blue-500
   error: 'var(--text-error, #AE2F2F)', // red-500
   warning: 'var(--text-warning, #7F6300)', // yellow-700
@@ -166,7 +167,8 @@ const placeholderColor = {
 const controlsTextColors = {
   // COLORS 2.0
   'control-permanent': 'var(--text-control-permanent, #FCFCFC)', // grey-100
-  'control-disable': 'var(--text-control-disable, #6B7280)', // grey-800
+  'control-disable-alpha': 'var(--text-control-disable-alpha, #DCE0E8)', // grey-550
+  'control-disable-beta': 'var(--text-control-disable-beta, #848E9C)', // grey-700
   'control-blue-hover': 'var(--text-control-blue-hover, #5976E9)', // blue-300
   'control-blue-active': 'var(--text-control-blue-active, #6785FB)', // blue-200
 
@@ -198,7 +200,7 @@ export default {
     gradientColorStops: backgroundsColors,
 
     extend: {
-      // `outline` utility emits a 1px solid ring, `outline-focus` paints it
+      // `outline` utility emits a 1px solid ring, `outline-focus-black` paints it
       // with the focus token — see the focus-visible states in buttons.scss
       outlineWidth: { DEFAULT: '1px' },
       outlineColor: { ...borderColors, ...controlsBorderColors },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -117,6 +117,7 @@ const borderColors = {
   info: 'var(--stroke-info, #124ACE)', // blue-500
   success: 'var(--stroke-success, #007274)', // green-800
   // controls
+  'hover-alpha': 'var(--stroke-hover-alpha, #2764D933)', // blue-500 alpha-20
   'focus-black': 'var(--stroke-focus-black, #161B2D)', // grey-1000
   'focus-blue': 'var(--stroke-focus-blue, #6785FB)', // blue-200
   'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,6 @@
 
 const backgroundsColors = {
   transparent: 'transparent',
-  // COLORS 2.0
   'layer-sunken': 'var(--bg-layer-sunken, #EEF1F7)', // grey-300
   'layer-base': 'var(--bg-layer-base, #F5F7FA)', // grey-200
   'layer-raised': 'var(--bg-layer-raised, #FCFCFC)', // grey-100
@@ -11,12 +10,76 @@ const backgroundsColors = {
   info: 'var(--bg-info, #E1EAF9)', // blue-100
   success: 'var(--bg-success, #DBF1EB)', // green-100
   backdrop: 'var(--bg-backdrop, #161B2D4D)', // grey-1000 with 70% opacity
+};
 
-  // shadow colors
-  'shadow-blue': 'var(--shadow-blue-500, #2764D924)',
-  'shadow-grey': 'var(--shadow-grey-1000, #161B2D08)',
+const controlsBgColors = {
+  'control-accent-alpha': 'var(--bg-control-accent-alpha, #2764D90F)', // blue-500 alpha-6
+  'control-accent-alpha-hover':
+    'var(--bg-control-accent-alpha-hover, #2764D924)', // blue-500 alpha-14
+  'control-accent-alpha-active':
+    'var(--bg-control-accent-alpha-active, #2764D933)', // blue-500 alpha-20
 
-  // REMOVED: old names, need to remove
+  'control-accent': 'var(--bg-control-accent, #124ACE)', // blue-500
+
+  'control-neutral': 'var(--bg-control-neutral, #FCFCFC)', // grey-100
+  'control-neutral-hover': 'var(--bg-control-neutral-hover, #E0E6F0)', // grey-500
+  'control-neutral-active': 'var(--bg-control-neutral-active, #D1DBEA)', // grey-600
+
+  'control-error': 'var(--bg-control-error, #AE2F2F)', // red-800
+  'control-error-hover': 'var(--bg-control-error-hover, #BF3939)', // red-700
+  'control-error-active': 'var(--bg-control-error-active, #CC4545)', // red-600
+  'control-error-alpha-hover': 'var(--bg-control-error-alpha-hover, #F764641A)', // red-800 alpha-10
+  'control-error-alpha-active':
+    'var(--bg-control-error-alpha-active, #F7646433)', // red-800 alpha-20
+
+  'control-disable': 'var(--bg-control-disable, #848E9C)', // grey-700
+};
+
+const borderColors = {
+  transparent: 'transparent',
+  primary: 'var(--stroke-primary, #6B7280)', // grey-800
+  secondary: 'var(--stroke-secondary, #D1DBEA)', // grey-600
+  tertiary: 'var(--stroke-tertiary, #E0E6F0)', // grey-500
+  error: 'var(--stroke-error, #AE2F2F)', // red-800
+  warning: 'var(--stroke-warning, #EEC840)', // yellow-500
+  info: 'var(--stroke-info, #124ACE)', // blue-500
+  success: 'var(--stroke-success, #007274)', // green-800
+  // controls
+  'hover-alpha': 'var(--stroke-hover-alpha, #2764D933)', // blue-500 alpha-20
+  'focus-black': 'var(--stroke-focus-black, #161B2D)', // grey-1000
+  'focus-blue': 'var(--stroke-focus-blue, #6785FB)', // blue-200
+  'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20
+  'error-alpha': 'var(--stroke-error-alpha, #AE2F2F73)', // red-800 alpha-45
+};
+
+const textColors = {
+  transparent: 'transparent',
+  primary: 'var(--text-primary, #161B2D)', // grey-1000
+  secondary: 'var(--text-secondary, #57647a)', // grey-800
+  tertiary: 'var(--text-tertiary, #848e9c)', // grey-700
+  accent: 'var(--text-accent, #1D4ED8)', // blue-500
+  error: 'var(--text-error, #AE2F2F)', // red-500
+  warning: 'var(--text-warning, #7F6300)', // yellow-700
+  'warning-icon': 'var(--text-warning-icon, #EEC840)', // yellow-500
+  info: 'var(--text-info, #1D4ED8)', // blue-500
+  success: 'var(--text-success, #007274)', // green-800
+};
+
+const placeholderColor = {
+  primary: 'var(--text-primary, #161B2D)', // grey-1000
+  secondary: 'var(--controls-text-secondary-disable, #575F73)',
+};
+
+const controlsTextColors = {
+  'control-permanent': 'var(--text-control-permanent, #FCFCFC)', // grey-100
+  'control-disable-alpha': 'var(--text-control-disable-alpha, #DCE0E8)', // grey-550
+  'control-disable-beta': 'var(--text-control-disable-beta, #848E9C)', // grey-700
+  'control-blue-hover': 'var(--text-control-blue-hover, #5976E9)', // blue-300
+  'control-blue-active': 'var(--text-control-blue-active, #6785FB)', // blue-200
+};
+
+// TODO: remove colors
+const backgroundsColorsToRemove = {
   'layer-0': 'var(--bg-layer-0, #FCFCFC)',
   'layer-1': 'var(--bg-layer-1, #E0E6F0)',
   'layer-2': 'var(--bg-layer-2, #EEF1F7)',
@@ -43,30 +106,8 @@ const backgroundsColors = {
   'red-400': 'var(--bg-red-400, #F76464)',
   'orange-400': 'var(--bg-orange-400, #D97C27)',
   'orange-800': 'var(--bg-orange-800, #B25500)',
-};
 
-const controlsBgColors = {
-  // COLORS 2.0
-  'control-accent-alpha': 'var(--bg-control-accent-alpha, #2764D90F)', // blue-500 alpha-6
-  'control-accent-alpha-hover':
-    'var(--bg-control-accent-alpha-hover, #2764D924)', // blue-500 alpha-14
-  'control-accent-alpha-active':
-    'var(--bg-control-accent-alpha-active, #2764D933)', // blue-500 alpha-20
-
-  'control-accent': 'var(--bg-control-accent, #124ACE)', // blue-500
-
-  'control-neutral': 'var(--bg-control-neutral, #FCFCFC)', // grey-100
-  'control-neutral-hover': 'var(--bg-control-neutral-hover, #E0E6F0)', // grey-500
-  'control-neutral-active': 'var(--bg-control-neutral-active, #D1DBEA)', // grey-600
-
-  'control-error': 'var(--bg-control-error, #AE2F2F)', // red-800
-  'control-error-hover': 'var(--bg-control-error-hover, #BF3939)', // red-700
-  'control-error-active': 'var(--bg-control-error-active, #CC4545)', // red-600
-  'control-error-alpha-hover': 'var(--bg-control-error-alpha-hover, #F764641A)', // red-800 alpha-10
-  'control-error-alpha-active':
-    'var(--bg-control-error-alpha-active, #F7646433)', // red-800 alpha-20
-
-  'control-disable': 'var(--bg-control-disable, #848E9C)', // grey-700
+  // controls
 
   // REMOVED: old names, need to remove
   'controls-accent-primary': 'var(--controls-bg-accent-primary, #124ACE)',
@@ -106,24 +147,11 @@ const controlsBgColors = {
   'controls-enable-primary': 'var(--controls-enable-primary, #FCFCFC)',
 };
 
-const borderColors = {
-  // COLORS 2.0
-  transparent: 'transparent',
-  primary: 'var(--stroke-primary, #6B7280)', // grey-800
-  secondary: 'var(--stroke-secondary, #D1DBEA)', // grey-600
-  tertiary: 'var(--stroke-tertiary, #E0E6F0)', // grey-500
-  error: 'var(--stroke-error, #AE2F2F)', // red-800
-  warning: 'var(--stroke-warning, #EEC840)', // yellow-500
-  info: 'var(--stroke-info, #124ACE)', // blue-500
-  success: 'var(--stroke-success, #007274)', // green-800
-  // controls
-  'hover-alpha': 'var(--stroke-hover-alpha, #2764D933)', // blue-500 alpha-20
-  'focus-black': 'var(--stroke-focus-black, #161B2D)', // grey-1000
-  'focus-blue': 'var(--stroke-focus-blue, #6785FB)', // blue-200
-  'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20
-  'error-alpha': 'var(--stroke-error-alpha, #AE2F2F73)', // red-800 alpha-45
+const controlsBorderColors = {
+  'controls-focus': 'var(--controls-stroke-focus, #EEF1F7)',
+};
 
-  // REMOVED: old names, need to remove
+const borderColorsToRemove = {
   'accent-primary': 'var(--stroke-accent-primary, #124ACE)',
   'accent-primary-hover': 'var(--stroke-accent-primary-hover, #7DA4FF)',
   'accent-secondary': 'var(--stroke-accent-secondary, #007274)',
@@ -136,44 +164,12 @@ const borderColors = {
   'red-900': 'var(--red-900, #402027)',
 };
 
-const controlsBorderColors = {
-  'controls-focus': 'var(--controls-stroke-focus, #EEF1F7)',
-};
-
-const textColors = {
-  // COLORS 2.0
-  transparent: 'transparent',
-  primary: 'var(--text-primary, #161B2D)', // grey-1000
-  secondary: 'var(--text-secondary, #57647a)', // grey-800
-  tertiary: 'var(--text-tertiary, #848e9c)', // grey-700
-  accent: 'var(--text-accent, #1D4ED8)', // blue-500
-  error: 'var(--text-error, #AE2F2F)', // red-500
-  warning: 'var(--text-warning, #7F6300)', // yellow-700
-  'warning-icon': 'var(--text-warning-icon, #EEC840)', // yellow-500
-  info: 'var(--text-info, #1D4ED8)', // blue-500
-  success: 'var(--text-success, #007274)', // green-800
-
-  // REMOVED: old names, need to remove
+const textColorsToRemove = {
   'accent-primary': 'var(--text-accent-primary, #7DA4FF)',
   'accent-secondary': 'var(--text-accent-secondary, #37BABC)',
   'accent-tertiary': 'var(--text-accent-tertiary, #A972FF)',
   'controls-disable': 'var(--controls-text-disable, #0C101D)',
-};
-
-const placeholderColor = {
-  primary: 'var(--text-primary, #161B2D)', // grey-1000
-  secondary: 'var(--controls-text-secondary-disable, #575F73)',
-};
-
-const controlsTextColors = {
-  // COLORS 2.0
-  'control-permanent': 'var(--text-control-permanent, #FCFCFC)', // grey-100
-  'control-disable-alpha': 'var(--text-control-disable-alpha, #DCE0E8)', // grey-550
-  'control-disable-beta': 'var(--text-control-disable-beta, #848E9C)', // grey-700
-  'control-blue-hover': 'var(--text-control-blue-hover, #5976E9)', // blue-300
-  'control-blue-active': 'var(--text-control-blue-active, #6785FB)', // blue-200
-
-  // REMOVED: old names, need to remove
+  // Controls
   'controls-permanent': 'var(--controls-text-permanent, #FCFCFC)',
   'controls-accent-disable': 'var(--controls-text-accent-disable, #D1DBEA)',
   'controls-primary-disable': 'var(--controls-text-primary-disable, #696E7C)',
@@ -192,19 +188,39 @@ const controlsTextColors = {
 export default {
   content: ['./src/**/*.{ts,tsx}', './src/**/*.scss'],
   theme: {
-    backgroundColor: { ...backgroundsColors, ...controlsBgColors },
-    borderColor: { ...borderColors, ...controlsBorderColors },
-    stroke: { ...borderColors, ...controlsBorderColors },
-    divideColor: { ...borderColors, ...controlsBorderColors },
+    backgroundColor: {
+      ...backgroundsColors,
+      ...backgroundsColorsToRemove,
+      ...controlsBgColors,
+    },
+    borderColor: {
+      ...borderColors,
+      ...borderColorsToRemove,
+      ...controlsBorderColors,
+    },
+    stroke: {
+      ...borderColors,
+      ...borderColorsToRemove,
+      ...controlsBorderColors,
+    },
+    divideColor: {
+      ...borderColors,
+      ...borderColorsToRemove,
+      ...controlsBorderColors,
+    },
     placeholderColor: placeholderColor,
-    textColor: { ...textColors, ...controlsTextColors },
+    textColor: { ...textColors, ...textColorsToRemove, ...controlsTextColors },
     gradientColorStops: backgroundsColors,
 
     extend: {
       // `outline` utility emits a 1px solid ring, `outline-focus-black` paints it
       // with the focus token — see the focus-visible states in buttons.scss
       outlineWidth: { DEFAULT: '1px' },
-      outlineColor: { ...borderColors, ...controlsBorderColors },
+      outlineColor: {
+        ...borderColors,
+        ...borderColorsToRemove,
+        ...controlsBorderColors,
+      },
       screens: {
         mobile: { max: '768px' },
         desktop: { min: '769px' },


### PR DESCRIPTION
**Description and UI changes:**

Three related pieces of work on the 2.0 component set: an accessibility pass over the existing controls, a cleanup of the Colors 2.0 token layer in `tailwind.config.js`, and the next batch of 2.0 components (`Input`, `Textarea`, `InfoButton`, `Label`, `CaptionText`).

**Accessibility (WCAG 2.2 AA + 2.5.5 Target Size AAA)**

- Icon-only controls (`FabButton`, `DialIconButton`, 2.0 `IconButton`, `Button`) are named from the first available candidate via the new `resolveAccessibleName` util, with `tooltipProps` as the last resort — a tooltip's `aria-describedby` lands on a wrapper element and is suppressed on mobile, so on its own it never reached assistive tech.
- Standard-size (40px+) controls get `dial-kit-enhanced-target`, which grows the pointer target to 44×44 with a transparent pseudo-element and leaves the rendered size untouched. `ElementSize.Small` and `ButtonAppearance.Link` are exempt and documented in the README exception table.
- `Notification` (2.0) — live-region role now follows the variant: `error` / `warning` stay `role="alert"`, `info` / `success` / `loading` become the polite `role="status"`. The variant icon is `aria-hidden`, so the `loading` spinner no longer forms a nested live region that announced the content twice.
- `ButtonDropdown` (2.0) — `aria-haspopup` / `aria-expanded` moved onto the trigger button itself; `DialDropdown` put them on a non-focusable wrapper `<span>`.
- `InlineSelect` — trigger now exposes `aria-expanded` and accepts an `ariaLabel` prop (it previously announced only its current value).
- `Calendar` (2.0) — day cells are named with the full date ("Sunday, 15 March 2026") instead of a bare number, the popover is a named dialog, and the field `label` is wired to the `div[role="button"]` trigger.
- `FolderPath` — `<nav>` landmark is named "Folder path" rather than inheriting `DialBreadcrumb`'s "Breadcrumb" default; added `ariaLabel` to override; decorative icons are `aria-hidden`.
- Decorative Tabler icons across the touched components get an explicit `aria-hidden="true"`.

**Colors 2.0 tokens**

- `tailwind.config.js` is split into the live 2.0 palettes (`borderColors`, `textColors`, `controlsTextColors`, `placeholderColor`, …) and clearly marked `*ToRemove` groups holding the legacy names, so the deprecated surface is visible instead of interleaved with current tokens.
- Border token `focus` → `focus-black` (`--stroke-focus` → `--stroke-focus-black`) so it sits alongside `focus-blue`. The colour is unchanged (`#161B2D`).
- `control-disable` background corrected to grey-700 (`#848E9C`).

**New 2.0 components**

- `Input` — with `InputButton`, validation states, and helper utils; stories + specs.
- `Textarea`, `InfoButton`, `Label`, `CaptionText` — stories + specs.
- Typography: new `.dial-tiny-lead-text` class and letter-spacing on `.dial-caption-semi-text`; Typography story and MCP typography description updated.

**Rename**

- `DialSpinner` → `Spinner` (`DialSpinnerProps` → `SpinnerProps`), dropping the `Dial*` prefix in line with 2.0 naming. Props, DOM, and styling unchanged.

**Docs**

- `CHANGELOG.md` entries under `Unreleased` for the three breaking changes plus the fixes and additions.
- Migration guides `migration-guides/0.13.0/spinner-dial-prefix-removal.md` and `migration-guides/0.13.0/focus-border-token-rename.md`, both indexed in `migration-guides/README.md`.
- `AGENTS.md` / `README.md` document the accessibility contract, the target-size rules, and the exception list.

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial — N/A: 2.0 components intentionally drop the `Dial*` prefix
- [x] custom css classes has dial- prefix
- [ ] component export added to index.ts — `InfoButton` and `Label` are exported; `Input`, `Textarea`, and `CaptionText` (2.0) are not yet
- [x] jsdoc is added for component
- [ ] absolute paths are used for imports — two relative imports remain: `New/Input/Button/InputButton.tsx` and `New/Label/Label.tsx`
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added
