### PR TITLE
feat: support Calendar trigger styling override via fieldClassName

### DIFF
--- a/src/components/New/Calendar/Calendar.spec.tsx
+++ b/src/components/New/Calendar/Calendar.spec.tsx
@@ -230,6 +230,63 @@ describe('Dial UI Kit :: Calendar', () => {
     });
   });
 
+  describe('fieldClassName override', () => {
+    test('Should merge fieldClassName onto the trigger in date mode', () => {
+      render(
+        <Calendar mode={CalendarMode.Date} fieldClassName="custom-field" />,
+      );
+      expect(screen.getByRole('button', { name: /select date/i })).toHaveClass(
+        'custom-field',
+      );
+    });
+
+    test('Should merge fieldClassName onto the trigger in datetime mode', () => {
+      render(
+        <Calendar mode={CalendarMode.DateTime} fieldClassName="custom-field" />,
+      );
+      expect(
+        screen.getByRole('button', { name: /select date and time/i }),
+      ).toHaveClass('custom-field');
+    });
+
+    test('Should merge fieldClassName onto the field in time mode', () => {
+      render(
+        <Calendar mode={CalendarMode.Time} fieldClassName="custom-field" />,
+      );
+      expect(screen.getByPlaceholderText('--:--')).toHaveClass('custom-field');
+    });
+
+    test('Should merge fieldClassName onto the trigger in weekday mode', () => {
+      render(
+        <Calendar mode={CalendarMode.Weekday} fieldClassName="custom-field" />,
+      );
+      expect(screen.getByRole('button', { name: /select day/i })).toHaveClass(
+        'custom-field',
+      );
+    });
+
+    test('Should not leak fieldClassName onto the popover panel', () => {
+      render(
+        <Calendar
+          mode={CalendarMode.Date}
+          label="Start date"
+          fieldClassName="custom-field"
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Start date/ }));
+
+      expect(screen.getByRole('dialog')).not.toHaveClass('custom-field');
+    });
+
+    test('Should override a conflicting default utility rather than duplicate it', () => {
+      render(<Calendar mode={CalendarMode.Date} fieldClassName="rounded" />);
+      const trigger = screen.getByRole('button', { name: /select date/i });
+      expect(trigger).toHaveClass('rounded');
+      expect(trigger).not.toHaveClass('rounded-xl');
+    });
+  });
+
   describe('localization', () => {
     test('Should localize month/weekday names and date formatting via the locale prop', () => {
       render(

--- a/src/components/New/Calendar/Calendar.stories.tsx
+++ b/src/components/New/Calendar/Calendar.stories.tsx
@@ -28,6 +28,7 @@ const meta = {
     label: { control: { type: 'text' } },
     placeholder: { control: { type: 'text' } },
     locale: { control: { type: 'text' } },
+    fieldClassName: { control: { type: 'text' } },
   },
   args: {
     label: 'Date',
@@ -108,5 +109,13 @@ export const Localized: Story = {
     value: new Date(2026, 2, 11),
     locale: 'de-DE',
     label: 'Datum',
+  },
+};
+
+export const CustomFieldStyle: Story = {
+  name: 'Custom field style',
+  args: {
+    mode: CalendarMode.Date,
+    fieldClassName: 'rounded border-primary h-[40px]',
   },
 };

--- a/src/components/New/Calendar/Calendar.tsx
+++ b/src/components/New/Calendar/Calendar.tsx
@@ -73,6 +73,7 @@ export interface CalendarProps {
   maxDate?: Date;
   /** BCP 47 locale tag used to localize month/weekday names and date formatting. */
   locale?: string;
+  fieldClassName?: string;
 }
 
 interface CalendarPopoverFieldProps {
@@ -81,6 +82,7 @@ interface CalendarPopoverFieldProps {
   invalid?: boolean;
   trigger: ReactNode;
   panelClassName?: string;
+  fieldClassName?: string;
   panel: (close: () => void) => ReactNode;
   /**
    * Ids naming the trigger. The trigger is a `div[role="button"]`, which is not
@@ -98,6 +100,7 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
   invalid,
   trigger,
   panelClassName,
+  fieldClassName,
   panel,
   labelledBy,
   panelLabel,
@@ -137,6 +140,7 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
           'focus-visible:outline focus-visible:outline-focus-black',
           invalid && calendarFieldInvalidClassName,
           disabled && calendarFieldDisabledClassName,
+          fieldClassName,
         )}
         {...getReferenceProps()}
       >
@@ -254,6 +258,7 @@ const TimeField: FC<TimeFieldProps> = ({
  * @param [minDate] - Earliest selectable date (date/datetime modes)
  * @param [maxDate] - Latest selectable date (date/datetime modes)
  * @param [locale="en-GB"] - BCP 47 locale tag used to localize month/weekday names and date formatting
+ * @param [fieldClassName] - Additional classes merged onto the trigger field, overriding conflicting defaults
  */
 export const Calendar: FC<CalendarProps> = ({
   mode = CalendarMode.Date,
@@ -268,6 +273,7 @@ export const Calendar: FC<CalendarProps> = ({
   minDate,
   maxDate,
   locale = DEFAULT_CALENDAR_LOCALE,
+  fieldClassName,
 }) => {
   const resolvedPlaceholder =
     placeholder ?? calendarModeDefaultPlaceholder[mode];
@@ -343,6 +349,7 @@ export const Calendar: FC<CalendarProps> = ({
           disabled={disabled}
           invalid={invalid}
           placeholder={resolvedPlaceholder}
+          className={fieldClassName}
         />
       </div>
     );
@@ -361,6 +368,7 @@ export const Calendar: FC<CalendarProps> = ({
           invalid={invalid}
           labelledBy={triggerLabelledBy}
           panelLabel={label ?? resolvedPlaceholder}
+          fieldClassName={fieldClassName}
           trigger={
             <>
               <span
@@ -419,6 +427,7 @@ export const Calendar: FC<CalendarProps> = ({
         invalid={invalid}
         labelledBy={triggerLabelledBy}
         panelLabel={label ?? resolvedPlaceholder}
+        fieldClassName={fieldClassName}
         trigger={
           <>
             <span


### PR DESCRIPTION
**Description and UI changes:**

Adds an optional `fieldClassName` prop to `Calendar` so consumers can override the trigger
field's styling (border radius, height, border color, etc.), which was previously fixed and
couldn't be customized. Threaded into the shared popover trigger (`Date`/`DateTime`/`Weekday`
modes) and the standalone `TimeField` (`Time` mode). Added a `CustomFieldStyle` Storybook story
and `fieldClassName` control, plus spec coverage for all four modes.

Issues:

- N/A

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added