### PR TITLE
feat: add 2.0 select, dropdown and popup components

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ not AAA:
 | `ButtonAppearance.Link` | content | Exempt under the 2.5.5 *Inline* exception; expanding it would overlap surrounding copy |
 | `DialCloseButton` | icon-sized | Renders `h-auto w-auto`, so its target follows the caller's icon size |
 | `DialInfoButton`, `InfoButton` | 24×24 | Fixed small affordance, same overlap constraint as small variants |
+| Standard 2.0 fields (`Input`, `Select`) | 40px tall | The pointer target spans the full field width but stays 4px short of 44 vertically; the height is a shared form design token, not a per-control choice |
 
 Give small-variant controls at least 20px of surrounding space if you need to reach
 AAA in a specific layout, or use the standard size instead.

--- a/src/components/FabButton/FabButton.stories.tsx
+++ b/src/components/FabButton/FabButton.stories.tsx
@@ -30,40 +30,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Hover: Story = {
-  parameters: { pseudo: { hover: true } },
-};
-
-export const Active: Story = {
-  parameters: { pseudo: { active: true } },
-};
-
-export const Focus: Story = {
-  parameters: { pseudo: { focusVisible: true } },
-};
-
-export const Disabled: Story = {
-  args: { disabled: true },
-};
-
 export const WithTooltip: Story = {
   args: {
     tooltipProps: { tooltip: 'Scroll to bottom' },
-  },
-};
-
-export const TooltipAsAccessibleName: Story = {
-  args: {
-    'aria-label': undefined,
-    tooltipProps: { tooltip: 'Scroll to bottom' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The button is icon-only, so it needs an accessible name. With no `aria-label`, a string `tooltipProps.tooltip` is used as the label — the tooltip itself is not announced by screen readers and is hidden on mobile.',
-      },
-    },
   },
 };
 

--- a/src/components/FileManager/components/FileMetadataPopup/FileMetadataPopup.tsx
+++ b/src/components/FileManager/components/FileMetadataPopup/FileMetadataPopup.tsx
@@ -2,8 +2,8 @@ import { DialPopup } from '@/components/Popup/Popup';
 import { PopupSize } from '@/types/popup';
 import { type FC, type ReactNode } from 'react';
 import type { DialFile } from '@/models/file';
-import { DialSkeleton } from '@/components/Skeleton/Skeleton';
-import { DialSkeletonVariant } from '@/types/skeleton';
+import { Skeleton } from '@/components/Skeleton/Skeleton';
+import { SkeletonVariant } from '@/types/skeleton';
 import { formatBytes, formatDate } from '@/components/FileManager/utils';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import {
@@ -93,40 +93,40 @@ export const FileMetadataPopup: FC<FileMetadataPopupProps> = ({
           {loading ? (
             <>
               <div className={LABEL_CLASS}>{nameLabel}</div>
-              <DialSkeleton
-                variant={DialSkeletonVariant.Text}
+              <Skeleton
+                variant={SkeletonVariant.Text}
                 width="100%"
                 height={SKELETON_HEIGHT}
                 className={SKELETON_CLASS}
               />
 
               <div className={LABEL_CLASS}>{modifiedDateLabel}</div>
-              <DialSkeleton
-                variant={DialSkeletonVariant.Text}
+              <Skeleton
+                variant={SkeletonVariant.Text}
                 width="90%"
                 height={SKELETON_HEIGHT}
                 className={SKELETON_CLASS}
               />
 
               <div className={LABEL_CLASS}>{sizeLabel}</div>
-              <DialSkeleton
-                variant={DialSkeletonVariant.Text}
+              <Skeleton
+                variant={SkeletonVariant.Text}
                 width="60%"
                 height={SKELETON_HEIGHT}
                 className={SKELETON_CLASS}
               />
 
               <div className={LABEL_CLASS}>{authorLabel}</div>
-              <DialSkeleton
-                variant={DialSkeletonVariant.Text}
+              <Skeleton
+                variant={SkeletonVariant.Text}
                 width="80%"
                 height={SKELETON_HEIGHT}
                 className={SKELETON_CLASS}
               />
 
               <div className={LABEL_CLASS}>{pathLabel}</div>
-              <DialSkeleton
-                variant={DialSkeletonVariant.Text}
+              <Skeleton
+                variant={SkeletonVariant.Text}
                 width="70%"
                 height={SKELETON_HEIGHT}
                 className={SKELETON_CLASS}

--- a/src/components/New/CaptionText/CaptionText.stories.tsx
+++ b/src/components/New/CaptionText/CaptionText.stories.tsx
@@ -43,20 +43,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const CustomClassName: Story = {
-  args: {
-    text: 'This is an error with custom class',
-    className: 'border border-secondary p-2',
-  },
-};
-
-export const AriaAttributes: Story = {
-  args: {
-    text: 'Error with aria attributes',
-    'aria-label': 'Error message',
-  },
-};
-
 export const Error: Story = {
   args: {
     variant: CaptionType.Error,

--- a/src/components/New/CloseButton/CloseButton.spec.tsx
+++ b/src/components/New/CloseButton/CloseButton.spec.tsx
@@ -1,0 +1,42 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DialCloseButton } from './CloseButton';
+
+describe('Dial UI Kit :: DialCloseButton', () => {
+  it('renders with default icon size', () => {
+    const { getByRole } = render(<DialCloseButton onClose={vi.fn()} />);
+    const button = getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('applies aria-label if provided', () => {
+    const { getByLabelText } = render(
+      <DialCloseButton ariaLabel="Close dialog" onClose={vi.fn()} />,
+    );
+    expect(getByLabelText('Close dialog')).toBeInTheDocument();
+  });
+
+  it('calls onClose when clicked', () => {
+    const onClose = vi.fn();
+    const { getByRole } = render(<DialCloseButton onClose={onClose} />);
+    fireEvent.click(getByRole('button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies custom className', () => {
+    const { getByRole } = render(
+      <DialCloseButton className="custom-class" onClose={vi.fn()} />,
+    );
+    expect(getByRole('button').className).toMatch(/custom-class/);
+  });
+
+  it('renders with custom icon size', () => {
+    const { container } = render(
+      <DialCloseButton size={32} onClose={vi.fn()} />,
+    );
+    // IconX renders an svg, check for svg with width/height 32
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('32');
+    expect(svg?.getAttribute('height')).toBe('32');
+  });
+});

--- a/src/components/New/CloseButton/CloseButton.spec.tsx
+++ b/src/components/New/CloseButton/CloseButton.spec.tsx
@@ -1,42 +1,90 @@
-import { render, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { DialCloseButton } from './CloseButton';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
 
-describe('Dial UI Kit :: DialCloseButton', () => {
-  it('renders with default icon size', () => {
-    const { getByRole } = render(<DialCloseButton onClose={vi.fn()} />);
-    const button = getByRole('button');
-    expect(button).toBeInTheDocument();
+import { ElementSize } from '@/types/size';
+import { CloseButton } from './CloseButton';
+
+describe('Dial UI Kit :: CloseButton', () => {
+  test('is named "Close" by default, so it is never an unnamed icon button', () => {
+    render(<CloseButton onClose={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
   });
 
-  it('applies aria-label if provided', () => {
-    const { getByLabelText } = render(
-      <DialCloseButton ariaLabel="Close dialog" onClose={vi.fn()} />,
-    );
-    expect(getByLabelText('Close dialog')).toBeInTheDocument();
+  test('applies ariaLabel when provided', () => {
+    render(<CloseButton ariaLabel="Close dialog" onClose={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Close dialog' }),
+    ).toBeInTheDocument();
   });
 
-  it('calls onClose when clicked', () => {
+  test('calls onClose when clicked', () => {
     const onClose = vi.fn();
-    const { getByRole } = render(<DialCloseButton onClose={onClose} />);
-    fireEvent.click(getByRole('button'));
-    expect(onClose).toHaveBeenCalled();
+    render(<CloseButton ariaLabel="Close dialog" onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('applies custom className', () => {
-    const { getByRole } = render(
-      <DialCloseButton className="custom-class" onClose={vi.fn()} />,
-    );
-    expect(getByRole('button').className).toMatch(/custom-class/);
+  test('does not call onClose while disabled', () => {
+    const onClose = vi.fn();
+    render(<CloseButton ariaLabel="Close dialog" onClose={onClose} disabled />);
+
+    const button = screen.getByRole('button', { name: 'Close dialog' });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('renders with custom icon size', () => {
-    const { container } = render(
-      <DialCloseButton size={32} onClose={vi.fn()} />,
+  test('applies custom className', () => {
+    render(
+      <CloseButton
+        ariaLabel="Close dialog"
+        className="custom-class"
+        onClose={vi.fn()}
+      />,
     );
-    // IconX renders an svg, check for svg with width/height 32
-    const svg = container.querySelector('svg');
-    expect(svg?.getAttribute('width')).toBe('32');
-    expect(svg?.getAttribute('height')).toBe('32');
+
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toHaveClass(
+      'custom-class',
+    );
+  });
+
+  describe('size', () => {
+    // jsdom does no layout, so only the classes are observable here.
+    test('renders the small box by default, without the enhanced target', () => {
+      render(<CloseButton ariaLabel="Close dialog" onClose={vi.fn()} />);
+
+      const button = screen.getByRole('button', { name: 'Close dialog' });
+      expect(button).toHaveClass('size-[24px]');
+      // A 44px target would overhang 10px per side and overlap its neighbours.
+      expect(button).not.toHaveClass('dial-kit-enhanced-target');
+      expect(button.querySelector('svg')).toHaveAttribute('width', '16');
+    });
+
+    test('renders the standard box with the enhanced pointer target', () => {
+      render(
+        <CloseButton
+          ariaLabel="Close dialog"
+          size={ElementSize.Standard}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByRole('button', { name: 'Close dialog' });
+      expect(button).toHaveClass('size-[40px]', 'dial-kit-enhanced-target');
+      expect(button.querySelector('svg')).toHaveAttribute('width', '20');
+    });
+  });
+
+  test('hides the icon from assistive tech, which reads the button name instead', () => {
+    render(<CloseButton ariaLabel="Close dialog" onClose={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Close dialog' }).querySelector('svg'),
+    ).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/src/components/New/CloseButton/CloseButton.stories.tsx
+++ b/src/components/New/CloseButton/CloseButton.stories.tsx
@@ -1,101 +1,101 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DialCloseButton, type DialCloseButtonProps } from './CloseButton';
 
-const meta: Meta<typeof DialCloseButton> = {
-  title: 'Dial/Elements/Buttons/CloseButton',
-  component: DialCloseButton,
+import { ElementSize } from '@/types/size';
+import { CloseButton, type CloseButtonProps } from './CloseButton';
+
+const meta = {
+  title: 'Components_2_0/CloseButton',
+  component: CloseButton,
   parameters: {
     layout: 'padded',
     docs: {
       description: {
         component:
-          'A contextual feedback component for displaying important messages with optional close button.',
+          'A ghost icon button that dismisses the surface it belongs to. Name it ' +
+          'after that surface — the default `"Close"` only keeps the control from ' +
+          'being unnamed.',
       },
     },
   },
   argTypes: {
     ariaLabel: {
       control: { type: 'text' },
-      description: 'Accessibility label (used when title is not provided)',
+      description: 'Accessible name of the button',
     },
     size: {
-      control: { type: 'number' },
-      description: 'Size of the close icon',
+      control: { type: 'inline-radio' },
+      options: [ElementSize.Small, ElementSize.Standard],
+      description: 'Button size: small is 24px, standard is 40px',
     },
+    disabled: { control: { type: 'boolean' } },
     className: {
       control: { type: 'text' },
-      description: 'Additional CSS classes applied to the alert container',
+      description: 'Additional CSS classes applied to the button',
     },
     onClose: {
       control: false,
-      description: 'Callback fired when the close button is clicked',
+      description: 'Callback fired when the button is clicked',
     },
   },
-} satisfies Meta<DialCloseButtonProps>;
+  args: {
+    ariaLabel: 'Close dialog',
+    size: ElementSize.Small,
+    disabled: false,
+    onClose: () => alert('Closed!'),
+  },
+} satisfies Meta<CloseButtonProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Default: Story = {};
+
+export const Standard: Story = {
   args: {
-    ariaLabel: 'Close',
-    onClose: () => alert('Closed!'),
+    size: ElementSize.Standard,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The 40px variant, which is the only one carrying the 44×44 pointer ' +
+          'target. Use it where the control stands on its own.',
+      },
+    },
   },
 };
 
-export const CustomSize: Story = {
+export const Disabled: Story = {
   args: {
-    ariaLabel: 'Close',
-    size: 32,
-    onClose: () => alert('Closed!'),
+    disabled: true,
   },
 };
 
 export const WithCustomClass: Story = {
+  name: 'With custom class',
   args: {
-    ariaLabel: 'Close',
-    className: 'bg-layer-2 text-primary hover:text-accent-tertiary',
-    onClose: () => alert('Closed!'),
-  },
-};
-
-export const NoAriaLabel: Story = {
-  args: {
-    onClose: () => alert('Closed!'),
+    className: 'text-error hover:text-error',
   },
 };
 
 export const AllVariants: Story = {
-  render: () => (
-    <div className="p-8 flex flex-col gap-y-6">
-      {/* Default */}
-      <div className="flex flex-row items-center">
-        <div className="text-primary pr-4 py-2">Default</div>
-        <DialCloseButton
-          ariaLabel="Close dialog"
-          onClose={() => alert('Closed!')}
-        />
-      </div>
-
-      {/* CustomSize */}
-      <div className="flex flex-row items-center">
-        <div className="text-primary pr-4 py-2">Custom Size</div>
-        <DialCloseButton
-          ariaLabel="Close dialog"
-          size={32}
-          onClose={() => alert('Closed!')}
-        />
-      </div>
-
-      {/* WithCustomClass */}
-      <div className="flex flex-row items-center">
-        <div className="text-primary pr-4 py-2">With custom class</div>
-        <DialCloseButton
-          ariaLabel="Close dialog"
-          className="bg-error text-error hover:text-error"
-          onClose={() => alert('Closed!')}
-        />
-      </div>
+  render: (args) => (
+    <div className="flex flex-col gap-y-6">
+      {[
+        { label: 'Small (24px)', size: ElementSize.Small },
+        { label: 'Standard (40px)', size: ElementSize.Standard },
+      ].map(({ label, size }) => (
+        <div key={size} className="flex flex-row items-center gap-x-4">
+          <div className="w-[140px] text-primary">{label}</div>
+          <CloseButton {...args} size={size} />
+          <CloseButton {...args} size={size} disabled />
+          <CloseButton
+            {...args}
+            size={size}
+            className="text-error hover:text-error"
+          />
+        </div>
+      ))}
     </div>
   ),
 };

--- a/src/components/New/CloseButton/CloseButton.stories.tsx
+++ b/src/components/New/CloseButton/CloseButton.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialCloseButton, type DialCloseButtonProps } from './CloseButton';
+
+const meta: Meta<typeof DialCloseButton> = {
+  title: 'Dial/Elements/Buttons/CloseButton',
+  component: DialCloseButton,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A contextual feedback component for displaying important messages with optional close button.',
+      },
+    },
+  },
+  argTypes: {
+    ariaLabel: {
+      control: { type: 'text' },
+      description: 'Accessibility label (used when title is not provided)',
+    },
+    size: {
+      control: { type: 'number' },
+      description: 'Size of the close icon',
+    },
+    className: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes applied to the alert container',
+    },
+    onClose: {
+      control: false,
+      description: 'Callback fired when the close button is clicked',
+    },
+  },
+} satisfies Meta<DialCloseButtonProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    ariaLabel: 'Close',
+    onClose: () => alert('Closed!'),
+  },
+};
+
+export const CustomSize: Story = {
+  args: {
+    ariaLabel: 'Close',
+    size: 32,
+    onClose: () => alert('Closed!'),
+  },
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    ariaLabel: 'Close',
+    className: 'bg-layer-2 text-primary hover:text-accent-tertiary',
+    onClose: () => alert('Closed!'),
+  },
+};
+
+export const NoAriaLabel: Story = {
+  args: {
+    onClose: () => alert('Closed!'),
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="p-8 flex flex-col gap-y-6">
+      {/* Default */}
+      <div className="flex flex-row items-center">
+        <div className="text-primary pr-4 py-2">Default</div>
+        <DialCloseButton
+          ariaLabel="Close dialog"
+          onClose={() => alert('Closed!')}
+        />
+      </div>
+
+      {/* CustomSize */}
+      <div className="flex flex-row items-center">
+        <div className="text-primary pr-4 py-2">Custom Size</div>
+        <DialCloseButton
+          ariaLabel="Close dialog"
+          size={32}
+          onClose={() => alert('Closed!')}
+        />
+      </div>
+
+      {/* WithCustomClass */}
+      <div className="flex flex-row items-center">
+        <div className="text-primary pr-4 py-2">With custom class</div>
+        <DialCloseButton
+          ariaLabel="Close dialog"
+          className="bg-error text-error hover:text-error"
+          onClose={() => alert('Closed!')}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/New/CloseButton/CloseButton.tsx
+++ b/src/components/New/CloseButton/CloseButton.tsx
@@ -1,0 +1,53 @@
+import { IconX } from '@tabler/icons-react';
+import type { FC, MouseEvent } from 'react';
+
+import { mergeClasses } from '@/utils/merge-classes';
+import { DialGhostIconButton } from '../IconButton/IconButtonWrappers';
+
+export interface DialCloseButtonProps {
+  ariaLabel?: string;
+  className?: string;
+  size?: number;
+  onClose: (e: MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+}
+/**
+ * A Close button component with a customizable icon and accessible label.
+ * aliases: DismissButton|ExitButton
+ *
+ * @example
+ * ```tsx
+ * <DialCloseButton
+ *   ariaLabel="Close dialog"
+ *   onClose={handleClose}
+ *   className="custom-close"
+ *   size={32}
+ * />
+ * ```
+ *
+ * @param [ariaLabel] - Accessible label for screen readers
+ * @param [className] - Additional CSS classes to apply to the button
+ * @param [size=24] - Size of the close icon
+ * @param onClose - Click event handler for the close button
+ * @param [disabled] - Whether the button is disabled
+ */
+export const DialCloseButton: FC<DialCloseButtonProps> = ({
+  ariaLabel,
+  className,
+  size = 24,
+  onClose,
+  ...props
+}) => {
+  return (
+    <DialGhostIconButton
+      aria-label={ariaLabel}
+      className={mergeClasses(
+        className,
+        'w-auto h-auto', // Exception: DialCloseButton does not require a static size
+      )}
+      onClick={onClose}
+      icon={<IconX size={size} />}
+      {...props}
+    />
+  );
+};

--- a/src/components/New/CloseButton/CloseButton.tsx
+++ b/src/components/New/CloseButton/CloseButton.tsx
@@ -1,53 +1,62 @@
 import { IconX } from '@tabler/icons-react';
 import type { FC, MouseEvent } from 'react';
 
-import { mergeClasses } from '@/utils/merge-classes';
-import { DialGhostIconButton } from '../IconButton/IconButtonWrappers';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ElementSize } from '@/types/size';
+import { GhostIconButton } from '../IconButton/IconButtonWrappers';
 
-export interface DialCloseButtonProps {
+export interface CloseButtonProps {
   ariaLabel?: string;
   className?: string;
-  size?: number;
+  size?: ElementSize;
   onClose: (e: MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
 }
+
 /**
- * A Close button component with a customizable icon and accessible label.
+ * A close button: a ghost {@link IconButton} carrying an X icon.
  * aliases: DismissButton|ExitButton
+ *
+ * Sized through {@link ElementSize} like every other 2.0 control. It defaults to
+ * the small 24px box that headers and toasts want; pass `ElementSize.Standard`
+ * where the control stands alone, since only that variant carries the 44×44
+ * pointer target. Name it after the thing it closes ("Close dialog", "Close
+ * notification") — the default `"Close"` only keeps the control from being unnamed.
  *
  * @example
  * ```tsx
- * <DialCloseButton
- *   ariaLabel="Close dialog"
- *   onClose={handleClose}
- *   className="custom-close"
- *   size={32}
- * />
+ * <CloseButton ariaLabel="Close notification" onClose={handleClose} />
+ * <CloseButton ariaLabel="Close dialog" size={ElementSize.Standard} onClose={handleClose} />
  * ```
  *
- * @param [ariaLabel] - Accessible label for screen readers
+ * @param [ariaLabel="Close"] - Accessible name of the button
  * @param [className] - Additional CSS classes to apply to the button
- * @param [size=24] - Size of the close icon
+ * @param [size=ElementSize.Small] - Button size: small is 24px, standard is 40px
  * @param onClose - Click event handler for the close button
  * @param [disabled] - Whether the button is disabled
  */
-export const DialCloseButton: FC<DialCloseButtonProps> = ({
-  ariaLabel,
+export const CloseButton: FC<CloseButtonProps> = ({
+  ariaLabel = 'Close',
   className,
-  size = 24,
+  size = ElementSize.Small,
   onClose,
   ...props
 }) => {
   return (
-    <DialGhostIconButton
-      aria-label={ariaLabel}
-      className={mergeClasses(
-        className,
-        'w-auto h-auto', // Exception: DialCloseButton does not require a static size
-      )}
-      onClick={onClose}
-      icon={<IconX size={size} />}
+    <GhostIconButton
       {...props}
+      size={size}
+      aria-label={ariaLabel}
+      className={className}
+      onClick={onClose}
+      icon={
+        <IconX
+          size={
+            size === ElementSize.Small ? DIAL_ICON_SIZE.SM : DIAL_ICON_SIZE.MD
+          }
+          aria-hidden="true"
+        />
+      }
     />
   );
 };

--- a/src/components/New/ConfirmationPopup/ConfirmationPopup.spec.tsx
+++ b/src/components/New/ConfirmationPopup/ConfirmationPopup.spec.tsx
@@ -1,0 +1,161 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { ConfirmationPopup } from './ConfirmationPopup';
+import { ConfirmationPopupVariant } from '@/types/confirmation-popup';
+
+describe('Dial UI Kit :: ConfirmationPopup', () => {
+  const baseProps = {
+    header: 'Confirm Deleting Model',
+    description: 'Are you sure that you want to delete model?',
+    open: true,
+    confirmLabel: 'Delete',
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  test('does not render when open is false', () => {
+    render(<ConfirmationPopup {...baseProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('renders title and description', () => {
+    render(<ConfirmationPopup {...baseProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Confirm Deleting Model')).toBeInTheDocument();
+    expect(
+      screen.getByText('Are you sure that you want to delete model?'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders React node as title and omits aria-labelledby', () => {
+    render(
+      <ConfirmationPopup
+        {...baseProps}
+        header={
+          <span>
+            <strong>Node title</strong>
+          </span>
+        }
+      />,
+    );
+    expect(screen.getByText('Node title')).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('renders custom children instead of description', () => {
+    render(
+      <ConfirmationPopup {...baseProps}>
+        <div>Custom content</div>
+      </ConfirmationPopup>,
+    );
+    expect(screen.getByText('Custom content')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Are you sure that you want to delete model?'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('applies descriptionClassName', () => {
+    render(
+      <ConfirmationPopup {...baseProps} descriptionClassName="text-red-500" />,
+    );
+    expect(
+      screen.getByText('Are you sure that you want to delete model?'),
+    ).toHaveClass('text-red-500');
+  });
+
+  test('danger variant applies the error accent and a danger confirm button', () => {
+    render(
+      <ConfirmationPopup
+        {...baseProps}
+        variant={ConfirmationPopupVariant.Danger}
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveClass(
+      'border-t-4',
+      'border-error',
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveClass(
+      'dial-kit-danger-solid-button',
+    );
+  });
+
+  test('info variant leaves the error accent off', () => {
+    render(<ConfirmationPopup {...baseProps} />);
+
+    expect(screen.getByRole('dialog')).not.toHaveClass('border-error');
+  });
+
+  test('confirm button disabled via prop', () => {
+    render(<ConfirmationPopup {...baseProps} disableConfirmButton />);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  test('calls onConfirm on confirm click', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmationPopup {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test('Cancel calls onCancel or falls back to onClose', () => {
+    const onCancel = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ConfirmationPopup
+        {...baseProps}
+        onCancel={onCancel}
+        onClose={onClose}
+        cancelLabel="Cancel"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('header close (from Popup) triggers onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <ConfirmationPopup {...baseProps} onClose={onClose} hideClose={false} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('loading state hides actions and the description', () => {
+    render(<ConfirmationPopup {...baseProps} isLoading />);
+    expect(
+      screen.queryByRole('button', { name: 'Delete' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Are you sure that you want to delete model?'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('merges className into container', () => {
+    render(<ConfirmationPopup {...baseProps} className="ring-1" />);
+    expect(screen.getByRole('dialog')).toHaveClass('ring-1');
+  });
+
+  test('falls back to onClose when onCancel is not provided', () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmationPopup
+        open
+        header="Confirm?"
+        cancelLabel="Cancel dialog"
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel dialog/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/New/ConfirmationPopup/ConfirmationPopup.stories.tsx
+++ b/src/components/New/ConfirmationPopup/ConfirmationPopup.stories.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  ConfirmationPopup,
+  type ConfirmationPopupProps,
+} from './ConfirmationPopup';
+import { ConfirmationPopupVariant } from '@/types/confirmation-popup';
+import { PrimaryButton } from '@/components/New/Button/ButtonWrappers';
+
+const meta = {
+  title: 'Components_2_0/ConfirmationPopup',
+  component: ConfirmationPopup,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    open: { control: false },
+    variant: {
+      control: { type: 'radio' },
+      options: [ConfirmationPopupVariant.Info, ConfirmationPopupVariant.Danger],
+    },
+    header: { control: { type: 'text' } },
+    description: { control: { type: 'text' } },
+    descriptionClassName: { control: { type: 'text' } },
+    className: { control: { type: 'text' } },
+    confirmClassName: { control: { type: 'text' } },
+    confirmLabel: { control: { type: 'text' } },
+    cancelLabel: { control: { type: 'text' } },
+    isLoading: { control: { type: 'boolean' } },
+    disableConfirmButton: { control: { type: 'boolean' } },
+    onClose: { action: 'onClose', control: false },
+    onConfirm: { action: 'onConfirm', control: false },
+    onCancel: { action: 'onCancel', control: false },
+  },
+  args: {
+    header: 'Title',
+    description: 'Body area',
+  },
+} satisfies Meta<ConfirmationPopupProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Reusable stateful renderer that opens the popup via a button click
+const StatefulRender = (
+  args: ConfirmationPopupProps & { buttonLabel?: string },
+) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <PrimaryButton
+        onClick={() => setOpen(true)}
+        label={args.buttonLabel || 'Open Confirmation'}
+      />
+
+      <ConfirmationPopup
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          args.onClose?.();
+        }}
+        onCancel={() => {
+          setOpen(false);
+          args.onCancel?.();
+        }}
+        onConfirm={() => {
+          setOpen(false);
+          args.onConfirm?.();
+        }}
+      />
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: StatefulRender,
+  args: {
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const Danger: Story = {
+  render: StatefulRender,
+  args: {
+    variant: ConfirmationPopupVariant.Danger,
+    header: 'Confirm Deletion',
+    description: (
+      <div className="space-y-2">
+        <p>Are you sure you want to delete this item?</p>
+        <div className="opacity-70">
+          <div>
+            <span className="opacity-70">ID:</span> 1234567890
+          </div>
+          <div>
+            <span className="opacity-70">Display name:</span> Test Item
+          </div>
+          <div>
+            <span className="opacity-70">Version:</span> 1.0.0
+          </div>
+          <div>
+            <span className="opacity-70">Created:</span> Jan 1, 2023 by John Doe
+          </div>
+        </div>
+      </div>
+    ),
+    confirmLabel: 'Delete',
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const PrimarySave: Story = {
+  render: StatefulRender,
+  args: {
+    variant: ConfirmationPopupVariant.Info,
+    header: 'Unsaved Changes',
+    description:
+      'You have unsaved changes. Do you want to save them before leaving?',
+    confirmLabel: 'Save',
+    cancelLabel: 'Continue editing',
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const WithoutDescription: Story = {
+  render: (args) => (
+    <StatefulRender
+      {...args}
+      description={undefined}
+      children={
+        <div className="px-6 py-4">
+          <p className="text-secondary dial-small-paragraph-text">
+            Replace description with <strong>custom content</strong>.
+          </p>
+        </div>
+      }
+    />
+  ),
+  args: {
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const Loading: Story = {
+  render: StatefulRender,
+  args: {
+    isLoading: true,
+    header: 'Processing…',
+    confirmLabel: 'Save',
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const CustomFooter: Story = {
+  render: StatefulRender,
+  args: {
+    footer: (
+      <div className="flex justify-between items-center px-6 py-3">
+        <span className="text-secondary dial-small-text">Custom footer</span>
+        <PrimaryButton label="Action" onClick={() => alert('Custom action')} />
+      </div>
+    ),
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};
+
+export const CustomClasses: Story = {
+  render: StatefulRender,
+  args: {
+    className: 'ring-2 ring-offset-2 ring-sky-400 !bg-accent-secondary',
+    onClose: () => null,
+    onConfirm: () => null,
+  },
+};

--- a/src/components/New/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/components/New/ConfirmationPopup/ConfirmationPopup.tsx
@@ -1,0 +1,153 @@
+import { type FC, type ReactNode, useCallback } from 'react';
+
+import { Button } from '@/components/New/Button/Button';
+import { NeutralButton } from '@/components/New/Button/ButtonWrappers';
+import { Popup, type PopupProps } from '@/components/New/Popup/Popup';
+import { Spinner } from '@/components/Spinner/Spinner';
+import { ConfirmationPopupVariant } from '@/types/confirmation-popup';
+import { PopupSize } from '@/types/popup';
+import { mergeClasses } from '@/utils/merge-classes';
+import {
+  actionsBaseClassName,
+  defaultCancelLabel,
+  defaultConfirmLabel,
+  descriptionBaseClassName,
+  loaderContainerClassName,
+  variantConfig,
+} from './constants';
+
+export interface ConfirmationPopupProps extends PopupProps {
+  description?: ReactNode;
+  descriptionClassName?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isLoading?: boolean;
+  disableConfirmButton?: boolean;
+  confirmClassName?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  children?: ReactNode;
+  variant?: ConfirmationPopupVariant;
+}
+
+/**
+ * A confirmation dialog built from {@link Popup} and the 2.0 {@link Button}.
+ * aliases: ConfirmDialog|WarningDialog
+ *
+ * Provides an accessible modal with a title, optional description or custom content,
+ * and a footer with Cancel / Confirm actions.
+ *
+ * @example
+ * ```tsx
+ * <ConfirmationPopup
+ *   open
+ *   header="Delete item?"
+ *   description="This action cannot be undone."
+ *   confirmLabel="Delete"
+ *   variant={ConfirmationPopupVariant.Danger}
+ *   onClose={() => setOpen(false)}
+ *   onConfirm={handleDelete}
+ * />
+ * ```
+ *
+ * @param header - Title content for the header
+ * @param [description] - Secondary text (ignored when `children` set)
+ * @param [descriptionClassName] - Custom CSS class for the description
+ * @param [open=false] - Controls visibility of the popup
+ * @param [confirmLabel="Ok"] - Label for the confirm button
+ * @param [cancelLabel="Cancel"] - Label for the cancel button
+ * @param [isLoading=false] - Shows loader placeholder and hides actions
+ * @param [disableConfirmButton=false] - Disables the confirm button
+ * @param [className] - Extra classes for the popup container
+ * @param [confirmClassName] - Extra classes merged into the confirm button
+ * @param onClose - Fired on close
+ * @param onConfirm - Fired on confirm
+ * @param [onCancel] - Fired on cancel (falls back to `onClose`)
+ * @param [children] - Custom body content
+ * @param [variant=ConfirmationPopupVariant.Info] - Visual variant for the popup
+ * @param [size=PopupSize.Sm] - Size of the popup
+ */
+export const ConfirmationPopup: FC<ConfirmationPopupProps> = ({
+  header,
+  description,
+  descriptionClassName,
+  open = false,
+  confirmLabel = defaultConfirmLabel,
+  cancelLabel = defaultCancelLabel,
+  isLoading = false,
+  disableConfirmButton = false,
+  className,
+  confirmClassName,
+  onClose,
+  onConfirm,
+  onCancel,
+  children,
+  variant = ConfirmationPopupVariant.Info,
+  size = PopupSize.Sm,
+  footer,
+  hideClose,
+  ...popupProps
+}) => {
+  const defaultFooter = !isLoading ? (
+    <div className={actionsBaseClassName}>
+      <NeutralButton
+        label={cancelLabel}
+        onClick={() => (onCancel ? onCancel() : onClose?.())}
+      />
+      <Button
+        variant={variantConfig[variant].confirm.variant}
+        appearance={variantConfig[variant].confirm.appearance}
+        className={confirmClassName}
+        label={confirmLabel}
+        disabled={disableConfirmButton}
+        onClick={onConfirm}
+      />
+    </div>
+  ) : null;
+
+  const renderContent = useCallback(() => {
+    if (isLoading) {
+      return (
+        <div className={loaderContainerClassName}>
+          <Spinner size={40} />
+        </div>
+      );
+    }
+
+    if (children != null) {
+      return children;
+    }
+
+    if (description) {
+      return (
+        <div
+          className={mergeClasses(
+            descriptionBaseClassName,
+            descriptionClassName,
+          )}
+        >
+          {description}
+        </div>
+      );
+    }
+
+    return null;
+  }, [children, description, isLoading, descriptionClassName]);
+
+  return (
+    <Popup
+      {...popupProps}
+      open={open}
+      header={header}
+      className={mergeClasses(variantConfig[variant].container, className)}
+      onClose={() => onClose?.()}
+      footer={footer ?? defaultFooter}
+      size={size}
+      // The dialog's own Cancel already dismisses it, so the header X is dropped
+      // unless the caller supplied a footer of their own (or none is rendered).
+      hideClose={hideClose ?? (!isLoading && footer === undefined)}
+    >
+      {renderContent()}
+    </Popup>
+  );
+};

--- a/src/components/New/ConfirmationPopup/constants.ts
+++ b/src/components/New/ConfirmationPopup/constants.ts
@@ -1,0 +1,41 @@
+import { ButtonAppearance, ButtonVariant } from '@/types/button';
+import { ConfirmationPopupVariant } from '@/types/confirmation-popup';
+
+export const actionsBaseClassName =
+  'flex justify-end gap-2 px-6 py-4 border-t border-tertiary';
+
+export const descriptionBaseClassName =
+  'text-secondary dial-small-paragraph-text px-6 pb-4';
+
+export const loaderContainerClassName = 'px-6 py-4 h-[120px]';
+
+export const defaultCancelLabel = 'Cancel';
+
+export const defaultConfirmLabel = 'Ok';
+
+export const variantConfig: Record<
+  ConfirmationPopupVariant,
+  {
+    container?: string;
+    confirm: {
+      variant: ButtonVariant;
+      appearance: ButtonAppearance;
+    };
+  }
+> = {
+  [ConfirmationPopupVariant.Info]: {
+    confirm: {
+      variant: ButtonVariant.Primary,
+      appearance: ButtonAppearance.Solid,
+    },
+  },
+  [ConfirmationPopupVariant.Danger]: {
+    // Utilities rather than the legacy `.dial-danger-popup` SCSS rule, which is
+    // scoped as `div .dial-danger-popup` and only lands by accident of nesting.
+    container: 'border-t-4 border-error',
+    confirm: {
+      variant: ButtonVariant.Danger,
+      appearance: ButtonAppearance.Solid,
+    },
+  },
+};

--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -1,0 +1,870 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { describe, expect, test, vi } from 'vitest';
+import { Dropdown } from './Dropdown';
+import { DropdownItemType, DropdownTrigger } from '@/types/dropdown';
+import { type DropdownItem } from '@/models/dropdown';
+import { IconCheck } from '@tabler/icons-react';
+
+const items: DropdownItem[] = [
+  { key: 'profile', label: 'Profile' },
+  { key: 'settings', label: 'Settings' },
+  { key: 'd1', type: DropdownItemType.Divider },
+  { key: 'error', label: 'Error', danger: true },
+  { key: 'logout', label: 'Logout' },
+];
+
+const openByClick = () => {
+  fireEvent.click(screen.getByRole('button', { name: /open/i }));
+};
+
+const readPosition = (el: HTMLElement) =>
+  el.style.transform || `${el.style.left}|${el.style.top}`;
+
+describe('Dial UI Kit :: Dropdown', () => {
+  test('renders & toggles aria-expanded on open/close', () => {
+    const { container } = render(
+      <Dropdown items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    const triggerWrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'false');
+
+    openByClick();
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('fires item click handlers and closes afterwards', () => {
+    const onItem = vi.fn();
+    const onMenu = vi.fn();
+    render(
+      <Dropdown
+        items={[
+          { key: 'a', label: 'A', onClick: onItem },
+          { key: 'b', label: 'B' },
+        ]}
+        onItemClick={onMenu}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'A' }));
+    expect(onItem).toHaveBeenCalledTimes(1);
+    expect(onMenu).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('disabled prevents opening', () => {
+    render(
+      <Dropdown disabled items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Profile' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('opens on context menu trigger', () => {
+    render(
+      <Dropdown trigger={[DropdownTrigger.ContextMenu]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('closable overlay shows button and calls onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <Dropdown closable onClose={onClose} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    const closeBtn = screen.getByRole('button', { name: 'Close dropdown' });
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('disabled item does not call handlers or close', () => {
+    const onItem = vi.fn();
+    const onMenu = vi.fn();
+    render(
+      <Dropdown
+        items={[
+          { key: 'x', label: 'X', disabled: true, onClick: onItem },
+          { key: 'y', label: 'Y' },
+        ]}
+        onItemClick={onMenu}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'X' }));
+    expect(onItem).not.toHaveBeenCalled();
+    expect(onMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('error item has proper class and overlay width hugs content', () => {
+    render(
+      <Dropdown items={items} matchReferenceWidth={false}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    const errorItem = screen.getByRole('menuitem', { name: 'Error' });
+    expect(errorItem).toHaveClass('text-error');
+    const menuEl = screen.getByRole('menu');
+    expect(menuEl).toHaveClass('w-max');
+  });
+
+  test('renders header item type correctly', () => {
+    const itemsWithHeader: DropdownItem[] = [
+      { key: 'item1', label: 'Item 1' },
+      { key: 'd1', type: DropdownItemType.Divider },
+      {
+        key: 'h1',
+        type: DropdownItemType.PlainText,
+        label: <span>Section Title</span>,
+      },
+      { key: 'item2', label: 'Item 2' },
+    ];
+    render(
+      <Dropdown items={itemsWithHeader}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    expect(screen.getByText('Section Title')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Item 1' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Item 2' }),
+    ).toBeInTheDocument();
+  });
+
+  test('header item does not act as clickable menuitem', () => {
+    const onMenu = vi.fn();
+    const itemsWithHeader: DropdownItem[] = [
+      { key: 'item1', label: 'Item 1' },
+      {
+        key: 'h1',
+        type: DropdownItemType.PlainText,
+        label: <span>Section Header</span>,
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithHeader} onItemClick={onMenu}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    const headerElement = screen.getByText('Section Header');
+    fireEvent.click(headerElement);
+    expect(onMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('outsideClosable=false keeps menu open on outside press', () => {
+    render(
+      <Dropdown outsideClosable={false} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    fireEvent.pointerDown(document.body);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('custom renderOverlay path renders when menu is not provided', () => {
+    render(
+      <Dropdown renderOverlay={() => <div role="none">custom</div>}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    expect(screen.getByText('custom')).toBeInTheDocument();
+  });
+
+  test('icon is rendered and inherits state classes (danger/disabled)', () => {
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'i1',
+            label: 'With Icon Danger',
+            danger: true,
+            icon: <IconCheck />,
+          },
+          {
+            key: 'i2',
+            label: 'With Icon Disabled',
+            disabled: true,
+            icon: <IconCheck />,
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    const dangerItem = screen.getByRole('menuitem', {
+      name: 'With Icon Danger',
+    });
+    const dangerIconWrapper = dangerItem.querySelector('span.text-error svg');
+    expect(dangerIconWrapper).toBeTruthy();
+
+    const disabledItem = screen.getByRole('menuitem', {
+      name: 'With Icon Disabled',
+    });
+    const disabledIconWrapper = disabledItem.querySelector(
+      'span.text-secondary svg',
+    );
+    expect(disabledIconWrapper).toBeTruthy();
+  });
+
+  test('disabled branch in click handler short-circuits when click is forced', () => {
+    const onItem = vi.fn();
+    const onMenu = vi.fn();
+
+    render(
+      <Dropdown
+        items={[
+          { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
+        ]}
+        onItemClick={onMenu}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    const btn = screen.getByRole('menuitem', {
+      name: 'Disabled',
+    }) as HTMLButtonElement;
+    btn.removeAttribute('disabled');
+    fireEvent.click(btn);
+
+    expect(onItem).not.toHaveBeenCalled();
+    expect(onMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('becomes disabled while open -> closes via effect', () => {
+    const { rerender } = render(
+      <Dropdown disabled={false} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    rerender(
+      <Dropdown disabled items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('ignores contextmenu when trigger does not include ContextMenu', () => {
+    render(
+      <Dropdown items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('outsidePress closes by default, but ignores clicks inside outsidePressIgnoreRef', () => {
+    const ignoreRef: { current: HTMLElement | null } = { current: null };
+
+    const { container } = render(
+      <div>
+        <div
+          ref={(el) => {
+            ignoreRef.current = el;
+          }}
+        >
+          <button type="button">Safe Outside</button>
+        </div>
+        <Dropdown outsidePressIgnoreRef={ignoreRef} items={items}>
+          <button type="button">Open</button>
+        </Dropdown>
+      </div>,
+    );
+
+    const trigger = container.querySelector('[aria-haspopup="menu"]')!;
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Safe Outside' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('explicit placement uses flip middleware path', () => {
+    render(
+      <Dropdown placement="bottom-end" items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('opens on hover when enabled', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Dropdown trigger={[DropdownTrigger.Hover]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    const triggerWrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    await user.hover(triggerWrapper);
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+
+    await user.unhover(triggerWrapper);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  test('controlled mode uses the `open` prop (isControlled ? !!open) regardless of defaultOpen or clicks', () => {
+    const { container, rerender } = render(
+      <Dropdown open={false} defaultOpen={true} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    let triggerWrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    rerender(
+      <Dropdown open={true} defaultOpen={true} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    triggerWrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    rerender(
+      <Dropdown open={false} defaultOpen={true} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    triggerWrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    expect(triggerWrapper).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('handleItemClick returns early when item.disabled is true (even if DOM not disabled)', () => {
+    const onItem = vi.fn();
+    const onMenu = vi.fn();
+
+    render(
+      <Dropdown
+        items={[
+          { key: 'd', label: 'Disabled', disabled: true, onClick: onItem },
+        ]}
+        onItemClick={onMenu}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    const btn = screen.getByRole('menuitem', {
+      name: 'Disabled',
+    }) as HTMLButtonElement;
+
+    expect(btn).toBeDisabled();
+    btn.removeAttribute('disabled');
+
+    fireEvent.click(btn);
+
+    expect(onItem).not.toHaveBeenCalled();
+    expect(onMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('renders menu.header (function) above items and footer (node) below items', () => {
+    const footerText = 'Times are displayed in UTC';
+    const headerText = 'Custom Time Range';
+
+    render(
+      <Dropdown
+        items={items}
+        menuHeader={() => <div>{headerText}</div>}
+        menuFooter={<div>{footerText}</div>}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    const menuEl = screen.getByRole('menu');
+    const headerEl = screen.getByText(headerText);
+    const firstItem = screen.getByRole('menuitem', { name: 'Profile' });
+    const footerEl = screen.getByText(footerText);
+    const lastItem = screen.getByRole('menuitem', { name: 'Logout' });
+
+    expect(
+      headerEl.compareDocumentPosition(firstItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(
+      lastItem.compareDocumentPosition(footerEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(menuEl).toContainElement(headerEl);
+    expect(menuEl).toContainElement(footerEl);
+  });
+
+  test('contextmenu does not open when disabled=true even if ContextMenu is in triggers', () => {
+    render(
+      <Dropdown disabled trigger={[DropdownTrigger.ContextMenu]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+  test('menu.header (function) renders above items and does not close on click', () => {
+    const headerText = 'Custom Time Range';
+    const simpleItems: DropdownItem[] = [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ];
+
+    render(
+      <Dropdown
+        items={simpleItems}
+        menuHeader={() => <div role="hdr">{headerText}</div>}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    const menu = screen.getByRole('menu');
+    const headerEl = screen.getByRole('hdr');
+    const firstItem = screen.getByRole('menuitem', { name: 'A' });
+
+    expect(menu).toContainElement(headerEl);
+
+    expect(
+      headerEl.compareDocumentPosition(firstItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(
+      screen.queryByRole('menuitem', { name: headerText }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(headerEl);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('menu.header (ReactNode) renders when provided as a node', () => {
+    const headerText = 'Filters';
+    render(
+      <Dropdown
+        items={[
+          { key: 'a', label: 'A' },
+          { key: 'b', label: 'B' },
+        ]}
+        menuHeader={<div>{headerText}</div>}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    const headerEl = screen.getByText(headerText);
+    expect(headerEl).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('menuitem', { name: headerText }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('menu.footer (function) is invoked and its content renders after items', () => {
+    const footerText = 'Times are displayed in UTC';
+    const footerFn = vi.fn(() => <div role="footer">{footerText}</div>);
+
+    render(
+      <Dropdown
+        items={[
+          { key: 'a', label: 'A' },
+          { key: 'b', label: 'B' },
+        ]}
+        menuFooter={footerFn}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+
+    expect(footerFn.mock.calls.length).toBeGreaterThan(0);
+
+    const footerEl = screen.getByRole('footer');
+    expect(footerEl).toBeInTheDocument();
+    expect(screen.getByText(footerText)).toBeInTheDocument();
+
+    const lastItem = screen.getByRole('menuitem', { name: 'B' });
+    expect(
+      lastItem.compareDocumentPosition(footerEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test('anchorToMouse + ContextMenu opens on right click', () => {
+    render(
+      <Dropdown
+        anchorToMouse
+        trigger={[DropdownTrigger.ContextMenu]}
+        items={items}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /open/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('anchorToMouse + Click opens on left click', () => {
+    render(
+      <Dropdown anchorToMouse trigger={[DropdownTrigger.Click]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('calls onOpenChange on open and close', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Dropdown onOpenChange={onOpenChange} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test('matchReferenceWidth=false -> menu has w-max and no inline min-width', () => {
+    render(
+      <Dropdown matchReferenceWidth={false} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    openByClick();
+    const menuEl = screen.getByRole('menu');
+    expect(menuEl).toHaveClass('w-max');
+    expect(menuEl.getAttribute('style') || '').not.toMatch(/min-width:/i);
+    expect(menuEl.style.minWidth).toBe('');
+  });
+
+  test('changes menu position based on clientX/clientY from pointerdown', async () => {
+    const { container } = render(
+      <Dropdown anchorToMouse trigger={[DropdownTrigger.Click]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    const wrapper = container.querySelector('[aria-haspopup="menu"]')!;
+
+    fireEvent.mouseDown(wrapper, { clientX: 10, clientY: 20 });
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+
+    const menu1 = await screen.findByRole('menu');
+    await waitFor(() => expect(readPosition(menu1)).not.toBe(''));
+    const pos1 = readPosition(menu1);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument(),
+    );
+
+    fireEvent.mouseDown(wrapper, { clientX: 150, clientY: 250 });
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+
+    const menu2 = await screen.findByRole('menu');
+    await waitFor(() => expect(readPosition(menu2)).not.toBe(''));
+    const pos2 = readPosition(menu2);
+
+    expect(pos1).not.toBe(pos2);
+  });
+
+  test('does not change position when anchorToMouse=false (covers early return)', async () => {
+    const { container } = render(
+      <Dropdown trigger={[DropdownTrigger.Click]} items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    const wrapper = container.querySelector('[aria-haspopup="menu"]')!;
+
+    fireEvent.mouseDown(wrapper, { clientX: 10, clientY: 20 });
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    const menu1 = await screen.findByRole('menu');
+    const pos1 = readPosition(menu1);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Profile' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument(),
+    );
+
+    fireEvent.mouseDown(wrapper, { clientX: 200, clientY: 100 });
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    const menu2 = await screen.findByRole('menu');
+    const pos2 = readPosition(menu2);
+
+    expect(pos1).toBe(pos2);
+  });
+
+  test('closes menu opened by context-menu trigger on side click', () => {
+    const { container } = render(
+      <Dropdown
+        trigger={[DropdownTrigger.ContextMenu]}
+        items={items}
+        anchorToMouse
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+
+    const wrapper = container.querySelector('[aria-haspopup="menu"]')!;
+    const button = screen.getByRole('button', { name: /open/i });
+
+    fireEvent.contextMenu(button);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(wrapper);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('item with children renders as submenu trigger (no onClick, has aria-haspopup)', () => {
+    const itemsWithSub: DropdownItem[] = [
+      { key: 'a', label: 'Normal' },
+      {
+        key: 'sub',
+        label: 'More',
+        children: [
+          { key: 'sub-1', label: 'Sub One' },
+          { key: 'sub-2', label: 'Sub Two' },
+        ],
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    const trigger = screen.getByRole('menuitem', { name: /more/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    // should not have a direct click handler that closes root
+    expect(trigger.tagName).toBe('BUTTON');
+  });
+
+  test('submenu opens on hover and child click fires handler + closes root', async () => {
+    const user = userEvent.setup();
+    const onChild = vi.fn();
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        children: [
+          { key: 'sub-1', label: 'Sub One', onClick: onChild },
+          { key: 'sub-2', label: 'Sub Two' },
+        ],
+      },
+    ];
+    const { container } = render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    await user.hover(subTrigger);
+
+    const subOne = await screen.findByRole('menuitem', { name: 'Sub One' });
+    expect(subOne).toBeInTheDocument();
+
+    fireEvent.click(subOne);
+    expect(onChild).toHaveBeenCalledTimes(1);
+    // root dropdown should close
+    await waitFor(() =>
+      expect(container.querySelector('[aria-haspopup="menu"]')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      ),
+    );
+  });
+
+  test.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('submenu opens with %s', async (_keyName, key) => {
+    const user = userEvent.setup();
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'sub',
+            label: 'More',
+            children: [{ key: 'sub-1', label: 'Sub One' }],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    subTrigger.focus();
+    await user.keyboard(key);
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Sub One' }),
+    ).toBeInTheDocument();
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Escape closes only submenu and returns focus to its trigger', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Dropdown
+        items={[
+          {
+            key: 'sub',
+            label: 'More',
+            children: [{ key: 'sub-1', label: 'Sub One' }],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    const rootTrigger = container.querySelector('[aria-haspopup="menu"]')!;
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    subTrigger.focus();
+    await user.keyboard('{Enter}');
+    const child = await screen.findByRole('menuitem', { name: 'Sub One' });
+    child.focus();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('menuitem', { name: 'Sub One' }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(rootTrigger).toHaveAttribute('aria-expanded', 'true');
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(subTrigger).toHaveFocus();
+  });
+
+  test('disabled submenu trigger does not open submenu', async () => {
+    const user = userEvent.setup();
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        disabled: true,
+        children: [{ key: 'sub-1', label: 'Sub One' }],
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    const subTrigger = screen.getByRole('menuitem', { name: /more/i });
+    expect(subTrigger).toBeDisabled();
+    await user.hover(subTrigger);
+    expect(
+      screen.queryByRole('menuitem', { name: 'Sub One' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('disabled child in submenu does not call onClick', async () => {
+    const user = userEvent.setup();
+    const onChild = vi.fn();
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        children: [
+          { key: 'sub-1', label: 'Sub One', disabled: true, onClick: onChild },
+        ],
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    await user.hover(screen.getByRole('menuitem', { name: /more/i }));
+    const child = await screen.findByRole('menuitem', { name: 'Sub One' });
+    expect(child).toBeDisabled();
+    fireEvent.click(child);
+    expect(onChild).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,535 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useRef, useState, type ReactNode } from 'react';
+import type { Placement } from '@floating-ui/react';
+import {
+  IconUser,
+  IconSettings,
+  IconLogout,
+  IconChevronDown,
+  IconRowRemove,
+  IconStack,
+  IconExternalLink,
+  IconCopy,
+  IconTrash,
+  IconDots,
+} from '@tabler/icons-react';
+
+import { Dropdown, type DropdownProps } from './Dropdown';
+import { DropdownItemType, DropdownTrigger } from '@/types/dropdown';
+import {
+  NeutralButton,
+  PrimaryButton,
+} from '@/components/New/Button/ButtonWrappers';
+import { type DropdownItem } from '@/models/dropdown';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+
+const items: DropdownItem[] = [
+  {
+    key: 'profile',
+    label: 'Profile',
+    icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
+  },
+  {
+    key: 'settings',
+    label: 'Settings',
+    icon: <IconSettings size={DIAL_ICON_SIZE.SM} />,
+  },
+  {
+    key: 'disabled',
+    label: 'Disabled',
+    icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+    disabled: true,
+  },
+  {
+    key: 'danger',
+    label: 'Danger',
+    icon: <IconRowRemove size={DIAL_ICON_SIZE.SM} />,
+    danger: true,
+  },
+  { key: 'd1', type: DropdownItemType.Divider },
+  {
+    key: 'logout',
+    label: 'Logout',
+    icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+  },
+];
+
+const specItems: DropdownItem[] = [
+  {
+    key: 'open',
+    label: 'Open in a new tab',
+    icon: <IconExternalLink size={DIAL_ICON_SIZE.SM} />,
+  },
+  {
+    key: 'dup',
+    label: 'Duplicate as a new version',
+    icon: <IconCopy size={DIAL_ICON_SIZE.SM} />,
+  },
+  { key: 'd2', type: DropdownItemType.Divider },
+  {
+    key: 'del',
+    label: 'Delete',
+    icon: <IconTrash size={DIAL_ICON_SIZE.SM} />,
+    danger: true,
+  },
+];
+
+const TriggerBtn = ({ label = 'Open' }: { label?: ReactNode }) => (
+  <PrimaryButton
+    iconAfter={<IconChevronDown size={DIAL_ICON_SIZE.SM} />}
+    label={label}
+  />
+);
+
+const PLACEMENTS: Placement[] = [
+  'top',
+  'top-start',
+  'top-end',
+  'right',
+  'right-start',
+  'right-end',
+  'bottom',
+  'bottom-start',
+  'bottom-end',
+  'left',
+  'left-start',
+  'left-end',
+];
+
+const meta = {
+  title: 'Components_2_0/Dropdown',
+  component: Dropdown,
+  parameters: { layout: 'centered', themes: {} },
+  argTypes: {
+    trigger: {
+      control: { type: 'inline-check' },
+      options: [
+        DropdownTrigger.Click,
+        DropdownTrigger.Hover,
+        DropdownTrigger.ContextMenu,
+      ],
+    },
+    placement: { control: { type: 'select' }, options: PLACEMENTS },
+    disabled: { control: { type: 'boolean' } },
+    closable: { control: { type: 'boolean' } },
+    anchorToMouse: { control: { type: 'boolean' } },
+    matchReferenceWidth: { control: { type: 'boolean' } },
+    className: { control: { type: 'text' } },
+    listClassName: { control: { type: 'text' } },
+    open: { control: false },
+    defaultOpen: { control: false },
+    onOpenChange: { control: false },
+    onClose: { control: false },
+    items: { control: false },
+    onItemClick: { control: false },
+    menuHeader: { control: false },
+    menuFooter: { control: false },
+    renderOverlay: { control: false },
+    children: { control: false },
+  },
+  args: {
+    trigger: [DropdownTrigger.Click],
+    disabled: false,
+    closable: false,
+    anchorToMouse: false,
+    matchReferenceWidth: true,
+    children: <TriggerBtn />,
+    items,
+  },
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const RightTightGap: Story = {
+  args: { placement: 'right-start' },
+};
+
+export const HoverTrigger: Story = {
+  args: { trigger: [DropdownTrigger.Hover] },
+};
+
+export const SpecWidthHugContent: Story = {
+  name: 'Width hugs content (spec-like)',
+  args: {
+    placement: 'bottom-start',
+    matchReferenceWidth: false,
+    items: specItems,
+  },
+};
+
+const ControlledExample = (args: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+  const controllerRef = useRef<HTMLSpanElement>(null);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span ref={controllerRef}>
+        <NeutralButton
+          label={open ? 'Close Dropdown' : 'Open Dropdown'}
+          onClick={() => setOpen((v) => !v)}
+        />
+      </span>
+      <Dropdown
+        {...args}
+        trigger={[]}
+        open={open}
+        onOpenChange={setOpen}
+        outsidePressIgnoreRef={controllerRef}
+      >
+        <TriggerBtn label="Controlled" />
+      </Dropdown>
+    </div>
+  );
+};
+
+export const ControlledOpen: Story = {
+  args: {},
+  render: ControlledExample,
+};
+
+export const AllPlacements: Story = {
+  args: {},
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <Dropdown {...args}>
+        <TriggerBtn label="Auto (default)" />
+      </Dropdown>
+      {PLACEMENTS.map((p) => (
+        <Dropdown key={p} {...args} placement={p}>
+          <TriggerBtn label={p} />
+        </Dropdown>
+      ))}
+    </div>
+  ),
+};
+
+export const SecondaryEllipsisTrigger: Story = {
+  name: 'Secondary trigger (ellipsis)',
+  args: {
+    children: (
+      <NeutralButton
+        aria-label="More actions"
+        iconBefore={<IconDots size={DIAL_ICON_SIZE.SM} />}
+      />
+    ),
+    items: specItems,
+    placement: 'bottom-end',
+  },
+};
+
+export const AllowedPlacements: Story = {
+  name: 'Allowed placements',
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <span className="text-primary dial-small-text">
+        The dropdown below is set to open at bottom-start, but if there is not
+        enough space, it can only be placed at top-start or top-end (no right or
+        left placements).
+      </span>
+      <Dropdown
+        {...args}
+        placement="bottom-start"
+        allowedPlacements={['top-start', 'top-end']}
+        items={specItems}
+      >
+        <TriggerBtn label="Allowed Placements" />
+      </Dropdown>
+    </div>
+  ),
+};
+
+const timeItems = [
+  { key: '15m', label: 'Last 15m' },
+  { key: '30m', label: 'Last 30m' },
+  { key: '1h', label: 'Last 1h' },
+  { key: '3h', label: 'Last 3h' },
+  { key: '6h', label: 'Last 6h' },
+  { key: '12h', label: 'Last 12h' },
+  { key: '24h', label: 'Last 24h' },
+  { key: 'd', label: 'Last 2d' },
+  { key: '7d', label: 'Last 7d' },
+  { key: '30d', label: 'Last 30d' },
+].map((i) => ({ key: i.key, label: i.label }));
+
+export const WithCustomHeader: Story = {
+  name: 'With custom header',
+  args: {
+    placement: 'bottom-start',
+    items: [{ key: 'divider', type: DropdownItemType.Divider }, ...timeItems],
+    menuHeader: (
+      <div className="px-3 pt-2">
+        <div className="flex items-center justify-between text-secondary">
+          <span className="dial-small-text font-medium">Custom Time Range</span>
+          <IconChevronDown size={14} />
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const WithCustomFooter: Story = {
+  name: 'With custom footer',
+  args: {
+    placement: 'bottom-start',
+    items: timeItems,
+    menuFooter: (
+      <div className="px-3 py-2 border-t">
+        <span className="dial-small-text text-primary font-medium">
+          Footer content
+        </span>
+      </div>
+    ),
+  },
+};
+
+export const WithHeaderAndFooter: Story = {
+  name: 'With header and footer',
+  args: {
+    placement: 'bottom-start',
+    items: timeItems,
+    menuHeader: (
+      <div className="px-3 py-2 border-b">
+        <span className="dial-small-text text-primary font-medium">
+          Select time range
+        </span>
+      </div>
+    ),
+    menuFooter: (
+      <div className="px-3 py-2 border-t">
+        <span className="dial-small-text text-primary font-medium">
+          Footer content
+        </span>
+      </div>
+    ),
+  },
+};
+
+const FooterActionsExample = (args: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dropdown
+      {...args}
+      trigger={[DropdownTrigger.Click]}
+      open={open}
+      onOpenChange={setOpen}
+      items={timeItems}
+      menuFooter={() => (
+        <div className="px-2 pb-2 pt-1 border-t border-divider">
+          <div className="flex items-center justify-end gap-2">
+            <NeutralButton label="Cancel" onClick={() => setOpen(false)} />
+            <PrimaryButton label="Apply" onClick={() => setOpen(false)} />
+          </div>
+        </div>
+      )}
+    >
+      <TriggerBtn label="With footer actions" />
+    </Dropdown>
+  );
+};
+
+export const WithFooterActionsControlled: Story = {
+  render: FooterActionsExample,
+};
+
+export const ContextMenuAtCursor: Story = {
+  name: 'Context menu anchored to cursor',
+  args: {
+    trigger: [DropdownTrigger.ContextMenu],
+    anchorToMouse: true,
+    matchReferenceWidth: false,
+    items: specItems,
+  },
+  render: (args) => (
+    <Dropdown {...args}>
+      <div className="h-48 w-[520px] p-4 text-primary border border-secondary flex items-center justify-center">
+        Right-click anywhere in this area
+      </div>
+    </Dropdown>
+  ),
+};
+
+export const ClickNearCursor: Story = {
+  name: 'Click anchored to cursor',
+  args: {
+    trigger: [DropdownTrigger.Click],
+    anchorToMouse: true,
+    matchReferenceWidth: false,
+    items: specItems,
+  },
+  render: (args) => (
+    <Dropdown {...args}>
+      <PrimaryButton label="Click me (opens near cursor)" />
+    </Dropdown>
+  ),
+};
+
+export const CompareWidthModes: Story = {
+  name: 'Compare: matchReferenceWidth=true vs false',
+  args: {},
+  render: (args) => (
+    <div className="flex gap-6">
+      <Dropdown {...args} matchReferenceWidth>
+        <NeutralButton label="Match trigger width" />
+      </Dropdown>
+      <Dropdown
+        {...args}
+        matchReferenceWidth={false}
+        renderOverlay={() => (
+          <div className="p-3 whitespace-nowrap">
+            Very long, unwrapped overlay content that should define its own
+            width
+          </div>
+        )}
+      >
+        <NeutralButton label="Hug content width" />
+      </Dropdown>
+    </div>
+  ),
+};
+
+export const DropdownDynamicButtons: Story = {
+  name: 'With dynamic button items and styles',
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    const [selectedFirstSection, setSelectedFirstSection] = useState<
+      string | null
+    >('custom');
+    const [selectedSecondSection, setSelectedSecondSection] = useState<
+      string | null
+    >('subsection1');
+    const [showSubsection, setShowSubsection] = useState(false);
+    const borderCss = 'border-l-2 border-accent-primary pl-2 rounded-l-none';
+
+    const baseItems: DropdownItem[] = [
+      {
+        key: 'header1',
+        type: DropdownItemType.PlainText,
+        label: 'First Section',
+      },
+      {
+        key: 'normal',
+        label: 'Normal Item',
+        className: selectedFirstSection === 'normal' ? borderCss : undefined,
+        onClick: () => {
+          setSelectedFirstSection('normal');
+        },
+      },
+      {
+        key: 'custom',
+        label: 'Custom Styled Item',
+        className: selectedFirstSection === 'custom' ? borderCss : undefined,
+        onClick: () => {
+          setSelectedFirstSection('custom');
+        },
+      },
+      {
+        key: 'withSubsection',
+        label: 'Item with Subsection',
+        className:
+          selectedFirstSection === 'withSubsection' ? borderCss : undefined,
+        onClick: (info) => {
+          info.domEvent.preventDefault();
+          setSelectedFirstSection('withSubsection');
+          setShowSubsection(true);
+          setTimeout(() => setOpen(true), 0);
+        },
+      },
+    ];
+
+    const subsectionItems: DropdownItem[] =
+      showSubsection && selectedFirstSection === 'withSubsection'
+        ? [
+            { key: 'd1', type: DropdownItemType.Divider },
+            {
+              key: 'header2',
+              type: DropdownItemType.PlainText,
+              label: 'Subsection',
+            },
+            {
+              key: 'subsection1',
+              label: 'Subsection Item 1',
+              className:
+                selectedSecondSection === 'subsection1' ? borderCss : undefined,
+              onClick: () => {
+                setSelectedSecondSection('subsection1');
+              },
+            },
+            {
+              key: 'subsection2',
+              label: 'Subsection Item 2',
+              className:
+                selectedSecondSection === 'subsection2' ? borderCss : undefined,
+              onClick: () => {
+                setSelectedSecondSection('subsection2');
+              },
+            },
+          ]
+        : [];
+
+    const items = [...baseItems, ...subsectionItems];
+
+    return (
+      <Dropdown
+        {...args}
+        open={open}
+        onOpenChange={setOpen}
+        onClose={() => setOpen(false)}
+        placement="bottom"
+        items={items}
+      >
+        <TriggerBtn label="Dynamic items" />
+      </Dropdown>
+    );
+  },
+};
+
+export const WithSubMenu: Story = {
+  name: 'With sub-menu items',
+  render: (args) => (
+    <Dropdown
+      {...args}
+      placement="bottom-start"
+      items={[
+        {
+          key: 'profile',
+          label: 'Profile',
+          icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
+        },
+        {
+          key: 'more',
+          label: 'More actions',
+          icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+          children: [
+            {
+              key: 'open',
+              label: 'Open in new tab',
+              icon: <IconExternalLink size={DIAL_ICON_SIZE.SM} />,
+            },
+            {
+              key: 'copy',
+              label: 'Duplicate',
+              icon: <IconCopy size={DIAL_ICON_SIZE.SM} />,
+            },
+            {
+              key: 'del',
+              label: 'Delete',
+              icon: <IconTrash size={DIAL_ICON_SIZE.SM} />,
+              danger: true,
+            },
+          ],
+        },
+        {
+          key: 'logout',
+          label: 'Logout',
+          icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+        },
+      ]}
+    >
+      <TriggerBtn label="Sub-menu" />
+    </Dropdown>
+  ),
+};

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -1,0 +1,516 @@
+import {
+  FloatingFocusManager,
+  FloatingPortal,
+  autoPlacement,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  size as fuiSize,
+  useClick,
+  useDismiss,
+  useFloating,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import type { Placement, ReferenceElement } from '@floating-ui/react';
+import classNames from 'classnames';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type MouseEvent,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+
+import { DialIcon } from '@/components/Icon/Icon';
+import { DropdownTrigger, DropdownItemType } from '@/types/dropdown';
+
+import {
+  dropdownBaseClassName,
+  dropdownListBaseClassName,
+  dropdownItemBaseClassName,
+  dropdownItemDisabledClassName,
+  dropdownItemDangerClassName,
+  dropdownDividerClassName,
+  dropdownGap,
+} from './constants';
+import { type DropdownItem } from '@/models/dropdown';
+import { CloseButton } from '@/components/New/CloseButton/CloseButton';
+
+import { mergeClasses } from '@/utils/merge-classes';
+import { DropdownSubMenuItem } from './DropdownSubMenuItem';
+
+export interface DropdownProps {
+  children: ReactNode;
+  items?: DropdownItem[];
+  onItemClick?: (info: { key: string; domEvent: MouseEvent }) => void;
+  menuHeader?: ReactNode | (() => ReactNode);
+  menuFooter?: ReactNode | (() => ReactNode);
+  renderOverlay?: () => ReactNode;
+  trigger?: DropdownTrigger[];
+  placement?: Placement;
+  allowedPlacements?: Placement[];
+  disabled?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  closable?: boolean;
+  onClose?: (e: MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  overlayContentClassName?: string;
+  separatorClassName?: string;
+  listClassName?: string;
+  outsidePressIgnoreRef?: RefObject<HTMLElement | null>;
+  outsideClosable?: boolean;
+  anchorToMouse?: boolean;
+  matchReferenceWidth?: boolean;
+  maxDropdownHeight?: number | null;
+}
+
+const getRefWidth = (el: ReferenceElement): number => {
+  if ('clientWidth' in el) return (el as Element).clientWidth;
+  const rect = (
+    el as { getBoundingClientRect?: () => DOMRect }
+  ).getBoundingClientRect?.();
+  return rect?.width ?? 0;
+};
+
+/**
+ *
+ * Renders the given trigger (`children`) and a floating contextual menu overlay.
+ * aliases: ContextMenu|PopupMenu
+ *
+ * Supports click/hover/contextMenu triggers, controlled/uncontrolled open, and an optional
+ * close button inside the overlay. Placement is taken directly from Floating UI; when
+ * `placement` is **undefined** (default), automatic placement is handled by `autoPlacement`.
+ *
+ * @example
+ * ```tsx
+ * // Simple items menu
+ * <Dropdown items={[{ key: 'profile', label: 'Profile' }, { key: 'logout', label: 'Logout' }]}>
+ *   <button type="button" className="px-3 py-2 rounded border">Open</button>
+ * </Dropdown>
+ *
+ * // Hover trigger
+ * <Dropdown trigger={[DropdownTrigger.Hover]} placement="bottom-end" items={items}>
+ *   <button type="button" className="px-3 py-2 rounded border">Hover me</button>
+ * </Dropdown>
+ *
+ * // Custom overlay content
+ * <Dropdown closable renderOverlay={() => <div className="p-3">Custom content</div>}>
+ *   <button type="button" className="px-3 py-2 rounded border">Custom</button>
+ * </Dropdown>
+ * ```
+ *
+ * @param children - Trigger element(s) to anchor and open the menu
+ * @param [items] - Menu items to render
+ * @param [onItemClick] - Global handler fired when any item is clicked
+ * @param [menuHeader] - Content rendered above the items list
+ * @param [menuFooter] - Content rendered below the items list
+ * @param [renderOverlay] - Render function for fully custom overlay content (ignored when `items` is provided)
+ * @param [trigger=[DropdownTrigger.Click]] - Interactions that open the menu
+ * @param [placement] - Floating UI placement string; when omitted, auto placement is used
+ * @param [allowedPlacements] - Restricts the allowed placements
+ * @param [disabled=false] - Disables interaction and prevents opening
+ * @param [open] - Controlled open state (when provided, `defaultOpen` is ignored)
+ * @param [defaultOpen=false] - Initial open state in uncontrolled mode
+ * @param [onOpenChange] - Fired whenever the open state changes
+ * @param [closable=false] - Whether the overlay shows an internal close button
+ * @param [onClose] - Fired when the close button inside the overlay is clicked
+ * @param [className] - Additional CSS classes applied to the trigger wrapper
+ * @param [overlayContentClassName] - Additional CSS classes applied to the overlay content
+ * @param [separatorClassName] - Additional CSS classes applied to the separators between items
+ * @param [listClassName] - Additional CSS classes applied to the floating overlay
+ * @param [outsidePressIgnoreRef] - Ref to an element that should not trigger outside press behavior
+ * @param [outsideClosable=true] - Whether clicks outside the overlay should close it
+ * @param [anchorToMouse=false] - Whether to anchor the dropdown to the mouse position
+ * @param [matchReferenceWidth=true] - Whether to match the reference element's width
+ * @param [maxDropdownHeight] - Maximum height of the dropdown menu; when omitted, no limit is applied
+ */
+export const Dropdown: FC<DropdownProps> = ({
+  children,
+  items,
+  onItemClick,
+  menuHeader,
+  menuFooter,
+  renderOverlay,
+  trigger = [DropdownTrigger.Click],
+  placement,
+  disabled = false,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  closable = false,
+  onClose,
+  className,
+  overlayContentClassName,
+  separatorClassName,
+  listClassName,
+  outsidePressIgnoreRef,
+  outsideClosable = true,
+  allowedPlacements,
+  anchorToMouse = false,
+  matchReferenceWidth = true,
+  maxDropdownHeight,
+}) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? !!open : uncontrolledOpen;
+  const pointedElementRef = useRef<Element | null>(null);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const listId = useId();
+  const useAuto = placement === undefined;
+
+  const { refs, floatingStyles, context } = useFloating({
+    placement,
+    open: isOpen,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset({ mainAxis: dropdownGap, crossAxis: 0 }),
+      useAuto
+        ? autoPlacement({
+            alignment: 'start',
+            crossAxis: true,
+            padding: dropdownGap,
+            allowedPlacements,
+          })
+        : flip({ padding: dropdownGap }),
+      shift({ padding: dropdownGap }),
+      fuiSize({
+        padding: dropdownGap,
+        apply({ availableWidth, availableHeight, elements }) {
+          const floating = elements.floating as HTMLElement;
+          const refWidth = getRefWidth(elements.reference);
+
+          floating.style.setProperty(
+            '--fui-available-height',
+            `${Math.floor(availableHeight)}px`,
+          );
+          floating.style.setProperty(
+            '--reference-width',
+            matchReferenceWidth ? `${Math.round(refWidth)}px` : '0px',
+          );
+
+          if (matchReferenceWidth) {
+            floating.style.minWidth = `${Math.round(refWidth)}px`;
+          } else {
+            floating.style.removeProperty('min-width');
+          }
+
+          floating.style.maxWidth = `${Math.floor(availableWidth)}px`;
+          const heightLimit = Math.floor(availableHeight);
+          floating.style.maxHeight = `${maxDropdownHeight ? Math.min(heightLimit, maxDropdownHeight) : heightLimit}px`;
+        },
+      }),
+    ],
+  });
+
+  const click = useClick(context, {
+    enabled: trigger.includes(DropdownTrigger.Click) && !disabled,
+  });
+
+  const hover = useHover(context, {
+    enabled: trigger.includes(DropdownTrigger.Hover) && !disabled,
+    move: false,
+    restMs: 40,
+    delay: { open: 80, close: 80 },
+  });
+
+  const dismiss = useDismiss(context, {
+    bubbles: true,
+    referencePress: false,
+    outsidePress: (event) => {
+      if (!outsideClosable) return false;
+      const target = event.target;
+      if (
+        outsidePressIgnoreRef?.current &&
+        target instanceof Node &&
+        outsidePressIgnoreRef.current.contains(target)
+      ) {
+        return false;
+      }
+      return true;
+    },
+  });
+
+  const role = useRole(context, { role: 'menu' });
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    click,
+    hover,
+    dismiss,
+    role,
+  ]);
+
+  const setPositionFromPointer = useCallback(
+    (clientX: number, clientY: number) => {
+      refs.setPositionReference({
+        getBoundingClientRect: () =>
+          ({
+            width: 0,
+            height: 0,
+            x: clientX,
+            y: clientY,
+            top: clientY,
+            left: clientX,
+            right: clientX,
+            bottom: clientY,
+          }) as DOMRect,
+      });
+    },
+    [refs],
+  );
+
+  const onContextMenu = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (!trigger.includes(DropdownTrigger.ContextMenu) || disabled) return;
+      e.preventDefault();
+      if (anchorToMouse) {
+        setPositionFromPointer(e.clientX, e.clientY);
+        pointedElementRef.current = document.elementFromPoint(
+          e.clientX,
+          e.clientY,
+        );
+      }
+      setOpen(true);
+    },
+    [anchorToMouse, disabled, setOpen, setPositionFromPointer, trigger],
+  );
+
+  const onPointerDown = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      if (!anchorToMouse || disabled) return;
+
+      if (trigger.includes(DropdownTrigger.ContextMenu) && isOpen) {
+        setOpen(false);
+      }
+
+      setPositionFromPointer(e.clientX, e.clientY);
+      pointedElementRef.current = document.elementFromPoint(
+        e.clientX,
+        e.clientY,
+      );
+    },
+    [anchorToMouse, disabled, setPositionFromPointer, isOpen, trigger, setOpen],
+  );
+
+  useEffect(() => {
+    if (disabled && isOpen) setOpen(false);
+  }, [disabled, isOpen, setOpen]);
+
+  const handleItemClick = useCallback(
+    (item: DropdownItem) => (e: MouseEvent) => {
+      if (item.disabled) return;
+      item.onClick?.({ key: item.key, domEvent: e });
+      onItemClick?.({ key: item.key, domEvent: e });
+      setOpen(false);
+    },
+    [onItemClick, setOpen],
+  );
+
+  const overlayContent: ReactNode = useMemo(() => {
+    if (renderOverlay) return renderOverlay();
+    if (!items) return null;
+
+    return (
+      <>
+        {menuHeader && (
+          <>{typeof menuHeader === 'function' ? menuHeader() : menuHeader}</>
+        )}
+
+        <div
+          role="none"
+          className={mergeClasses('py-1', overlayContentClassName)}
+          aria-label="dropdown"
+        >
+          {items.map((it) => {
+            if (it.type === DropdownItemType.Divider) {
+              return (
+                <div
+                  key={it.key}
+                  role="separator"
+                  className={mergeClasses(
+                    dropdownDividerClassName,
+                    separatorClassName,
+                  )}
+                />
+              );
+            }
+            if (it.type === DropdownItemType.PlainText) {
+              return (
+                <div
+                  key={it.key}
+                  className={mergeClasses(
+                    'px-3 py-2 text-secondary dial-caption-text',
+                    it.className,
+                  )}
+                >
+                  {it.label}
+                </div>
+              );
+            }
+            if (it.children?.length) {
+              return (
+                <DropdownSubMenuItem
+                  key={it.key}
+                  item={it}
+                  onRootClose={() => setOpen(false)}
+                />
+              );
+            }
+            return (
+              <button
+                key={it.key}
+                role="menuitem"
+                type="button"
+                aria-disabled={!!it.disabled}
+                className={classNames(
+                  dropdownItemBaseClassName,
+                  it.disabled && dropdownItemDisabledClassName,
+                  it.danger && dropdownItemDangerClassName,
+                  it.className,
+                )}
+                disabled={it.disabled}
+                onClick={handleItemClick(it)}
+              >
+                {it.icon && (
+                  <span
+                    className={classNames(
+                      it.danger && 'text-error',
+                      it.disabled && 'text-secondary',
+                    )}
+                  >
+                    <DialIcon icon={it.icon} />
+                  </span>
+                )}
+                <span
+                  className={classNames(
+                    'flex-1 truncate text-start',
+                    it.danger && 'text-error',
+                    it.disabled && 'text-secondary',
+                  )}
+                >
+                  {it.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {menuFooter && (
+          <>{typeof menuFooter === 'function' ? menuFooter() : menuFooter}</>
+        )}
+      </>
+    );
+  }, [
+    handleItemClick,
+    items,
+    menuFooter,
+    menuHeader,
+    renderOverlay,
+    setOpen,
+    overlayContentClassName,
+    separatorClassName,
+  ]);
+
+  const referenceProps = getReferenceProps({
+    onContextMenu,
+    onMouseDown: onPointerDown,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const refEl = refs.reference.current;
+    let targetEl: Element | null = null;
+
+    if (refEl instanceof Element) {
+      targetEl = refEl;
+    } else if (pointedElementRef.current instanceof Element) {
+      targetEl = pointedElementRef.current;
+    }
+
+    if (!targetEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) setOpen(false);
+      },
+      { root: null, threshold: 0 },
+    );
+
+    observer.observe(targetEl);
+
+    return () => observer.disconnect();
+  }, [isOpen, refs.reference, setOpen]);
+
+  return (
+    <>
+      <span
+        ref={refs.setReference}
+        className={classNames(
+          dropdownBaseClassName,
+          disabled && '!cursor-not-allowed opacity-75',
+          className,
+        )}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={listId}
+        {...referenceProps}
+      >
+        {children}
+      </span>
+
+      {isOpen && (
+        <FloatingPortal>
+          <FloatingFocusManager
+            context={context}
+            modal={false}
+            initialFocus={-1}
+            returnFocus
+          >
+            <div
+              id={listId}
+              ref={refs.setFloating}
+              style={floatingStyles}
+              className={classNames(
+                dropdownListBaseClassName,
+                !matchReferenceWidth && 'w-max',
+                listClassName,
+              )}
+              {...getFloatingProps()}
+            >
+              {closable && (
+                <div className="flex items-center justify-between px-2 pt-2">
+                  <CloseButton
+                    ariaLabel="Close dropdown"
+                    onClose={(e) => {
+                      onClose?.(e);
+                      setOpen(false);
+                    }}
+                  />
+                </div>
+              )}
+              {overlayContent}
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -1,0 +1,135 @@
+import classNames from 'classnames';
+import { useCallback, type FC, type MouseEvent } from 'react';
+
+import { DialIcon } from '@/components/Icon/Icon';
+import { type DropdownItem } from '@/models/dropdown';
+import { SubMenuPanel, useSubMenuFloating } from '@/utils/sub-menu-floating';
+
+import {
+  dropdownGap,
+  dropdownItemBaseClassName,
+  dropdownItemDangerClassName,
+  dropdownItemDisabledClassName,
+  submenuCaretIcon,
+} from './constants';
+
+export interface DropdownSubMenuItemProps {
+  item: DropdownItem;
+  /** Close the root dropdown when a leaf child is selected. */
+  onRootClose: () => void;
+}
+
+export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
+  item,
+  onRootClose,
+}) => {
+  const {
+    isOpen,
+    refs,
+    floatingStyles,
+    context,
+    getReferenceProps,
+    getFloatingProps,
+  } = useSubMenuFloating(dropdownGap, 'menu', !!item.disabled);
+
+  const handleChildClick = useCallback(
+    (child: DropdownItem) => (e: MouseEvent) => {
+      if (child.disabled) return;
+      child.onClick?.({ key: child.key, domEvent: e });
+      onRootClose();
+    },
+    [onRootClose],
+  );
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        type="button"
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-disabled={!!item.disabled}
+        disabled={item.disabled}
+        className={classNames(
+          dropdownItemBaseClassName,
+          item.disabled && dropdownItemDisabledClassName,
+          item.className,
+        )}
+        {...getReferenceProps()}
+      >
+        {item.icon && (
+          <span className={classNames(item.disabled && 'text-secondary')}>
+            <DialIcon icon={item.icon} />
+          </span>
+        )}
+        <span
+          className={classNames(
+            'flex-1 truncate text-start',
+            item.disabled && 'text-secondary',
+          )}
+        >
+          {item.label}
+        </span>
+        <span
+          className={classNames(
+            'ml-auto shrink-0',
+            item.disabled && 'text-secondary',
+          )}
+        >
+          {submenuCaretIcon}
+        </span>
+      </button>
+
+      {isOpen && (
+        <SubMenuPanel
+          refs={refs}
+          floatingStyles={floatingStyles}
+          context={context}
+          getFloatingProps={getFloatingProps}
+          role="menu"
+          className="w-max"
+        >
+          <div role="none" className="py-1">
+            {item.children!.map((child) => (
+              <button
+                key={child.key}
+                role="menuitem"
+                type="button"
+                aria-disabled={!!child.disabled}
+                disabled={child.disabled}
+                className={classNames(
+                  dropdownItemBaseClassName,
+                  child.disabled && dropdownItemDisabledClassName,
+                  child.danger && dropdownItemDangerClassName,
+                  child.className,
+                )}
+                onClick={handleChildClick(child)}
+              >
+                {child.icon && (
+                  <span
+                    className={classNames(
+                      child.danger && 'text-error',
+                      child.disabled && 'text-secondary',
+                    )}
+                  >
+                    <DialIcon icon={child.icon} />
+                  </span>
+                )}
+                <span
+                  className={classNames(
+                    'flex-1 truncate text-start',
+                    child.danger && 'text-error',
+                    child.disabled && 'text-secondary',
+                  )}
+                >
+                  {child.label}
+                </span>
+              </button>
+            ))}
+          </div>
+        </SubMenuPanel>
+      )}
+    </>
+  );
+};

--- a/src/components/New/Dropdown/constants.tsx
+++ b/src/components/New/Dropdown/constants.tsx
@@ -1,0 +1,37 @@
+import { IconChevronRight } from '@tabler/icons-react';
+import classNames from 'classnames';
+
+import {
+  overlayGap,
+  overlayItemClassName,
+  overlayItemDisabledClassName,
+  overlaySurfaceClassName,
+} from '@/components/New/constants/overlay';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+
+export const dropdownBaseClassName = classNames(
+  'flex items-center gap-2 align-middle',
+  'h-auto px-0 bg-transparent border-0',
+);
+
+export const dropdownListBaseClassName = classNames(
+  'z-[53] focus-visible:outline-none',
+  overlaySurfaceClassName,
+);
+
+export const dropdownItemBaseClassName = overlayItemClassName;
+
+export const dropdownItemDisabledClassName = classNames(
+  overlayItemDisabledClassName,
+  '!cursor-not-allowed',
+);
+
+export const dropdownItemDangerClassName = 'text-error';
+
+export const dropdownDividerClassName = 'my-1 border-t border-secondary';
+
+export const dropdownGap = overlayGap;
+
+export const submenuCaretIcon = (
+  <IconChevronRight size={DIAL_ICON_SIZE.SM} aria-hidden="true" />
+);

--- a/src/components/New/IconButton/IconButton.stories.tsx
+++ b/src/components/New/IconButton/IconButton.stories.tsx
@@ -67,22 +67,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Hover: Story = {
-  parameters: { pseudo: { hover: true } },
-};
-
-export const Active: Story = {
-  parameters: { pseudo: { active: true } },
-};
-
-export const Focus: Story = {
-  parameters: { pseudo: { focusVisible: true } },
-};
-
-export const Disabled: Story = {
-  args: { disabled: true },
-};
-
 export const Small: Story = {
   args: {
     size: ElementSize.Small,

--- a/src/components/New/InfoButton/InfoButton.stories.ts
+++ b/src/components/New/InfoButton/InfoButton.stories.ts
@@ -34,14 +34,3 @@ export const Default: Story = {
     caption: 'Info',
   },
 };
-
-/**
- * A long caption still works as a tooltip, but a short `aria-label` keeps the
- * announced name scannable.
- */
-export const ExplicitAccessibleName: Story = {
-  args: {
-    caption: 'Only digits, without spaces or a country prefix',
-    'aria-label': 'Phone number help',
-  },
-};

--- a/src/components/New/InlineSelect/InlineSelect.stories.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   InlineSelect,
   InlineSelectTrigger,
-  type InlineSelectProps,
   type InlineSelectTriggerProps,
 } from './InlineSelect';
 

--- a/src/components/New/InlineSelect/InlineSelect.stories.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.stories.tsx
@@ -35,24 +35,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Hover: Story = {
-  parameters: { pseudo: { hover: true } },
-};
-
-export const Active: Story = {
-  parameters: { pseudo: { active: true } },
-};
-
-export const Focus: Story = {
-  parameters: { pseudo: { focusVisible: true } },
-};
-
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-  },
-};
-
 export const LongLabel: Story = {
   args: {
     label: 'A very long option label that may overflow',
@@ -76,9 +58,3 @@ export const WithDropdown: Story = {
     },
   },
 };
-
-export const WithDropdownDisabled: Story = {
-  render: () => <InlineSelect items={selectItems} disabled />,
-};
-
-export type { InlineSelectProps };

--- a/src/components/New/Input/Input.spec.tsx
+++ b/src/components/New/Input/Input.spec.tsx
@@ -50,6 +50,20 @@ describe('Dial UI Kit :: DialInput', () => {
     expect(container.textContent).toContain('A');
   });
 
+  test('renders the content slot inside the field, before the input', () => {
+    render(
+      <Input id="slot-input" placeholder="With slot">
+        <span>tag</span>
+      </Input>,
+    );
+
+    const field = screen.getByLabelText('input-container');
+    expect(screen.getByText('tag')).toBeInTheDocument();
+    expect(field.firstElementChild).toHaveTextContent('tag');
+    // The slot must not be forwarded to the void `<input>` element.
+    expect(screen.getByPlaceholderText('With slot')).toBeEmptyDOMElement();
+  });
+
   test('calls onChange when input changes', () => {
     const handleChange = vi.fn();
     const { getByPlaceholderText } = render(

--- a/src/components/New/Input/Input.stories.tsx
+++ b/src/components/New/Input/Input.stories.tsx
@@ -67,49 +67,11 @@ export const Filled: Story = {
   },
 };
 
-export const IconBefore: Story = {
-  args: {
-    placeholder: 'Search...',
-    iconBefore: <IconSearch size={DIAL_ICON_SIZE.MD} />,
-  },
-};
-
-export const IconAfter: Story = {
-  args: {
-    placeholder: 'Password',
-    type: 'password',
-    iconAfter: <IconEye size={DIAL_ICON_SIZE.MD} />,
-  },
-};
-
-export const BothIcons: Story = {
-  args: {
-    placeholder: 'Search...',
-    iconBefore: <IconSearch size={DIAL_ICON_SIZE.MD} />,
-    iconAfter: <IconEye size={DIAL_ICON_SIZE.MD} />,
-  },
-};
-
 export const Small: Story = {
   args: {
     placeholder: 'Search...',
     size: ElementSize.Small,
     iconBefore: <IconSearch size={DIAL_ICON_SIZE.SM} />,
-  },
-};
-
-export const Disabled: Story = {
-  args: {
-    placeholder: 'Disable input',
-    disabled: true,
-  },
-};
-
-export const Invalid: Story = {
-  args: {
-    placeholder: 'Invalid input',
-    value: 'Invalid value',
-    invalid: true,
   },
 };
 

--- a/src/components/New/Input/Input.tsx
+++ b/src/components/New/Input/Input.tsx
@@ -40,6 +40,15 @@ export interface InputProps extends Omit<
   iconBefore?: ReactNode;
   iconAfter?: ReactNode;
 
+  /**
+   * Content rendered inside the field, between `iconBefore` and the input, for
+   * values a plain `<input>` cannot hold — the tags of a multi-select, a value
+   * with its own markup. When the slot stands in for the value, give the input
+   * itself a zero width through `className` so it keeps taking focus without
+   * competing for space.
+   */
+  children?: ReactNode;
+
   prefix?: string;
   postfix?: string;
 
@@ -70,6 +79,7 @@ export interface InputProps extends Omit<
  * @param [invalid] - Whether the input has validation errors (applies error styling)
  * @param [iconAfter] - Icon or element to display after the input
  * @param [iconBefore] - Icon or element to display before the input
+ * @param [children] - Content rendered inside the field before the input, for values a plain `<input>` cannot hold (e.g. multi-select tags)
  * @param [textBeforeInput] - Text to display before the input
  * @param [suffix] - Text to display inside the input on the right
  * @param [containerClassName] - Additional CSS classes to apply to the container div
@@ -119,6 +129,7 @@ const InputWrapper: FC<InputWrapperProps> = ({
   prefix,
   className,
   postfix,
+  children,
   iconBefore,
   iconAfter,
   wrapperClassName,
@@ -213,6 +224,8 @@ const InputWrapper: FC<InputWrapperProps> = ({
         )}
 
         <DialIcon icon={iconBefore} />
+
+        {children}
 
         <input
           ref={ref}

--- a/src/components/New/NumberInput/NumberInput.spec.tsx
+++ b/src/components/New/NumberInput/NumberInput.spec.tsx
@@ -1,0 +1,346 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ElementSize } from '@/types/size';
+import { NumberInput } from './NumberInput';
+
+describe('Dial UI Kit :: NumberInput', () => {
+  test('renders the field through the 2.0 Input', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        size={ElementSize.Small}
+        invalid
+      />,
+    );
+
+    const wrapper = screen.getByLabelText('input-container');
+    expect(wrapper).toHaveClass('dial-kit-input', 'dial-kit-input-small');
+    expect(wrapper).toHaveClass('dial-kit-input-error');
+    expect(screen.getByRole('spinbutton')).toHaveAccessibleName(
+      'Test Number Field',
+    );
+  });
+
+  test('keeps the numeric key guard when a custom onKeyDown is passed', async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <NumberInput
+        id="test-number"
+        placeholder="num"
+        onKeyDown={onKeyDown}
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    await user.click(input);
+    await user.keyboard('a');
+
+    // The consumer's handler still sees the key, but the guard blocked it.
+    expect(onKeyDown).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('renders with basic props', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        placeholder="Enter number"
+        value={42.5}
+      />,
+    );
+
+    expect(screen.getByText(/test number field/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter number')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('42.5')).toBeInTheDocument();
+  });
+
+  test('renders with value', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        value={42.5}
+      />,
+    );
+
+    expect(screen.getByText(/test number field/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('42.5')).toBeInTheDocument();
+  });
+
+  test('shows required indicator when required is true', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field', required: true }}
+      />,
+    );
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  test('displays error text when provided', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        error="This field is required"
+      />,
+    );
+
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  test('calls onChange with processed number value', () => {
+    const onChange = vi.fn();
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '123.45' } });
+
+    expect(onChange).toHaveBeenCalledWith(123.45);
+  });
+
+  test('applies min and max attributes correctly', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        min={0}
+        max={100}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('min', '0');
+    expect(input).toHaveAttribute('max', '100');
+  });
+
+  test('applies only min attribute when max is not provided', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        min={10}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('min', '10');
+    expect(input).not.toHaveAttribute('max');
+  });
+
+  test('does not apply min/max attributes when not provided', () => {
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).not.toHaveAttribute('min');
+    expect(input).not.toHaveAttribute('max');
+  });
+
+  test('handles decimal values with min and max constraints', () => {
+    const onChange = vi.fn();
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        min={0.1}
+        max={99.9}
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('min', '0.1');
+    expect(input).toHaveAttribute('max', '99.9');
+
+    fireEvent.change(input, { target: { value: '50.5' } });
+    expect(onChange).toHaveBeenCalledWith(50.5);
+  });
+
+  test('handles leading zeros properly with min/max constraints', () => {
+    const onChange = vi.fn();
+    render(
+      <NumberInput
+        id="test-number"
+        labelProps={{ label: 'Test Number Field' }}
+        min={0}
+        max={1}
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '0.005' } });
+
+    expect(onChange).toHaveBeenCalledWith('0.005');
+  });
+
+  describe('integer mode', () => {
+    test('blocks decimal point keystroke', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.keyboard('.');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test('blocks minus sign keystroke', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.keyboard('-');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test('blocks e, E, and + keys', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.keyboard('e');
+      await user.keyboard('E');
+      await user.keyboard('+');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test('allows digit keys', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.keyboard('5');
+
+      expect(onChange).toHaveBeenCalledWith(5);
+    });
+
+    test('onChange emits number, not string', () => {
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      fireEvent.change(input, { target: { value: '42' } });
+
+      expect(onChange).toHaveBeenCalledWith(42);
+      expect(typeof onChange.mock.calls[0][0]).toBe('number');
+    });
+
+    test('strips non-digit characters on paste', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.paste('12.34');
+
+      expect(onChange).toHaveBeenCalledWith(1234);
+    });
+
+    test('does not intercept paste when text is all digits', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput
+          id="int-test"
+          placeholder="int"
+          integer
+          onChange={onChange}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.paste('1234');
+
+      expect(onChange).toHaveBeenCalledWith(1234);
+    });
+
+    test('without integer prop, decimal input still works', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <NumberInput id="test-number" placeholder="num" onChange={onChange} />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.paste('1.5');
+
+      expect(onChange).toHaveBeenCalledOnce();
+      expect(onChange).toHaveBeenCalledWith(1.5);
+    });
+  });
+});

--- a/src/components/New/NumberInput/NumberInput.stories.tsx
+++ b/src/components/New/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,199 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { ElementSize } from '@/types/size';
+import { NumberInput, type NumberInputProps } from './NumberInput';
+
+const InteractiveNumberInput = (args: NumberInputProps) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <div className="max-w-80 text-primary">
+      <NumberInput
+        {...args}
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Components_2_0/NumberInput',
+  component: NumberInput,
+  tags: ['input'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A number field built on the 2.0 `Input`, with special handling for leading zeros and decimal values.',
+      },
+    },
+  },
+  // `type` is owned by the component, so the shared input argTypes are not
+  // spread in here — they would offer controls that do nothing.
+  argTypes: {
+    placeholder: { control: { type: 'text' } },
+    disabled: { control: { type: 'boolean' } },
+    invalid: { control: { type: 'boolean' } },
+    error: { control: { type: 'text' } },
+    caption: { control: { type: 'text' } },
+    size: {
+      control: { type: 'inline-radio' },
+      options: [ElementSize.Standard, ElementSize.Small],
+      description: 'Field height: standard is 40px, small is 24px',
+    },
+    min: { control: { type: 'number' } },
+    max: { control: { type: 'number' } },
+    integer: {
+      control: { type: 'boolean' },
+      description: 'Restrict input to integer values only',
+    },
+    onChange: { control: false },
+  },
+  args: {
+    labelProps: { label: 'Number Input' },
+    id: 'number-input',
+    required: false,
+    placeholder: 'Enter a number',
+    value: undefined,
+    disabled: false,
+    invalid: false,
+    integer: false,
+    error: undefined,
+    min: undefined,
+    max: undefined,
+  },
+  render: InteractiveNumberInput,
+} satisfies Meta<NumberInputProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    labelProps: { label: 'Age' },
+    id: 'age-input',
+    placeholder: 'Enter your age',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    labelProps: { label: 'Price' },
+    id: 'price-input',
+    placeholder: 'Enter your price',
+    value: 29.99,
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    labelProps: { label: 'Budget' },
+    id: 'budget-input',
+    placeholder: 'Enter budget amount',
+    value: -100,
+    invalid: true,
+    error: 'Budget must be a positive number',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    labelProps: { label: 'System Generated ID' },
+    id: 'id-input',
+    value: 12345,
+    disabled: true,
+  },
+};
+
+export const DecimalHandling: Story = {
+  args: {
+    labelProps: { label: 'Precision Value' },
+    id: 'precision-input',
+    placeholder: 'Enter decimal value',
+    value: 0.005,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates how the component handles decimal values with leading zeros.',
+      },
+    },
+  },
+};
+
+export const MinAndMaxValues: Story = {
+  args: {
+    labelProps: { label: 'Age' },
+    id: 'age-input',
+    placeholder: 'Enter your age (18-120)',
+    min: 18,
+    max: 120,
+    value: 25,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates a number input with minimum and maximum value constraints.',
+      },
+    },
+  },
+};
+
+export const MinValue: Story = {
+  args: {
+    labelProps: { label: 'Temperature' },
+    id: 'temp-input',
+    placeholder: 'Enter temperature (min: -273.15°C)',
+    min: -273.15,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates a number input with only a minimum value constraint.',
+      },
+    },
+  },
+};
+
+export const MaxValue: Story = {
+  args: {
+    labelProps: { label: 'Percentage' },
+    id: 'percentage-input',
+    placeholder: 'Enter percentage (max: 100%)',
+    max: 100,
+    value: 85,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates a number input with only a maximum value constraint.',
+      },
+    },
+  },
+};
+
+export const Integer: Story = {
+  args: {
+    labelProps: { label: 'Port Number' },
+    id: 'port-input',
+    placeholder: 'Enter port number',
+    integer: true,
+    min: 0,
+    max: 65535,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Integer-only input mode. Decimal points, minus signs, plus signs, and scientific notation (e/E) are blocked. Pasted text is sanitized to digits only.',
+      },
+    },
+  },
+};

--- a/src/components/New/NumberInput/NumberInput.tsx
+++ b/src/components/New/NumberInput/NumberInput.tsx
@@ -1,0 +1,119 @@
+import type { ClipboardEvent, FC, KeyboardEvent } from 'react';
+
+import { Input, type InputProps } from '@/components/New/Input/Input';
+import { handleKeyDown } from '@/components/New/Input/utils';
+
+const lessThanOnePattern = /^0+\.(\d+)?$/;
+const leadingZerosPattern = /^0+/;
+const integerBlockedKeys = ['.', '-', '+', 'e', 'E'];
+
+/**
+ * Normalizes a raw field value: decimals below one keep their string form so a
+ * trailing digit can still be typed ("0.00" would otherwise collapse to 0),
+ * everything else becomes a number.
+ */
+const toNumberValue = (
+  inputValue?: string | number,
+): string | number | undefined => {
+  if (!inputValue || inputValue === '-') {
+    return inputValue;
+  }
+
+  return String(inputValue).match(lessThanOnePattern)
+    ? String(inputValue).replace(leadingZerosPattern, '0')
+    : Number(inputValue);
+};
+
+export interface NumberInputProps extends Omit<
+  InputProps,
+  'onChange' | 'type'
+> {
+  /** When true, restricts input to integer values only — blocks decimal points, minus, plus, and scientific notation (e/E) */
+  integer?: boolean;
+  onChange?: (value?: number | string) => void;
+}
+
+/**
+ * A number field, built on {@link Input}.
+ * aliases: NumericField|NumberField
+ *
+ * `type` is owned by this component; every other {@link Input} prop is passed
+ * through, so it shares the 2.0 field styling, sizes, label, caption and error
+ * states.
+ *
+ * @example
+ * ```tsx
+ * <NumberInput
+ *   id="age"
+ *   placeholder="Enter your age"
+ *   value={25}
+ *   onChange={(value) => setAge(value)}
+ * />
+ * ```
+ *
+ * @param [integer] - When true, restricts input to integer values only — blocks decimal points, minus, plus, and scientific notation (e/E)
+ * @param [min] - Minimum allowed value
+ * @param [max] - Maximum allowed value
+ * @param [size=ElementSize.Standard] - Field height: standard is 40px, small is 24px
+ * @param [onKeyDown] - Called after the numeric key guard has run, unless the key was blocked
+ * @param [onPaste] - Called after pasted text has been sanitized in `integer` mode
+ * @param onChange - Callback function called when the input value changes.
+ *                        Returns either a number (for most values) or a string (for decimal values < 1 with leading zeros)
+ */
+export const NumberInput: FC<NumberInputProps> = ({
+  integer,
+  onChange,
+  min,
+  max,
+  onKeyDown,
+  onPaste,
+  ...props
+}) => {
+  // `Input` guards numeric keystrokes through its own `onKeyDown`, which this
+  // component has to replace — so the guard is re-applied here. Chaining the
+  // consumer's handler after it keeps a custom `onKeyDown` from silently
+  // disabling the guard.
+  const handleNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (integer && integerBlockedKeys.includes(e.key)) {
+      e.preventDefault();
+      return;
+    }
+
+    handleKeyDown(e, 'number', min, max);
+    onKeyDown?.(e);
+  };
+
+  const handleNumberPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    if (integer) {
+      const pastedText = e.clipboardData.getData('text');
+      const digitsOnly = pastedText.replace(/\D/g, '');
+
+      if (digitsOnly !== pastedText) {
+        e.preventDefault();
+
+        if (digitsOnly) {
+          const input = e.currentTarget;
+          const start = input.selectionStart ?? 0;
+          const end = input.selectionEnd ?? 0;
+          const newValue =
+            input.value.slice(0, start) + digitsOnly + input.value.slice(end);
+          onChange?.(toNumberValue(newValue));
+        }
+      }
+    }
+
+    onPaste?.(e);
+  };
+
+  return (
+    <Input
+      {...props}
+      type="number"
+      min={min}
+      max={max}
+      onChange={(inputValue) => onChange?.(toNumberValue(inputValue))}
+      onKeyDown={handleNumberKeyDown}
+      onPaste={handleNumberPaste}
+    />
+  );
+};

--- a/src/components/New/PasswordInput/PasswordInput.spec.tsx
+++ b/src/components/New/PasswordInput/PasswordInput.spec.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ElementSize } from '@/types/size';
+import { PasswordInput } from './PasswordInput';
+
+const getField = () => screen.getByLabelText('Password');
+
+describe('Dial UI Kit :: PasswordInput', () => {
+  test('renders the label, caption and error of the underlying Input', () => {
+    const { rerender } = render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        caption="At least 12 characters"
+      />,
+    );
+
+    expect(getField()).toBeInTheDocument();
+    expect(screen.getByText('At least 12 characters')).toBeInTheDocument();
+
+    rerender(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        caption="At least 12 characters"
+        error="Password is required"
+      />,
+    );
+
+    expect(screen.getByText('Password is required')).toBeInTheDocument();
+    expect(
+      screen.queryByText('At least 12 characters'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('masks the value until the toggle is pressed', async () => {
+    const user = userEvent.setup();
+    render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        value="secret"
+      />,
+    );
+
+    expect(getField()).toHaveAttribute('type', 'password');
+
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(toggle);
+
+    expect(getField()).toHaveAttribute('type', 'text');
+    const pressedToggle = screen.getByRole('button', {
+      name: 'Hide password',
+    });
+    expect(pressedToggle).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(pressedToggle);
+    expect(getField()).toHaveAttribute('type', 'password');
+  });
+
+  test('the toggle is reachable and operable by keyboard', async () => {
+    const user = userEvent.setup();
+    render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        value="secret"
+      />,
+    );
+
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Show password' })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(getField()).toHaveAttribute('type', 'text');
+  });
+
+  test('accepts custom toggle labels', async () => {
+    const user = userEvent.setup();
+    render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        showPasswordLabel="Passwort anzeigen"
+        hidePasswordLabel="Passwort verbergen"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Passwort anzeigen' }));
+    expect(
+      screen.getByRole('button', { name: 'Passwort verbergen' }),
+    ).toBeInTheDocument();
+  });
+
+  test('a disabled field stays masked and its toggle is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        value="secret"
+        disabled
+      />,
+    );
+
+    const toggle = screen.getByRole('button', { name: 'Show password' });
+    expect(toggle).toBeDisabled();
+
+    await user.click(toggle);
+    expect(getField()).toHaveAttribute('type', 'password');
+    // The value must not leak through the tooltip `Input` adds to disabled fields.
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+  });
+
+  test('reports changes through the Input onChange signature', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    const Controlled = () => {
+      const [value, setValue] = useState('');
+      return (
+        <PasswordInput
+          id="pw"
+          labelProps={{ label: 'Password' }}
+          value={value}
+          onChange={(next) => {
+            setValue(next ?? '');
+            onChange(next);
+          }}
+        />
+      );
+    };
+
+    render(<Controlled />);
+    await user.type(getField(), 'ab');
+
+    expect(onChange).toHaveBeenLastCalledWith('ab');
+    expect(getField()).toHaveValue('ab');
+  });
+
+  test('passes the size down to the field', () => {
+    render(
+      <PasswordInput
+        id="pw"
+        labelProps={{ label: 'Password' }}
+        size={ElementSize.Small}
+      />,
+    );
+
+    expect(screen.getByLabelText('input-container')).toHaveClass(
+      'dial-kit-input-small',
+    );
+    expect(screen.getByRole('button', { name: 'Show password' })).toHaveClass(
+      'size-[24px]',
+    );
+  });
+});

--- a/src/components/New/PasswordInput/PasswordInput.stories.tsx
+++ b/src/components/New/PasswordInput/PasswordInput.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { ElementSize } from '@/types/size';
+import { PasswordInput, type PasswordInputProps } from './PasswordInput';
+
+const InteractivePasswordInput = (args: PasswordInputProps) => {
+  const [value, setValue] = useState(args.value ?? '');
+
+  return (
+    <PasswordInput
+      {...args}
+      value={value}
+      onChange={(newValue) => setValue(newValue ?? '')}
+    />
+  );
+};
+
+const meta = {
+  title: 'Components_2_0/PasswordInput',
+  component: PasswordInput,
+  tags: ['input'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A password field built on the 2.0 `Input`. The reveal toggle is a real ' +
+          'button, so it can be reached by keyboard and announces its state.',
+      },
+    },
+  },
+  // `type` and `iconAfter` are owned by the component, so the shared input
+  // argTypes are not spread in here — they would offer controls that do nothing.
+  argTypes: {
+    placeholder: { control: { type: 'text' } },
+    disabled: { control: { type: 'boolean' } },
+    invalid: { control: { type: 'boolean' } },
+    error: { control: { type: 'text' } },
+    caption: { control: { type: 'text' } },
+    size: {
+      control: { type: 'inline-radio' },
+      options: [ElementSize.Standard, ElementSize.Small],
+      description: 'Field height: standard is 40px, small is 24px',
+    },
+    showPasswordLabel: { control: { type: 'text' } },
+    hidePasswordLabel: { control: { type: 'text' } },
+    onChange: { control: false },
+  },
+  args: {
+    id: 'story-password',
+    placeholder: 'Placeholder',
+    disabled: false,
+    invalid: false,
+    size: ElementSize.Standard,
+  },
+  render: InteractivePasswordInput,
+} satisfies Meta<PasswordInputProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    labelProps: { label: 'Password' },
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    labelProps: { label: 'Password' },
+    value: 'sup3r-s3cret',
+  },
+};
+
+export const WithCaption: Story = {
+  name: 'With caption',
+  args: {
+    labelProps: { label: 'Password' },
+    caption: 'At least 12 characters',
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    labelProps: { label: 'Password', required: true },
+    value: 'short',
+    invalid: true,
+    error: 'Password is too short',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    labelProps: { label: 'Password' },
+    value: 'sup3r-s3cret',
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A disabled field stays masked and its toggle is disabled, so the value ' +
+          'cannot be revealed while the field is out of reach.',
+      },
+    },
+  },
+};
+
+export const Small: Story = {
+  args: {
+    labelProps: { label: 'Password' },
+    value: 'sup3r-s3cret',
+    size: ElementSize.Small,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-y-6">
+      {[ElementSize.Standard, ElementSize.Small].map((size) => (
+        <div key={size} className="flex flex-row items-start gap-x-6">
+          <InteractivePasswordInput
+            id={`${size}-default`}
+            size={size}
+            labelProps={{ label: 'Default' }}
+            placeholder="Placeholder"
+          />
+          <InteractivePasswordInput
+            id={`${size}-filled`}
+            size={size}
+            labelProps={{ label: 'Filled' }}
+            value="sup3r-s3cret"
+          />
+          <InteractivePasswordInput
+            id={`${size}-invalid`}
+            size={size}
+            labelProps={{ label: 'Invalid', required: true }}
+            value="short"
+            invalid
+            error="Password is too short"
+          />
+          <InteractivePasswordInput
+            id={`${size}-disabled`}
+            size={size}
+            labelProps={{ label: 'Disabled' }}
+            value="sup3r-s3cret"
+            disabled
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/New/PasswordInput/PasswordInput.tsx
+++ b/src/components/New/PasswordInput/PasswordInput.tsx
@@ -1,0 +1,80 @@
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import { type FC, useState } from 'react';
+
+import { GhostIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { Input, type InputProps } from '@/components/New/Input/Input';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ElementSize } from '@/types/size';
+
+export interface PasswordInputProps extends Omit<
+  InputProps,
+  'type' | 'iconAfter'
+> {
+  /** Accessible name of the reveal toggle while the value is masked. */
+  showPasswordLabel?: string;
+  /** Accessible name of the reveal toggle while the value is visible. */
+  hidePasswordLabel?: string;
+}
+
+/**
+ * A password field with a reveal toggle, built on {@link Input}.
+ * aliases: SecureInput|ToggleablePassword
+ *
+ * The toggle is a real `<button>`, so it is reachable by keyboard and announces
+ * both its purpose and its state. `type` and `iconAfter` are owned by this
+ * component; every other {@link Input} prop is passed through.
+ *
+ * @example
+ * ```tsx
+ * <PasswordInput
+ *   id="password"
+ *   labelProps={{ label: 'Password', required: true }}
+ *   value={password}
+ *   onChange={setPassword}
+ * />
+ * ```
+ *
+ * @param [showPasswordLabel="Show password"] - Accessible name of the toggle while the value is masked
+ * @param [hidePasswordLabel="Hide password"] - Accessible name of the toggle while the value is visible
+ * @param [size=ElementSize.Standard] - Field height: standard is 40px, small is 24px
+ * @param [disabled=false] - Disables the field and its reveal toggle
+ */
+export const PasswordInput: FC<PasswordInputProps> = ({
+  showPasswordLabel = 'Show password',
+  hidePasswordLabel = 'Hide password',
+  disabled,
+  size = ElementSize.Standard,
+  ...props
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // A disabled field is never revealed: its toggle cannot be reached to mask the
+  // value again, and `Input` exposes the value of a disabled non-password field
+  // through a tooltip, which would leak the password.
+  const isRevealed = isVisible && !disabled;
+
+  return (
+    <Input
+      {...props}
+      size={size}
+      disabled={disabled}
+      type={isRevealed ? 'text' : 'password'}
+      iconAfter={
+        <GhostIconButton
+          size={ElementSize.Small}
+          disabled={disabled}
+          aria-label={isRevealed ? hidePasswordLabel : showPasswordLabel}
+          aria-pressed={isRevealed}
+          icon={
+            isRevealed ? (
+              <IconEyeOff size={DIAL_ICON_SIZE.SM} aria-hidden="true" />
+            ) : (
+              <IconEye size={DIAL_ICON_SIZE.SM} aria-hidden="true" />
+            )
+          }
+          onClick={() => setIsVisible((prev) => !prev)}
+        />
+      }
+    />
+  );
+};

--- a/src/components/New/Popup/Popup.spec.tsx
+++ b/src/components/New/Popup/Popup.spec.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { Popup } from './Popup';
+import { PopupSize } from '@/types/popup';
+import { popupSizeClassMap } from './constants';
+
+describe('Dial UI Kit :: Popup', () => {
+  test('does not render when closed', () => {
+    const { queryByRole } = render(<Popup open={false} />);
+    expect(queryByRole('dialog')).toBeNull();
+  });
+
+  test('renders title and body when open', () => {
+    render(
+      <Popup open header="Title">
+        <div>Body content</div>
+      </Popup>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  test('renders footer', () => {
+    render(
+      <Popup open header="With footer" footer={<div>Footer here</div>}>
+        <div>Body</div>
+      </Popup>,
+    );
+    expect(screen.getByText('Footer here')).toBeInTheDocument();
+  });
+
+  test('calls onClose when close button clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <Popup open header="Closable" onClose={onClose}>
+        <div>Body</div>
+      </Popup>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders React component as title (non-string path) and omits aria-labelledby', () => {
+    render(
+      <Popup
+        open
+        header={
+          <span>
+            <strong>Node title</strong>
+          </span>
+        }
+      >
+        <div>Body</div>
+      </Popup>,
+    );
+
+    expect(screen.getByText('Node title')).toBeInTheDocument();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('names the dialog from a string header', () => {
+    render(
+      <Popup open header="Title">
+        <div>Body</div>
+      </Popup>,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Title' })).toBeInTheDocument();
+  });
+
+  test('names the dialog from ariaLabel when the header is a node', () => {
+    render(
+      <Popup open header={<strong>Node title</strong>} ariaLabel="Move items">
+        <div>Body</div>
+      </Popup>,
+    );
+
+    expect(
+      screen.getByRole('dialog', { name: 'Move items' }),
+    ).toBeInTheDocument();
+  });
+
+  test('a string header wins over ariaLabel, so the visible title is announced', () => {
+    render(
+      <Popup open header="Title" ariaLabel="Ignored">
+        <div>Body</div>
+      </Popup>,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Title' });
+    expect(dialog).not.toHaveAttribute('aria-label');
+  });
+
+  test('gives each open popup its own heading id', () => {
+    render(
+      <>
+        <Popup open header="First">
+          <div>Body</div>
+        </Popup>
+        <Popup open header="Second">
+          <div>Body</div>
+        </Popup>
+      </>,
+    );
+
+    // Queried by attribute rather than by role: each modal focus manager
+    // aria-hides the other dialog, so a role query would not see both.
+    const dialogs = Array.from(document.querySelectorAll('[role="dialog"]'));
+    expect(dialogs).toHaveLength(2);
+
+    const headingIds = dialogs.map((dialog) =>
+      dialog.getAttribute('aria-labelledby'),
+    );
+    expect(new Set(headingIds).size).toBe(2);
+    headingIds.forEach((headingId) =>
+      expect(document.getElementById(headingId!)).toBeInTheDocument(),
+    );
+  });
+
+  test('applies size class correctly', () => {
+    render(
+      <Popup open header="Size Test" size={PopupSize.Lg}>
+        <div>Body</div>
+      </Popup>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass(popupSizeClassMap[PopupSize.Lg]);
+  });
+
+  test('applies headerClassName to the popup header', () => {
+    render(
+      <Popup
+        open
+        header="Header class test"
+        headerClassName="custom-header-class"
+      >
+        <div>Body</div>
+      </Popup>,
+    );
+
+    const header = screen
+      .getByRole('button', { name: 'Close dialog' })
+      .closest('div');
+
+    expect(header).toHaveClass('custom-header-class');
+  });
+
+  test('does not close on outside click when closeOnOutsideClick is false', () => {
+    const onClose = vi.fn();
+
+    render(
+      <Popup
+        open
+        header="Outside click disabled"
+        onClose={onClose}
+        closeOnOutsideClick={false}
+      >
+        <div>Body</div>
+      </Popup>,
+    );
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('does not render close button when hideClose is true', () => {
+    render(
+      <Popup open header="No Close" hideClose>
+        <div>Body</div>
+      </Popup>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Close dialog' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/New/Popup/Popup.stories.tsx
+++ b/src/components/New/Popup/Popup.stories.tsx
@@ -19,13 +19,12 @@ const meta = {
     className: { control: { type: 'text' } },
     overlayClassName: { control: { type: 'text' } },
     titleClassName: { control: { type: 'text' } },
-    dividers: { control: { type: 'boolean' } },
+    ariaLabel: { control: { type: 'text' } },
     footer: { control: { type: 'text' } },
     onClose: { action: 'onClose', control: false },
   },
   args: {
     header: 'Title',
-    dividers: true,
     children: <div className="px-6 py-4 min-h-[220px]">Body area</div>,
     footer: (
       <div className="px-6 py-4 flex justify-end gap-2">
@@ -66,11 +65,6 @@ export const Default: Story = { render: StatefulRender };
 export const WithoutFooter: Story = {
   render: StatefulRender,
   args: { footer: undefined },
-};
-
-export const WithoutDividers: Story = {
-  render: StatefulRender,
-  args: { dividers: false },
 };
 
 export const WithoutTitle: Story = {
@@ -128,8 +122,8 @@ export const WithoutHeaderAndDismiss: Story = {
   args: {
     className: '!w-[280px]',
     header: undefined,
+    ariaLabel: 'Moving items',
     footer: undefined,
-    dividers: false,
     headerClassName: 'hidden',
     hideClose: true,
     children: (

--- a/src/components/New/Popup/Popup.stories.tsx
+++ b/src/components/New/Popup/Popup.stories.tsx
@@ -1,0 +1,155 @@
+import {
+  NeutralButton,
+  PrimaryButton,
+} from '@/components/New/Button/ButtonWrappers';
+import { DialLoader } from '@/components/Loader/Loader';
+import { ButtonAppearance } from '@/types/button';
+import { PopupSize } from '@/types/popup';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Popup, type PopupProps } from './Popup';
+
+const meta = {
+  title: 'Components_2_0/Popup',
+  component: Popup,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    open: { control: false },
+    header: { control: { type: 'text' } },
+    className: { control: { type: 'text' } },
+    overlayClassName: { control: { type: 'text' } },
+    titleClassName: { control: { type: 'text' } },
+    dividers: { control: { type: 'boolean' } },
+    footer: { control: { type: 'text' } },
+    onClose: { action: 'onClose', control: false },
+  },
+  args: {
+    header: 'Title',
+    dividers: true,
+    children: <div className="px-6 py-4 min-h-[220px]">Body area</div>,
+    footer: (
+      <div className="px-6 py-4 flex justify-end gap-2">
+        <NeutralButton label="Button label" />
+        <PrimaryButton label="Button label" />
+      </div>
+    ),
+  },
+} satisfies Meta<PopupProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Reusable stateful renderer that opens the popup via a button click
+const StatefulRender = (args: PopupProps & { buttonLabel?: string }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <PrimaryButton
+        label={args.buttonLabel || 'Open Popup'}
+        onClick={() => setOpen(true)}
+      />
+
+      <Popup
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          args.onClose?.(null);
+        }}
+      />
+    </>
+  );
+};
+
+export const Default: Story = { render: StatefulRender };
+
+export const WithoutFooter: Story = {
+  render: StatefulRender,
+  args: { footer: undefined },
+};
+
+export const WithoutDividers: Story = {
+  render: StatefulRender,
+  args: { dividers: false },
+};
+
+export const WithoutTitle: Story = {
+  render: StatefulRender,
+  args: { header: undefined },
+};
+
+export const WithLongTitle: Story = {
+  render: StatefulRender,
+  args: {
+    header:
+      'This is a very long title that should wrap onto multiple lines to demonstrate text wrapping behavior in the popup header. It might even be long enough to require truncation with an ellipsis if it exceeds a certain length',
+  },
+};
+
+export const CustomClasses: Story = {
+  render: StatefulRender,
+  args: {
+    className: 'ring-2 ring-offset-2 ring-sky-400 !bg-accent-secondary',
+    titleClassName: 'font-medium bg-red-400',
+  },
+};
+
+export const DifferentSizes: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      <div>
+        <StatefulRender
+          {...args}
+          size={PopupSize.Sm}
+          buttonLabel="Open Small Popup"
+        />
+      </div>
+      <div>
+        <StatefulRender
+          {...args}
+          size={PopupSize.Md}
+          buttonLabel="Open Medium Popup"
+        />
+      </div>
+      <div>
+        <StatefulRender
+          {...args}
+          size={PopupSize.Lg}
+          buttonLabel="Open Large Popup"
+        />
+      </div>
+    </div>
+  ),
+  args: {},
+};
+
+export const WithoutHeaderAndDismiss: Story = {
+  render: StatefulRender,
+  args: {
+    className: '!w-[280px]',
+    header: undefined,
+    footer: undefined,
+    dividers: false,
+    headerClassName: 'hidden',
+    hideClose: true,
+    children: (
+      <div className="flex items-center flex-col gap-6 p-9">
+        <DialLoader size={120} />
+        <div className="flex flex-col gap-2 text-center text-primary">
+          <div className="text-lg font-semibold">Moving items</div>
+          <div className="text-sm">8 of 24 items moved...</div>
+        </div>
+        <PrimaryButton
+          className="w-fit"
+          appearance={ButtonAppearance.Ghost}
+          label="Cancel"
+        />
+      </div>
+    ),
+  },
+};
+
+export const WithoutCloseButton: Story = {
+  render: StatefulRender,
+  args: { hideClose: true },
+};

--- a/src/components/New/Popup/Popup.tsx
+++ b/src/components/New/Popup/Popup.tsx
@@ -7,18 +7,15 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react';
-import { IconX } from '@tabler/icons-react';
 import classNames from 'classnames';
 import { type FC, type MouseEvent, type ReactNode, useId, useRef } from 'react';
 
-import { GhostIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { CloseButton } from '@/components/New/CloseButton/CloseButton';
 import { DialTooltip } from '@/components/Tooltip/Tooltip';
-import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { PopupSize } from '@/types/popup';
 import { mergeClasses } from '@/utils/merge-classes';
 import {
   popupBaseClassName,
-  popupDividerClassName,
   popupHeaderClassName,
   popupOverlayBaseClassName,
   popupSizeClassMap,
@@ -34,9 +31,6 @@ export interface PopupProps {
   overlayClassName?: string;
   titleClassName?: string;
   headerClassName?: string;
-  // TODO: review after implementing common design system
-  dividers?: boolean;
-  dividerFooter?: boolean;
   children?: ReactNode;
   footer?: ReactNode;
   onClose?: (e?: MouseEvent<HTMLButtonElement> | null) => void;
@@ -52,7 +46,9 @@ export interface PopupProps {
  * aliases: Modal|Dialog
  *
  * Renders in a portal with a scrim overlay, focus management, a header with the
- * title and close control, a scrollable body and an optional footer.
+ * title and close control, a scrollable body and an optional footer. Sections
+ * are separated by spacing rather than rules; add your own through
+ * `headerClassName` or the footer node if a surface needs them.
  *
  * A string `header` names the dialog automatically. A `header` node cannot —
  * pass `ariaLabel` in that case, or the dialog opens unnamed.
@@ -83,8 +79,6 @@ export interface PopupProps {
  * @param [overlayClassName] - Additional CSS classes applied to the overlay
  * @param [titleClassName] - Additional CSS classes applied to the title element
  * @param [headerClassName] - Additional CSS classes applied to the popup header container
- * @param [dividers=true] - Whether to render separators between sections
- * @param [dividerFooter=true] - Whether to render a divider above the footer when `dividers` is true
  * @param [children] - Body content
  * @param [footer] - Footer area for actions
  * @param [onClose] - Callback fired when the popup requests to close
@@ -103,8 +97,6 @@ export const Popup: FC<PopupProps> = ({
   overlayClassName,
   titleClassName,
   headerClassName,
-  dividers = true,
-  dividerFooter = true,
   children,
   footer,
   onClose,
@@ -138,12 +130,12 @@ export const Popup: FC<PopupProps> = ({
     if (!title) return <span /* empty element to balance the close button */ />;
 
     return typeof title === 'string' ? (
-      <h3
+      <h2
         id={headingId}
         className={mergeClasses(popupTitleClassName, titleClassName)}
       >
         <DialTooltip tooltip={title}>{title}</DialTooltip>
-      </h3>
+      </h2>
     ) : (
       title
     );
@@ -168,7 +160,6 @@ export const Popup: FC<PopupProps> = ({
             className={mergeClasses(
               popupBaseClassName,
               popupSizeClassMap[size],
-              dividers && popupDividerClassName,
               className,
             )}
           >
@@ -185,19 +176,15 @@ export const Popup: FC<PopupProps> = ({
             >
               {renderTitle(header)}
               {!hideClose && (
-                <GhostIconButton
-                  aria-label={closeAriaLabel}
-                  icon={<IconX size={DIAL_ICON_SIZE.MD} aria-hidden="true" />}
-                  onClick={(e) => onClose?.(e)}
+                <CloseButton
+                  ariaLabel={closeAriaLabel}
+                  onClose={(e) => onClose?.(e)}
                 />
               )}
             </div>
 
             <div className="grow overflow-auto">{children}</div>
 
-            {dividerFooter && !footer && (
-              <div className={popupDividerClassName} />
-            )}
             {footer}
           </div>
         </FloatingFocusManager>

--- a/src/components/New/Popup/Popup.tsx
+++ b/src/components/New/Popup/Popup.tsx
@@ -1,0 +1,207 @@
+import {
+  FloatingFocusManager,
+  FloatingOverlay,
+  FloatingPortal,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import { IconX } from '@tabler/icons-react';
+import classNames from 'classnames';
+import { type FC, type MouseEvent, type ReactNode, useId, useRef } from 'react';
+
+import { GhostIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { PopupSize } from '@/types/popup';
+import { mergeClasses } from '@/utils/merge-classes';
+import {
+  popupBaseClassName,
+  popupDividerClassName,
+  popupHeaderClassName,
+  popupOverlayBaseClassName,
+  popupSizeClassMap,
+  popupTitleClassName,
+} from './constants';
+
+export interface PopupProps {
+  open?: boolean;
+  header?: ReactNode;
+  ariaLabel?: string;
+  portalId?: string;
+  className?: string;
+  overlayClassName?: string;
+  titleClassName?: string;
+  headerClassName?: string;
+  // TODO: review after implementing common design system
+  dividers?: boolean;
+  dividerFooter?: boolean;
+  children?: ReactNode;
+  footer?: ReactNode;
+  onClose?: (e?: MouseEvent<HTMLButtonElement> | null) => void;
+  size?: PopupSize;
+  hideClose?: boolean;
+  closeAriaLabel?: string;
+  closeOnOutsideClick?: boolean;
+  preventKeyboardOnOpen?: boolean;
+}
+
+/**
+ * An accessible modal dialog using Floating UI.
+ * aliases: Modal|Dialog
+ *
+ * Renders in a portal with a scrim overlay, focus management, a header with the
+ * title and close control, a scrollable body and an optional footer.
+ *
+ * A string `header` names the dialog automatically. A `header` node cannot —
+ * pass `ariaLabel` in that case, or the dialog opens unnamed.
+ *
+ * @example
+ * ```tsx
+ * <Popup
+ *   open
+ *   header="Title"
+ *   size={PopupSize.Md}
+ *   footer={
+ *     <div className="flex justify-end gap-2 px-6 py-4">
+ *       <NeutralButton label="Cancel" />
+ *       <PrimaryButton label="Confirm" />
+ *     </div>
+ *   }
+ *   onClose={() => setOpen(false)}
+ * >
+ *   <div className="px-6 py-4">Dialog content goes here…</div>
+ * </Popup>
+ * ```
+ *
+ * @param [open=false] - Controls visibility of the popup
+ * @param [header] - Optional title rendered in the header
+ * @param [ariaLabel] - Accessible name for the dialog; needed when `header` is not a string
+ * @param [portalId] - Optional portal container id
+ * @param [className] - Additional CSS classes applied to the popup container
+ * @param [overlayClassName] - Additional CSS classes applied to the overlay
+ * @param [titleClassName] - Additional CSS classes applied to the title element
+ * @param [headerClassName] - Additional CSS classes applied to the popup header container
+ * @param [dividers=true] - Whether to render separators between sections
+ * @param [dividerFooter=true] - Whether to render a divider above the footer when `dividers` is true
+ * @param [children] - Body content
+ * @param [footer] - Footer area for actions
+ * @param [onClose] - Callback fired when the popup requests to close
+ * @param [size=PopupSize.Md] - Sets the max-width of the popup
+ * @param [hideClose=false] - Whether the close button is hidden in the header
+ * @param [closeAriaLabel="Close dialog"] - Accessible name of the close button
+ * @param [closeOnOutsideClick=true] - Whether the popup closes when clicking outside
+ * @param [preventKeyboardOnOpen=false] - When true, initial focus goes to a non-input guard to avoid opening the virtual keyboard on mobile
+ */
+export const Popup: FC<PopupProps> = ({
+  open = false,
+  header,
+  ariaLabel,
+  portalId,
+  className,
+  overlayClassName,
+  titleClassName,
+  headerClassName,
+  dividers = true,
+  dividerFooter = true,
+  children,
+  footer,
+  onClose,
+  size = PopupSize.Md,
+  hideClose = false,
+  closeAriaLabel = 'Close dialog',
+  closeOnOutsideClick = true,
+  preventKeyboardOnOpen = false,
+}) => {
+  const focusGuardRef = useRef<HTMLDivElement>(null);
+  // Generated rather than fixed: two popups mounted at once would otherwise
+  // share one heading id, and each dialog would be named by the first title.
+  const generatedId = useId();
+  const { refs, context } = useFloating({
+    open,
+    onOpenChange: (next) => {
+      if (!next) onClose?.(null);
+    },
+  });
+
+  const role = useRole(context, { role: 'dialog' });
+  const dismiss = useDismiss(context, { outsidePress: closeOnOutsideClick });
+  const { getFloatingProps } = useInteractions([role, dismiss]);
+
+  if (!open) return null;
+
+  const headingId =
+    typeof header === 'string' ? `popup-heading-${generatedId}` : undefined;
+
+  const renderTitle = (title?: ReactNode) => {
+    if (!title) return <span /* empty element to balance the close button */ />;
+
+    return typeof title === 'string' ? (
+      <h3
+        id={headingId}
+        className={mergeClasses(popupTitleClassName, titleClassName)}
+      >
+        <DialTooltip tooltip={title}>{title}</DialTooltip>
+      </h3>
+    ) : (
+      title
+    );
+  };
+
+  return (
+    <FloatingPortal id={portalId}>
+      <FloatingOverlay
+        className={classNames(popupOverlayBaseClassName, overlayClassName)}
+      >
+        <FloatingFocusManager
+          context={context}
+          initialFocus={preventKeyboardOnOpen ? focusGuardRef : undefined}
+        >
+          <div
+            ref={refs.setFloating}
+            {...getFloatingProps()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={headingId}
+            aria-label={headingId ? undefined : ariaLabel}
+            className={mergeClasses(
+              popupBaseClassName,
+              popupSizeClassMap[size],
+              dividers && popupDividerClassName,
+              className,
+            )}
+          >
+            {preventKeyboardOnOpen && (
+              <div
+                ref={focusGuardRef}
+                tabIndex={-1}
+                aria-hidden
+                className="absolute size-px -m-px overflow-hidden opacity-0 pointer-events-none"
+              />
+            )}
+            <div
+              className={mergeClasses(popupHeaderClassName, headerClassName)}
+            >
+              {renderTitle(header)}
+              {!hideClose && (
+                <GhostIconButton
+                  aria-label={closeAriaLabel}
+                  icon={<IconX size={DIAL_ICON_SIZE.MD} aria-hidden="true" />}
+                  onClick={(e) => onClose?.(e)}
+                />
+              )}
+            </div>
+
+            <div className="grow overflow-auto">{children}</div>
+
+            {dividerFooter && !footer && (
+              <div className={popupDividerClassName} />
+            )}
+            {footer}
+          </div>
+        </FloatingFocusManager>
+      </FloatingOverlay>
+    </FloatingPortal>
+  );
+};

--- a/src/components/New/Popup/constants.ts
+++ b/src/components/New/Popup/constants.ts
@@ -1,18 +1,16 @@
 import { PopupSize } from '@/types/popup';
 
 export const popupOverlayBaseClassName =
-  'z-[52] flex items-center justify-center bg-blackout md:p-4';
+  'z-[52] flex items-center justify-center bg-backdrop md:p-4 gap-5 p-6';
 
 export const popupBaseClassName =
-  'relative flex w-full max-h-full flex-col rounded-xl bg-layer-raised shadow-lg md:h-auto';
-
-export const popupDividerClassName = 'divide-tertiary divide-y';
+  'relative flex w-full max-h-full flex-col rounded-xl bg-layer-raised md:h-auto';
 
 export const popupHeaderClassName =
   'flex flex-row items-center justify-between px-6 py-4';
 
 export const popupTitleClassName =
-  'flex-1 min-w-0 mr-3 truncate dial-h3-text text-primary';
+  'flex-1 min-w-0 mr-3 truncate dial-h2-text text-primary';
 
 /**
  * Max widths per size. Full width below the `md` breakpoint, where the popup

--- a/src/components/New/Popup/constants.ts
+++ b/src/components/New/Popup/constants.ts
@@ -1,0 +1,25 @@
+import { PopupSize } from '@/types/popup';
+
+export const popupOverlayBaseClassName =
+  'z-[52] flex items-center justify-center bg-blackout md:p-4';
+
+export const popupBaseClassName =
+  'relative flex w-full max-h-full flex-col rounded-xl bg-layer-raised shadow-lg md:h-auto';
+
+export const popupDividerClassName = 'divide-tertiary divide-y';
+
+export const popupHeaderClassName =
+  'flex flex-row items-center justify-between px-6 py-4';
+
+export const popupTitleClassName =
+  'flex-1 min-w-0 mr-3 truncate dial-h3-text text-primary';
+
+/**
+ * Max widths per size. Full width below the `md` breakpoint, where the popup
+ * fills the screen.
+ */
+export const popupSizeClassMap: Record<PopupSize, string> = {
+  [PopupSize.Sm]: 'max-w-full md:max-w-[400px]',
+  [PopupSize.Md]: 'max-w-full md:max-w-[800px]',
+  [PopupSize.Lg]: 'max-w-full md:max-w-[1200px]',
+};

--- a/src/components/New/Select/MultiSelectTags.tsx
+++ b/src/components/New/Select/MultiSelectTags.tsx
@@ -1,0 +1,46 @@
+import type { FC, MouseEvent } from 'react';
+
+import { DialIcon } from '@/components/Icon/Icon';
+import { DialTag } from '@/components/Tag/Tag';
+import type { SelectOption } from '@/models/select';
+
+export interface MultiSelectTagsProps {
+  options: SelectOption[];
+  selectedValues: string[];
+  handleRemoveTag?: (
+    event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
+    val: string,
+  ) => void;
+}
+
+/**
+ * The selected values of a multi-select, rendered as removable tags inside the
+ * field.
+ *
+ * @param options - All available options, used to resolve labels and icons
+ * @param selectedValues - Values currently selected
+ * @param [handleRemoveTag] - Called with the value whose tag was removed; when omitted the tags are not removable
+ */
+export const MultiSelectTags: FC<MultiSelectTagsProps> = ({
+  options,
+  selectedValues,
+  handleRemoveTag,
+}) => {
+  return (
+    <>
+      {selectedValues.map((v) => {
+        const option = options.find((o) => o.value === v);
+        return (
+          <DialTag
+            key={v}
+            label={option?.label ?? v}
+            closable={!!handleRemoveTag}
+            onRemove={(e) => handleRemoveTag?.(e, v)}
+            icon={option?.icon ? <DialIcon icon={option.icon} /> : null}
+            className="max-w-full"
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/New/Select/Select.spec.tsx
+++ b/src/components/New/Select/Select.spec.tsx
@@ -101,6 +101,23 @@ describe('Dial UI Kit :: Select', () => {
     expect(getField()).toHaveValue('Filter: Option 1');
   });
 
+  test('marks the selected option with a check icon', () => {
+    renderSelect({ defaultValue: 'opt-1' });
+
+    openSelect();
+
+    const selected = screen.getByRole('option', { name: 'Option 1' });
+    expect(selected).toHaveAttribute('aria-selected', 'true');
+    // The icon is decorative, so it is queried structurally rather than by role.
+    expect(selected.querySelector('.tabler-icon-check')).toBeInTheDocument();
+
+    expect(
+      screen
+        .getByRole('option', { name: 'Option 2' })
+        .querySelector('.tabler-icon-check'),
+    ).not.toBeInTheDocument();
+  });
+
   test('disabled option is not selectable in single mode', () => {
     const onChange = vi.fn();
     renderSelect({ onChange });
@@ -412,6 +429,38 @@ describe('Dial UI Kit :: Select', () => {
       openSelect();
       const parentTrigger = screen.getByText('Group').closest('button')!;
       expect(parentTrigger).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('selected child is marked with a check icon', async () => {
+      const user = userEvent.setup();
+      renderSelect({
+        defaultValue: 'g1',
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [
+              { value: 'g1', label: 'G One' },
+              { value: 'g2', label: 'G Two' },
+            ],
+          },
+        ],
+      });
+      openSelect();
+      await user.hover(screen.getByText('Group').closest('button')!);
+
+      const selectedChild = (await screen.findByText('G One')).closest(
+        'button',
+      )!;
+      expect(
+        selectedChild.querySelector('.tabler-icon-check'),
+      ).toBeInTheDocument();
+      expect(
+        screen
+          .getByText('G Two')
+          .closest('button')!
+          .querySelector('.tabler-icon-check'),
+      ).not.toBeInTheDocument();
     });
 
     test('disabled submenu trigger does not open submenu on hover', async () => {

--- a/src/components/New/Select/Select.spec.tsx
+++ b/src/components/New/Select/Select.spec.tsx
@@ -65,6 +65,27 @@ describe('Dial UI Kit :: Select', () => {
     expect(getField()).toHaveAttribute('aria-haspopup', 'listbox');
   });
 
+  test('holds the option list to the field width, and lets listClassName win', () => {
+    const { rerender } = renderSelect();
+
+    openSelect();
+    // The list is the dropdown's floating element — the listbox's parent.
+    const list = screen.getByRole('listbox').parentElement!;
+    expect(list).toHaveClass('!max-w-[var(--reference-width)]');
+
+    rerender(
+      <Select
+        options={baseOptions}
+        ariaLabel="Operator"
+        open
+        listClassName="!max-w-[500px]"
+      />,
+    );
+    const widened = screen.getByRole('listbox').parentElement!;
+    expect(widened).toHaveClass('!max-w-[500px]');
+    expect(widened).not.toHaveClass('!max-w-[var(--reference-width)]');
+  });
+
   test('opens on ArrowDown and Enter', () => {
     renderSelect();
     const field = getField();

--- a/src/components/New/Select/Select.spec.tsx
+++ b/src/components/New/Select/Select.spec.tsx
@@ -1,0 +1,466 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ElementSize } from '@/types/size';
+import { Select, type SelectProps } from './Select';
+
+const baseOptions = [
+  { value: 'opt-1', label: 'Option 1' },
+  { value: 'opt-2', label: 'Option 2' },
+  { value: 'opt-3', label: 'Option 3' },
+  { value: 'opt-4', label: 'Option 4' },
+  { value: 'opt-5', label: 'Option 5' },
+  { value: 'opt-6', label: 'Option 6' },
+  { value: 'opt-7', label: 'Option 7' },
+  { value: 'opt-8', label: 'Option 8' },
+  { value: 'disabled', label: 'Disabled option', disabled: true },
+];
+
+const renderSelect = (props: Partial<SelectProps> = {}) => {
+  const defaultProps: SelectProps = {
+    options: baseOptions,
+    placeholder: 'Select...',
+    ariaLabel: 'Operator',
+  };
+  return render(<Select {...defaultProps} {...props} />);
+};
+
+const getField = () => screen.getByRole('combobox', { name: /operator/i });
+
+const openSelect = () => {
+  fireEvent.click(getField());
+};
+
+describe('Dial UI Kit :: Select', () => {
+  test('renders placeholder and toggles aria-expanded on open/close', () => {
+    renderSelect();
+
+    const field = getField();
+    expect(field).toHaveAttribute('aria-expanded', 'false');
+    expect(field).toHaveAttribute('placeholder', 'Select...');
+    expect(field).toHaveAttribute('readonly');
+
+    openSelect();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(field).toHaveAttribute('aria-expanded', 'true');
+    expect(field).toHaveAttribute(
+      'aria-controls',
+      screen.getByRole('listbox').id,
+    );
+
+    fireEvent.click(screen.getByRole('option', { name: 'Option 1' }));
+    expect(field).toHaveAttribute('aria-expanded', 'false');
+
+    // ensure the field shows the selected value
+    expect(field).toHaveValue('Option 1');
+  });
+
+  test('renders the field through the 2.0 Input', () => {
+    renderSelect({ size: ElementSize.Small, invalid: true });
+
+    const wrapper = screen.getByLabelText('input-container');
+    expect(wrapper).toHaveClass('dial-kit-input', 'dial-kit-input-small');
+    expect(wrapper).toHaveClass('dial-kit-input-error');
+    expect(getField()).toHaveAttribute('aria-haspopup', 'listbox');
+  });
+
+  test('opens on ArrowDown and Enter', () => {
+    renderSelect();
+    const field = getField();
+
+    fireEvent.keyDown(field, { key: 'ArrowDown' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(field, { key: 'Enter' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(field, { key: 'Enter' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  test('fires onChange in single mode and closes afterwards', () => {
+    const onChange = vi.fn();
+    renderSelect({ onChange });
+
+    openSelect();
+    fireEvent.click(screen.getByRole('option', { name: 'Option 2' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('opt-2');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('respects defaultValue in uncontrolled single mode', () => {
+    renderSelect({ defaultValue: 'opt-1' });
+    expect(getField()).toHaveValue('Option 1');
+  });
+
+  test('prefixes the selected value when prefix is given', () => {
+    renderSelect({ defaultValue: 'opt-1', prefix: 'Filter:' });
+    expect(getField()).toHaveValue('Filter: Option 1');
+  });
+
+  test('disabled option is not selectable in single mode', () => {
+    const onChange = vi.fn();
+    renderSelect({ onChange });
+
+    openSelect();
+    const disabledOpt = screen.getByRole('option', { name: 'Disabled option' });
+    expect(disabledOpt).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(disabledOpt);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  describe('label, caption and error', () => {
+    test('labels the field through the Label component', () => {
+      renderSelect({
+        id: 'operator',
+        ariaLabel: undefined,
+        labelProps: { label: 'Operator' },
+      });
+
+      expect(
+        screen.getByRole('combobox', { name: 'Operator' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Operator').closest('label')).toHaveAttribute(
+        'for',
+        'operator',
+      );
+    });
+
+    test('shows the caption, and replaces it with the error', () => {
+      const { rerender } = renderSelect({ caption: 'Helper text' });
+      expect(screen.getByText('Helper text')).toBeInTheDocument();
+
+      rerender(
+        <Select
+          options={baseOptions}
+          ariaLabel="Operator"
+          caption="Helper text"
+          error="Required"
+        />,
+      );
+      expect(screen.getByText('Required')).toBeInTheDocument();
+      expect(screen.queryByText('Helper text')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('multiple mode', () => {
+    test('selectAll toggles all filtered and shows indeterminate when partially selected', () => {
+      renderSelect({ multiple: true, selectAll: true });
+
+      openSelect();
+
+      const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+      expect(selectAll).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(selectAll);
+      expect(selectAll).toHaveAttribute('aria-checked', 'true');
+
+      const cb1 = screen.getByRole('checkbox', { name: 'Option 1' });
+      fireEvent.click(cb1);
+      expect(selectAll).toHaveAttribute('aria-checked', 'mixed');
+    });
+
+    test('a11y: listbox has aria-multiselectable', () => {
+      renderSelect({ multiple: true });
+      openSelect();
+      expect(screen.getByRole('listbox')).toHaveAttribute(
+        'aria-multiselectable',
+        'true',
+      );
+    });
+
+    test('renders the selection as tags and folds it into the accessible name', () => {
+      renderSelect({ multiple: true, defaultValue: ['opt-1', 'opt-2'] });
+
+      // The tags live in the field's content slot, so the input itself is empty
+      // and the selection has to be announced through the name.
+      expect(
+        screen.getByRole('combobox', { name: 'Operator, Option 1, Option 2' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Option 1')).toBeInTheDocument();
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+    });
+
+    test('removing a tag deselects it without opening the overlay', () => {
+      const onChange = vi.fn();
+      renderSelect({
+        multiple: true,
+        defaultValue: ['opt-1', 'opt-2'],
+        onChange,
+      });
+
+      fireEvent.click(screen.getAllByRole('button')[0]);
+
+      expect(onChange).toHaveBeenCalledWith(['opt-2']);
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('searchable', () => {
+    test('filters options by label', () => {
+      renderSelect({ searchable: true });
+
+      openSelect();
+      const search = screen.getByRole('textbox', { name: 'Search options' });
+      fireEvent.change(search, { target: { value: 'Option 2' } });
+
+      expect(
+        screen.getByRole('option', { name: 'Option 2' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', { name: 'Option 1' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', { name: 'Disabled option' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('searchSize Small applies the compact Input sizing', () => {
+      renderSelect({ searchable: true, searchSize: ElementSize.Small });
+
+      openSelect();
+      const search = screen.getByRole('textbox', { name: 'Search options' });
+
+      expect(search.closest('.dial-kit-input-small')).toBeInTheDocument();
+    });
+
+    test('reports the query, and resets it when the overlay closes', () => {
+      const onSearchQueryChange = vi.fn();
+      renderSelect({ searchable: true, onSearchQueryChange });
+
+      openSelect();
+      fireEvent.change(
+        screen.getByRole('textbox', { name: 'Search options' }),
+        { target: { value: 'Option 2' } },
+      );
+      expect(onSearchQueryChange).toHaveBeenLastCalledWith('Option 2');
+
+      openSelect();
+      expect(onSearchQueryChange).toHaveBeenLastCalledWith('');
+    });
+
+    test('keeps the search row when the option list shrinks below the threshold', () => {
+      const { rerender } = renderSelect({ searchable: true, open: true });
+
+      fireEvent.change(
+        screen.getByRole('textbox', { name: 'Search options' }),
+        { target: { value: 'Option 2' } },
+      );
+
+      // A consumer fetching options for the query swaps in a short list — the
+      // search row must survive it instead of vanishing under the cursor.
+      rerender(
+        <Select
+          options={[{ value: 'opt-2', label: 'Option 2' }]}
+          ariaLabel="Operator"
+          searchable
+          open
+        />,
+      );
+
+      expect(
+        screen.getByRole('textbox', { name: 'Search options' }),
+      ).toBeInTheDocument();
+    });
+
+    test('empty state is shown when nothing matches', () => {
+      renderSelect({ searchable: true, emptyStateTitle: 'Nothing here' });
+
+      openSelect();
+      fireEvent.change(
+        screen.getByRole('textbox', { name: 'Search options' }),
+        {
+          target: { value: 'zzz' },
+        },
+      );
+
+      expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    });
+  });
+
+  test('closable overlay shows button and calls onClose', () => {
+    const onClose = vi.fn();
+    renderSelect({ closable: true, onClose });
+
+    openSelect();
+    const closeBtn = screen.getByRole('button', { name: 'Close select' });
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  describe('rich single value', () => {
+    test('a labelNode is rendered in the content slot and named on the field', () => {
+      renderSelect({
+        options: [
+          {
+            value: 'dotted',
+            label: 'someValue.withOption',
+            labelNode: <span>someValue.withOption</span>,
+          },
+        ],
+        defaultValue: 'dotted',
+      });
+
+      // The input cannot hold the node, so it stays empty and the value is
+      // announced through the accessible name instead.
+      const field = screen.getByRole('combobox', {
+        name: 'Operator, someValue.withOption',
+      });
+      expect(field).toHaveValue('');
+      expect(screen.getByText('someValue.withOption')).toBeInTheDocument();
+    });
+
+    test('an option description is rendered next to the value', () => {
+      renderSelect({
+        options: [
+          { value: 'opt-1', label: 'Option 1', description: 'The first one' },
+        ],
+        defaultValue: 'opt-1',
+      });
+
+      expect(screen.getByText('The first one')).toBeInTheDocument();
+      expect(
+        screen.getByRole('combobox', { name: 'Operator, Option 1' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('sub-menu options', () => {
+    test('option with children renders as submenu trigger (aria-haspopup, not selectable directly)', () => {
+      renderSelect({
+        options: [
+          { value: 'a', label: 'Alpha' },
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [
+              { value: 'g1', label: 'G One' },
+              { value: 'g2', label: 'G Two' },
+            ],
+          },
+        ],
+      });
+      openSelect();
+      const trigger = screen.getByText('Group').closest('button')!;
+      expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger.tagName).toBe('BUTTON');
+    });
+
+    test('submenu opens on hover and child click selects value + closes dropdown', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderSelect({
+        onChange,
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [
+              { value: 'g1', label: 'G One' },
+              { value: 'g2', label: 'G Two' },
+            ],
+          },
+        ],
+      });
+      openSelect();
+      await user.hover(screen.getByText('Group').closest('button')!);
+      const child = await screen.findByText('G One');
+      fireEvent.click(child.closest('button')!);
+      expect(onChange).toHaveBeenCalledWith('g1');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    test('selected child value is shown in the field', async () => {
+      const user = userEvent.setup();
+      renderSelect({
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [{ value: 'g1', label: 'G One' }],
+          },
+        ],
+      });
+      openSelect();
+      await user.hover(screen.getByText('Group').closest('button')!);
+      fireEvent.click((await screen.findByText('G One')).closest('button')!);
+      expect(getField()).toHaveValue('G One');
+    });
+
+    test('parent trigger shows selected state when a child is selected', async () => {
+      const user = userEvent.setup();
+      renderSelect({
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [{ value: 'g1', label: 'G One' }],
+          },
+        ],
+      });
+      openSelect();
+      await user.hover(screen.getByText('Group').closest('button')!);
+      fireEvent.click((await screen.findByText('G One')).closest('button')!);
+      openSelect();
+      const parentTrigger = screen.getByText('Group').closest('button')!;
+      expect(parentTrigger).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('disabled submenu trigger does not open submenu on hover', async () => {
+      const user = userEvent.setup();
+      renderSelect({
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            disabled: true,
+            children: [{ value: 'g1', label: 'G One' }],
+          },
+        ],
+      });
+      openSelect();
+      const trigger = screen.getByText('Group').closest('button')!;
+      expect(trigger).toBeDisabled();
+      await user.hover(trigger);
+      expect(screen.queryByText('G One')).not.toBeInTheDocument();
+    });
+
+    test('disabled child in submenu is not selectable', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      renderSelect({
+        onChange,
+        options: [
+          {
+            value: 'grp',
+            label: 'Group',
+            children: [{ value: 'g1', label: 'G One', disabled: true }],
+          },
+        ],
+      });
+      openSelect();
+      await user.hover(screen.getByText('Group').closest('button')!);
+      const childEl = await screen.findByText('G One');
+      const childBtn = childEl.closest('button')!;
+      expect(childBtn).toBeDisabled();
+      fireEvent.click(childBtn);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  test('disabled select does not open', () => {
+    renderSelect({ disabled: true });
+
+    openSelect();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(getField()).toBeDisabled();
+  });
+});

--- a/src/components/New/Select/Select.stories.tsx
+++ b/src/components/New/Select/Select.stories.tsx
@@ -1,0 +1,384 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconAbc, IconDashboardOff, IconEqual } from '@tabler/icons-react';
+import { useRef, useState } from 'react';
+
+import { PrimaryButton } from '@/components/New/Button/ButtonWrappers';
+import type { SelectOption } from '@/models/select';
+import { ElementSize } from '@/types/size';
+import { Select, type SelectProps } from './Select';
+
+const iconSize = 16;
+const baseOptions: SelectOption[] = [
+  { value: 'contain', label: 'Contain', icon: <IconAbc size={iconSize} /> },
+  {
+    value: 'not-contains',
+    label: 'Not contains',
+    icon: <IconAbc size={iconSize} />,
+  },
+  { value: 'equal', label: 'Equal', icon: <IconEqual size={iconSize} /> },
+  {
+    value: 'not-equal',
+    label: 'Not equal',
+    icon: <IconDashboardOff size={iconSize} />,
+  },
+  { value: 'starts', label: 'Starts with', icon: <IconAbc size={iconSize} /> },
+  { value: 'ends', label: 'Ends with', icon: <IconAbc size={iconSize} /> },
+  { value: 'empty', label: 'Is empty' },
+  { value: 'disabled', label: 'Disabled option', disabled: true },
+  {
+    value: 'long-option',
+    label:
+      'This is a very long option to test overflow. It should be truncated appropriately',
+  },
+  {
+    value: 'another-long-option',
+    label:
+      'Another long option to test overflow. It should be truncated appropriately',
+    description: 'another long option description',
+  },
+  {
+    value: 'icon-long-option',
+    label: 'Long option that has icon. It should be truncated appropriately',
+    icon: <IconDashboardOff size={iconSize} />,
+    description: 'icon-long option description',
+  },
+  { value: 'option-1', label: 'Option 1', description: 'Option 1 description' },
+  {
+    value: 'option-icon',
+    label: 'Option Icon',
+    icon: <IconDashboardOff size={iconSize} />,
+    description: 'Option Icon description',
+  },
+  { value: 'option-2', label: 'Option 2' },
+  { value: 'option-3', label: 'Option 3' },
+  { value: 'option-4', label: 'Option 4' },
+  { value: 'option-5', label: 'Option 5' },
+  { value: 'option-6', label: 'Option 6' },
+  { value: 'option-7', label: 'Option 7' },
+  { value: 'option-8', label: 'Option 8' },
+  { value: 'option-9', label: 'Option 9' },
+  { value: 'option-10', label: 'Option 10' },
+];
+
+const meta = {
+  title: 'Components_2_0/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A select whose field is the 2.0 `Input`, so it shares its sizes, ' +
+          'label, caption, error and disabled states.',
+      },
+    },
+  },
+  argTypes: {
+    options: { control: { type: 'object' } },
+    multiple: { control: { type: 'boolean' } },
+    value: { control: { type: 'object' } },
+    prefix: { control: { type: 'text' } },
+    defaultValue: { control: { type: 'object' } },
+    placeholder: { control: { type: 'text' } },
+    size: {
+      control: { type: 'inline-radio' },
+      options: [ElementSize.Standard, ElementSize.Small],
+      description: 'Field height: standard is 40px, small is 24px',
+    },
+    searchable: { control: { type: 'boolean' } },
+    searchSize: {
+      control: { type: 'select' },
+      options: [ElementSize.Standard, ElementSize.Small],
+    },
+    selectAll: { control: { type: 'boolean' } },
+    selectAllLabel: { control: { type: 'text' } },
+    emptyStateTitle: { control: { type: 'text' } },
+    emptyStateDescription: { control: { type: 'text' } },
+    emptyStateIcon: { control: { type: 'object' } },
+    disabled: { control: { type: 'boolean' } },
+    invalid: { control: { type: 'boolean' } },
+    error: { control: { type: 'text' } },
+    caption: { control: { type: 'text' } },
+    className: { control: { type: 'text' } },
+    fieldClassName: { control: { type: 'text' } },
+    closable: { control: { type: 'boolean' } },
+    open: { control: { type: 'boolean' } },
+    onOpenChange: { control: false },
+    onClose: { control: false },
+    onChange: { control: false },
+    onSearchQueryChange: { control: false },
+  },
+  args: {
+    options: baseOptions,
+    placeholder: 'Select…',
+    searchable: false,
+    multiple: false,
+    selectAll: false,
+    selectAllLabel: 'Select all',
+    closable: false,
+    disabled: false,
+    size: ElementSize.Standard,
+  },
+  render: (args) => {
+    return (
+      <div className="w-[320px]">
+        <Select {...args} />
+      </div>
+    );
+  },
+} satisfies Meta<SelectProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SinglePreselected: Story = {
+  args: { defaultValue: 'contain' },
+};
+
+export const Multiple: Story = {
+  args: {
+    multiple: true,
+    defaultValue: ['contain', 'equal'],
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: ElementSize.Small,
+  },
+};
+
+export const WithLabel: Story = {
+  name: 'With label and caption',
+  args: {
+    id: 'labelled-select',
+    labelProps: { label: 'Operator', required: true },
+    caption: 'Pick how the values are compared',
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    invalid: true,
+    error: 'Please select an operator',
+    labelProps: { label: 'Operator' },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 'contain',
+  },
+};
+
+export const WithFooterClickCallback: Story = {
+  name: 'With footer click callback',
+  args: {
+    header: (
+      <div className="px-3 py-2 border-b">
+        <span className="dial-small-text text-primary font-medium">
+          Select time range
+        </span>
+      </div>
+    ),
+    footer: <PrimaryButton label="Apply" />,
+    onFooterClick: (e) => {
+      console.info('Footer clicked', e);
+    },
+  },
+};
+
+export const WithCustomSelectedValue: Story = {
+  args: {
+    customSelectedValue: 'Custom Selected Value',
+    value: 'custom-value',
+  },
+};
+
+export const Searchable: Story = {
+  args: {
+    prefix: 'Filter:',
+    searchable: true,
+  },
+};
+
+export const SearchableSmall: Story = {
+  name: 'Searchable (small search)',
+  args: {
+    searchable: true,
+    searchSize: ElementSize.Small,
+  },
+};
+
+const productsMockOptions: SelectOption[] = [
+  { value: 'laptop', label: 'Laptop' },
+  { value: 'smartphone', label: 'Smartphone' },
+  { value: 'tablet', label: 'Tablet' },
+  { value: 'smartwatch', label: 'Smartwatch' },
+  { value: 'headphones', label: 'Headphones' },
+  { value: 'camera', label: 'Camera' },
+  { value: 'printer', label: 'Printer' },
+  { value: 'monitor', label: 'Monitor' },
+  { value: 'keyboard', label: 'Keyboard' },
+  { value: 'mouse', label: 'Mouse' },
+];
+
+export const SearchWithExternalRequest: Story = {
+  name: 'Search with external request',
+  args: {
+    searchable: true,
+    searchPlaceholder: 'Start typing device name, e.g. smartphone...',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Simulates fetching options from an external source based on the overlay ' +
+          'search query, with debounce.',
+      },
+    },
+  },
+  render: (args) => {
+    const [options, setOptions] = useState<SelectOption[]>(productsMockOptions);
+    const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
+
+    const handleSearch = (query: string) => {
+      // Clear previous timeout
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+
+      // Simulate an API request with debounce
+      debounceTimeoutRef.current = setTimeout(() => {
+        setOptions(
+          query.length
+            ? productsMockOptions.filter((option) =>
+                option.label.toLowerCase().includes(query.toLowerCase()),
+              )
+            : productsMockOptions,
+        );
+      }, 300);
+    };
+
+    return (
+      <div className="w-[320px]">
+        <Select
+          {...args}
+          options={options}
+          onSearchQueryChange={handleSearch}
+        />
+      </div>
+    );
+  },
+};
+
+export const CustomFieldClass: Story = {
+  name: 'Custom field class',
+  args: {
+    fieldClassName: '!h-auto min-h-[48px]',
+  },
+};
+
+export const WithSubMenuOptions: Story = {
+  name: 'With sub-menu options',
+  render: (args) => (
+    <div className="w-[280px]">
+      <Select
+        {...args}
+        placeholder="Select option..."
+        options={[
+          {
+            value: 'contain',
+            label: 'Contain',
+            icon: <IconAbc size={iconSize} />,
+          },
+          {
+            value: 'equal',
+            label: 'Equal',
+            icon: <IconEqual size={iconSize} />,
+          },
+          {
+            value: 'group-compare',
+            label: 'Compare',
+            children: [
+              { value: 'gt', label: 'Greater than' },
+              { value: 'gte', label: 'Greater than or equal' },
+              { value: 'lt', label: 'Less than' },
+              { value: 'lte', label: 'Less than or equal' },
+            ],
+          },
+          {
+            value: 'disabled-group',
+            label: 'Disabled group',
+            disabled: true,
+            icon: <IconDashboardOff size={iconSize} />,
+            children: [{ value: 'x', label: 'Child X' }],
+          },
+        ]}
+      />
+    </div>
+  ),
+};
+
+/**
+ * Splits a dotted label into a secondary-colored namespace part (everything up
+ * to and including the last dot) and a primary-colored name part (everything
+ * after the last dot). This mimics styling being computed by the consumer.
+ */
+const renderDottedLabel = (label: string) => {
+  const lastDot = label.lastIndexOf('.');
+  if (lastDot === -1) {
+    return <span className="text-primary">{label}</span>;
+  }
+
+  const namespace = label.slice(0, lastDot + 1);
+  const name = label.slice(lastDot + 1);
+
+  return (
+    <span className="truncate">
+      <span className="text-secondary">{namespace}</span>
+      <span className="text-primary">{name}</span>
+    </span>
+  );
+};
+
+const dottedLabels = [
+  'someValue.withOption',
+  'secondValue.specificOption',
+  'lastValue.strongText',
+];
+
+const dottedOptions: SelectOption[] = dottedLabels.map((label) => ({
+  value: label,
+  label,
+  labelNode: renderDottedLabel(label),
+}));
+
+export const CustomLabelNode: Story = {
+  name: 'Custom label node',
+  args: {
+    options: dottedOptions,
+    placeholder: 'Select value…',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Options can render a custom `labelNode` while keeping a plain-text `label` ' +
+          'for filtering and accessibility. Here the part before the last dot ' +
+          '(including the dot) is muted (`text-secondary`) and the part after it is ' +
+          'emphasized (`text-primary`). Styling and labels are computed by the consumer. ' +
+          'Because a `labelNode` cannot live inside an `<input>`, the selected value is ' +
+          "rendered in the field's content slot and folded into its accessible name.",
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-[320px]">
+      <Select {...args} />
+    </div>
+  ),
+};

--- a/src/components/New/Select/Select.tsx
+++ b/src/components/New/Select/Select.tsx
@@ -1,0 +1,686 @@
+import { IconChevronDown } from '@tabler/icons-react';
+import classNames from 'classnames';
+import {
+  type FC,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from 'react';
+
+import { DialCheckbox } from '@/components/Checkbox/Checkbox';
+import { DialDropdown } from '@/components/Dropdown/Dropdown';
+import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
+import { DialIcon } from '@/components/Icon/Icon';
+import {
+  CaptionText,
+  ErrorText,
+} from '@/components/New/CaptionText/CaptionText';
+import { GhostIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { Input } from '@/components/New/Input/Input';
+import { Label, type LabelProps } from '@/components/New/Label/Label';
+import { DialNoDataContent } from '@/components/NoDataContent/NoDataContent';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import type { SelectOption } from '@/models/select';
+import { ElementSize } from '@/types/size';
+import { resolveAccessibleName } from '@/utils/accessible-name';
+import { mergeClasses } from '@/utils/merge-classes';
+import { MultiSelectTags } from './MultiSelectTags';
+import { SelectSubMenuItem } from './SelectSubMenuItem';
+import {
+  dropdownMenuMaxHeight,
+  selectCloseIcon,
+  selectEmptyStateIcon,
+  selectFieldIconClassName,
+  selectOptionBaseClassName,
+  selectOptionCheckIcon,
+  selectOptionDisabledClassName,
+  selectOptionSelectedClassName,
+  selectOptionSingleSelectedClassName,
+  selectOverlayBaseClassName,
+  selectSearchIcon,
+  selectSearchThreshold,
+} from './constants';
+
+export interface SelectProps {
+  options: SelectOption[];
+  multiple?: boolean;
+  id?: string;
+  size?: ElementSize;
+  value?: string | string[];
+  customSelectedValue?: string;
+  prefix?: string;
+  defaultValue?: string | string[];
+  placeholder?: string;
+  labelProps?: LabelProps;
+  error?: string;
+  caption?: string;
+  ariaLabel?: string;
+  searchable?: boolean;
+  searchSize?: ElementSize;
+  searchPlaceholder?: string;
+  selectAll?: boolean;
+  selectAllLabel?: string;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
+  emptyStateIcon?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+  fieldClassName?: string;
+  listClassName?: string;
+  closable?: boolean;
+  invalid?: boolean;
+  header?: ReactNode | (() => ReactNode);
+  footer?: ReactNode | (() => ReactNode);
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSearchQueryChange?: (query: string) => void;
+  dismissRef?: Ref<unknown>;
+  onClose?: (e: MouseEvent<HTMLButtonElement>) => void;
+  onChange?: (next: string | string[]) => void;
+  onFooterClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  customMultiSelectTagsRenderer?: (
+    options: SelectOption[],
+    selectedValues: string[],
+    handleRemoveTag: (
+      event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
+      val: string,
+    ) => void,
+  ) => ReactNode;
+}
+
+/**
+ * A versatile select supporting single and multiple selections.
+ * aliases: OptionPicker|ChoiceSelector
+ *
+ * The field is an {@link Input}, so it carries the 2.0 field styling, sizes,
+ * label, caption and error states, and it exposes the control as a `combobox`
+ * whose popup is the option list.
+ *
+ * Single mode:
+ * - The field shows the selected option's leading icon + label.
+ * - In the list, the selected option is indicated by a LEFT border, a tinted background
+ *   and a trailing check icon.
+ *
+ * Multiple mode uses checkboxes (including Select All with indeterminate state) and
+ * renders the selection as removable tags inside the field.
+ *
+ * The field itself is never typeable: `searchable` puts a search field in the overlay
+ * header that filters the options.
+ *
+ * @example
+ * ```tsx
+ * <Select options={[{ value: 'option-1', label: 'Option 1' }]} />
+ * <Select searchable options={[{ value: 'a', label: 'Alpha' }, { value: 'b', label: 'Beta' }]} />
+ * <Select multiple selectAll options={[{ value: '1', label: 'One' }, { value: '2', label: 'Two' }]} />
+ * <Select labelProps={{ label: 'Operator' }} caption="Pick a comparison" options={options} />
+ * ```
+ *
+ * @param options - Array of options to select from.
+ * @param [id] - The id of the field, linked to the label.
+ * @param [multiple] - Whether multiple selections are allowed.
+ * @param [size=ElementSize.Standard] - Field height: standard is 40px, small is 24px.
+ * @param [value] - Controlled selected value(s).
+ * @param [customSelectedValue] - Custom string to render as the selected value in single mode.
+ * @param [prefix] - Prefix for selected value(s).
+ * @param [defaultValue] - Uncontrolled initial selected value(s).
+ * @param [placeholder="Select..."] - Placeholder text when no selection is made.
+ * @param [labelProps] - Props of the {@link Label} rendered above the field.
+ * @param [error] - Error message rendered below the field (does not by itself apply error styling, pass `invalid` too).
+ * @param [caption] - Helper text rendered below the field when there is no `error`.
+ * @param [ariaLabel] - Accessible name for the field; use it when there is no visible label.
+ * @param [searchable=false] - Show a search field in the overlay header.
+ * @param [searchSize=ElementSize.Standard] - Size of the overlay search input when `searchable` is enabled.
+ * @param [searchPlaceholder] - Placeholder for the overlay search input.
+ * @param [selectAll=false] - Show a "Select All" checkbox in multiple mode.
+ * @param [selectAllLabel="Select all"] - Label for the "Select All" checkbox.
+ * @param [emptyStateTitle="No options available"] - Title text when there are no options.
+ * @param [emptyStateDescription] - Description text when there are no options.
+ * @param [emptyStateIcon] - Icon to display when there are no options.
+ * @param [invalid] - Whether the select is in an invalid state, affecting styling.
+ * @param [disabled=false] - Disable the control.
+ * @param [className] - Additional CSS classes for the outer container.
+ * @param [fieldClassName] - Additional CSS classes for the field itself.
+ * @param [listClassName] - Additional CSS classes for the list dropdown.
+ * @param [closable=false] - Show a close button in the dropdown header.
+ * @param [header] - Custom node/function rendered above the options.
+ * @param [footer] - Custom node/function rendered below the options.
+ * @param [open] - Controlled open state of the dropdown. When provided, makes the dropdown controlled.
+ * @param [onOpenChange] - Called when the dropdown open state changes.
+ * @param [onClose] - Called when the dropdown close button is clicked.
+ * @param [onChange] - Called when the selection changes.
+ * @param [onSearchQueryChange] - Called when the overlay search query changes, including the reset to `''` on close. Use it to fetch options for the query.
+ * @param [onFooterClick] - Called when the footer element is clicked. When provided, automatically closes the dropdown.
+ * @param [dismissRef] - Ref object to expose a `dismiss` method to programmatically close the select.
+ * @param [customMultiSelectTagsRenderer] - Renders the selected tags of a multi-select in place of the default ones.
+ */
+export const Select: FC<SelectProps> = ({
+  options,
+  multiple = false,
+  id,
+  value,
+  defaultValue,
+  size = ElementSize.Standard,
+  prefix,
+  customSelectedValue,
+  placeholder = 'Select...',
+  labelProps,
+  error,
+  caption,
+  ariaLabel,
+  searchable = false,
+  searchSize = ElementSize.Standard,
+  searchPlaceholder,
+  selectAll = false,
+  invalid,
+  selectAllLabel = 'Select all',
+  emptyStateTitle = 'No options available',
+  emptyStateDescription,
+  emptyStateIcon,
+  disabled = false,
+  className,
+  fieldClassName,
+  listClassName,
+  closable = false,
+  header,
+  footer,
+  onClose,
+  onChange,
+  dismissRef,
+  onFooterClick,
+  open,
+  onOpenChange,
+  onSearchQueryChange,
+  customMultiSelectTagsRenderer,
+}) => {
+  const generatedId = useId();
+  const fieldId = id || generatedId;
+  const listId = `list-${fieldId}`;
+  const isSmall = size === ElementSize.Small;
+
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlledOpen = open !== undefined;
+  const isOpen = isControlledOpen ? !!open : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlledOpen) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlledOpen, onOpenChange],
+  );
+
+  const [query, setInternalQuery] = useState('');
+  const setQuery = useCallback(
+    (next?: string) => {
+      if (next !== query) {
+        setInternalQuery(next || '');
+        onSearchQueryChange?.(next || '');
+      }
+    },
+    [onSearchQueryChange, query],
+  );
+
+  const isControlled = value !== undefined;
+  const [uncontrolled, setUncontrolled] = useState<
+    string | string[] | undefined
+  >(defaultValue);
+  const currentValue = isControlled ? value : uncontrolled;
+
+  const selectedValues: string[] = useMemo(() => {
+    if (multiple) return Array.isArray(currentValue) ? currentValue : [];
+    return typeof currentValue === 'string' ? [currentValue] : [];
+  }, [currentValue, multiple]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, query]);
+
+  // A closed overlay drops its search, so reopening always starts from the full list.
+  useEffect(() => {
+    if (!isOpen) setQuery('');
+  }, [isOpen, setQuery]);
+
+  const setSelection = useCallback(
+    (next: string | string[]) => {
+      if (!isControlled) setUncontrolled(next);
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  const handleToggle = useCallback(
+    (val: string) => {
+      if (multiple) {
+        const set = new Set(selectedValues);
+        if (set.has(val)) {
+          set.delete(val);
+        } else {
+          set.add(val);
+        }
+        setSelection(Array.from(set));
+        return;
+      }
+      setSelection(val);
+      setOpen(false);
+    },
+    [multiple, setSelection, setOpen, selectedValues],
+  );
+
+  const handleRemoveTag = useCallback(
+    (event: MouseEvent<HTMLButtonElement>, val: string) => {
+      event.stopPropagation();
+      if (!multiple) {
+        setSelection('');
+        return;
+      }
+      const next = selectedValues.filter((v) => v !== val);
+      setSelection(next);
+    },
+    [multiple, selectedValues, setSelection],
+  );
+
+  const selectableFiltered = useMemo(
+    () => filtered.filter((o) => !o.disabled),
+    [filtered],
+  );
+
+  const selectedInFilteredCount = useMemo(
+    () =>
+      selectableFiltered.filter((o) => selectedValues.includes(o.value)).length,
+    [selectableFiltered, selectedValues],
+  );
+
+  const { allSelectedInFiltered, someSelectedInFiltered } = useMemo(() => {
+    const all =
+      selectableFiltered.length > 0 &&
+      selectedInFilteredCount === selectableFiltered.length;
+    return {
+      allSelectedInFiltered: all,
+      someSelectedInFiltered: selectedInFilteredCount > 0 && !all,
+    };
+  }, [selectableFiltered, selectedInFilteredCount]);
+
+  const toggleSelectAll = useCallback(() => {
+    if (!multiple || selectableFiltered.length === 0) return;
+    if (allSelectedInFiltered) {
+      const filteredIds = new Set(selectableFiltered.map((o) => o.value));
+      setSelection(selectedValues.filter((v) => !filteredIds.has(v)));
+    } else {
+      const union = new Set(selectedValues);
+      selectableFiltered.forEach((o) => union.add(o.value));
+      setSelection(Array.from(union));
+    }
+  }, [
+    allSelectedInFiltered,
+    multiple,
+    selectableFiltered,
+    selectedValues,
+    setSelection,
+  ]);
+
+  const hasSelection = selectedValues.length > 0;
+
+  const singleSelectedValue =
+    !multiple && hasSelection ? selectedValues[0] : undefined;
+
+  const singleSelectedOption = useMemo(
+    () =>
+      singleSelectedValue
+        ? (options.find((o) => o.value === singleSelectedValue) ??
+          options
+            .flatMap((o) => o.children ?? [])
+            .find((c) => c.value === singleSelectedValue))
+        : undefined,
+    [options, singleSelectedValue],
+  );
+
+  const selectedLabel = singleSelectedOption
+    ? prefix
+      ? `${prefix} ${singleSelectedOption.label}`
+      : singleSelectedOption.label
+    : undefined;
+
+  /**
+   * Values an `<input>` cannot hold — the tags of a multi-select, an option's
+   * `labelNode`, an option description — are rendered in the field's content
+   * slot instead, and the input itself is collapsed to zero width.
+   */
+  const fieldContent = useMemo(() => {
+    if (multiple) {
+      if (!hasSelection) return null;
+      return (
+        <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+          {customMultiSelectTagsRenderer?.(
+            options,
+            selectedValues,
+            handleRemoveTag,
+          ) ?? (
+            <MultiSelectTags
+              options={options}
+              selectedValues={selectedValues}
+              handleRemoveTag={handleRemoveTag}
+            />
+          )}
+        </span>
+      );
+    }
+
+    if (!singleSelectedOption) return null;
+    if (!singleSelectedOption.labelNode && !singleSelectedOption.description) {
+      return null;
+    }
+
+    return (
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        <DialEllipsisTooltip
+          text={singleSelectedOption.labelNode ?? selectedLabel}
+        />
+        {singleSelectedOption.description && (
+          <span className="truncate text-secondary dial-tiny-text">
+            {singleSelectedOption.description}
+          </span>
+        )}
+      </span>
+    );
+  }, [
+    customMultiSelectTagsRenderer,
+    handleRemoveTag,
+    hasSelection,
+    multiple,
+    options,
+    selectedLabel,
+    selectedValues,
+    singleSelectedOption,
+  ]);
+
+  const fieldValue = (() => {
+    if (multiple || fieldContent) return '';
+    if (selectedLabel) return selectedLabel;
+    if (customSelectedValue && value) return customSelectedValue;
+    return '';
+  })();
+
+  const labelText =
+    typeof labelProps?.label === 'string' ? labelProps.label : undefined;
+
+  // A combobox announces its value from the input's own value, so a selection
+  // living in the content slot would never be read out. Fold it into the
+  // accessible name instead — together with the field's own name, which an
+  // `aria-label` would otherwise replace.
+  const fieldAriaLabel = fieldContent
+    ? [
+        resolveAccessibleName(ariaLabel, labelText),
+        multiple
+          ? selectedValues
+              .map((v) => options.find((o) => o.value === v)?.label ?? v)
+              .join(', ')
+          : selectedLabel,
+      ]
+        .filter(Boolean)
+        .join(', ') || undefined
+    : resolveAccessibleName(ariaLabel);
+
+  useImperativeHandle(dismissRef, () => ({
+    dismiss: () => {
+      setOpen(false);
+    },
+  }));
+
+  const handleFieldKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (disabled) return;
+      // Enter and Space are already handled by the dropdown trigger this field
+      // is nested in; only the arrow keys need wiring up.
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (!isOpen) setOpen(true);
+      }
+    },
+    [disabled, isOpen, setOpen],
+  );
+
+  const renderOptionsList = () => (
+    <div
+      id={listId}
+      role="listbox"
+      aria-multiselectable={multiple || undefined}
+      className={selectOverlayBaseClassName}
+    >
+      {header && <>{typeof header === 'function' ? header() : header}</>}
+      {/*
+        A short list needs no filtering — but once a query is active the row has
+        to stay, or it would vanish under the cursor as soon as the results (or
+        externally fetched options) drop below the threshold.
+      */}
+      {(searchable || closable) &&
+        (options.length > selectSearchThreshold || !!query) && (
+          <div className="flex items-center gap-2 px-2 pt-2">
+            {searchable && (
+              <Input
+                id={`search-${fieldId}`}
+                size={searchSize}
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder || 'Search options'}
+                onChange={(next) => setQuery(next)}
+                value={query}
+                iconBefore={selectSearchIcon}
+                containerClassName="w-full"
+              />
+            )}
+            {closable && (
+              <GhostIconButton
+                aria-label="Close select"
+                className="shrink-0"
+                size={ElementSize.Small}
+                icon={selectCloseIcon}
+                onClick={(e) => {
+                  onClose?.(e);
+                  setOpen(false);
+                }}
+              />
+            )}
+          </div>
+        )}
+
+      {multiple && selectAll && selectableFiltered.length > 0 && (
+        <div className={classNames(selectOptionBaseClassName, 'mt-2')}>
+          <DialCheckbox
+            id={`${fieldId}-selectAll`}
+            label={selectAllLabel}
+            checked={allSelectedInFiltered}
+            indeterminate={someSelectedInFiltered}
+            onChange={toggleSelectAll}
+            ariaLabel={selectAllLabel}
+          />
+        </div>
+      )}
+
+      <div className="overflow-y-auto max-h-[352px] py-1">
+        {filtered.length === 0 ? (
+          <div className="px-2 py-3">
+            <DialNoDataContent
+              icon={emptyStateIcon ?? selectEmptyStateIcon}
+              title={emptyStateTitle}
+              description={emptyStateDescription}
+            />
+          </div>
+        ) : (
+          filtered.map((opt) => {
+            const selected = selectedValues.includes(opt.value);
+
+            if (multiple) {
+              return (
+                <div
+                  key={opt.value}
+                  role="option"
+                  aria-selected={selected}
+                  aria-disabled={!!opt.disabled}
+                  className={classNames(
+                    selectOptionBaseClassName,
+                    selected && selectOptionSelectedClassName,
+                    opt.disabled && selectOptionDisabledClassName,
+                    'w-full',
+                  )}
+                >
+                  <DialCheckbox
+                    id={`${fieldId}-${opt.value}`}
+                    label={
+                      <span className="flex w-full flex-1 pl-2 min-w-0 items-center gap-2 text-primary">
+                        {opt.icon && <DialIcon icon={opt.icon} />}
+                        <span className="truncate">
+                          {opt.labelNode ?? opt.label}
+                        </span>
+                      </span>
+                    }
+                    checked={selected}
+                    disabled={opt.disabled}
+                    onChange={() => !opt.disabled && handleToggle(opt.value)}
+                    ariaLabel={opt.label}
+                  />
+
+                  {opt.description && (
+                    <div className="text-secondary dial-small-text">
+                      {opt.description}
+                    </div>
+                  )}
+                </div>
+              );
+            }
+
+            if (opt.children?.length) {
+              return (
+                <SelectSubMenuItem
+                  key={opt.value}
+                  opt={opt}
+                  selectedValues={selectedValues}
+                  onSelect={handleToggle}
+                />
+              );
+            }
+
+            return (
+              <button
+                key={opt.value}
+                role="option"
+                type="button"
+                aria-selected={selected}
+                aria-disabled={!!opt.disabled}
+                disabled={opt.disabled}
+                className={classNames(
+                  selectOptionBaseClassName,
+                  selected && selectOptionSingleSelectedClassName,
+                  opt.disabled && selectOptionDisabledClassName,
+                )}
+                onClick={() => !opt.disabled && handleToggle(opt.value)}
+              >
+                <div className="flex items-center gap-2 w-full min-w-0">
+                  {opt.icon && <DialIcon icon={opt.icon} />}
+                  <DialEllipsisTooltip text={opt.labelNode ?? opt.label} />
+
+                  {opt.description && (
+                    <div className="text-secondary dial-small-text">
+                      {opt.description}
+                    </div>
+                  )}
+                </div>
+
+                {selected && selectOptionCheckIcon}
+              </button>
+            );
+          })
+        )}
+      </div>
+      {footer && (
+        <div
+          onClick={(e) => {
+            onFooterClick?.(e);
+            if (onFooterClick) {
+              setOpen(false);
+            }
+          }}
+        >
+          {typeof footer === 'function' ? footer() : footer}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className={mergeClasses('flex w-full flex-col gap-2', className)}>
+      {labelProps && <Label {...labelProps} htmlFor={fieldId} />}
+
+      <div className="flex flex-col gap-1">
+        <DialDropdown
+          open={isOpen}
+          onOpenChange={setOpen}
+          disabled={disabled}
+          closable={closable}
+          onClose={onClose}
+          placement="bottom-start"
+          allowedPlacements={['bottom-start', 'top-start']}
+          maxDropdownHeight={searchable ? null : dropdownMenuMaxHeight}
+          listClassName={listClassName}
+          className="w-full"
+          renderOverlay={renderOptionsList}
+        >
+          <Input
+            id={fieldId}
+            size={size}
+            disabled={disabled}
+            invalid={invalid}
+            value={fieldValue}
+            placeholder={fieldContent ? undefined : placeholder}
+            readOnly
+            iconBefore={multiple ? undefined : singleSelectedOption?.icon}
+            iconAfter={
+              <IconChevronDown
+                size={isSmall ? DIAL_ICON_SIZE.SM : DIAL_ICON_SIZE.MD}
+                aria-hidden="true"
+                className={classNames(
+                  selectFieldIconClassName,
+                  isOpen && 'rotate-180',
+                )}
+              />
+            }
+            role="combobox"
+            aria-haspopup="listbox"
+            aria-expanded={isOpen}
+            aria-controls={listId}
+            aria-autocomplete="none"
+            aria-label={fieldAriaLabel}
+            containerClassName="w-full"
+            wrapperClassName={mergeClasses(
+              !disabled && 'cursor-pointer',
+              multiple &&
+                hasSelection &&
+                classNames(
+                  '!h-auto flex-wrap py-1.5',
+                  isSmall ? 'min-h-[24px]' : 'min-h-[40px]',
+                ),
+              fieldClassName,
+            )}
+            className={mergeClasses(
+              'cursor-pointer',
+              fieldContent && 'w-0 min-w-0 flex-none p-0',
+            )}
+            onKeyDown={handleFieldKeyDown}
+          >
+            {fieldContent}
+          </Input>
+        </DialDropdown>
+
+        <ErrorText text={error} />
+        {!error && <CaptionText text={caption} />}
+      </div>
+    </div>
+  );
+};

--- a/src/components/New/Select/Select.tsx
+++ b/src/components/New/Select/Select.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react';
 
 import { DialCheckbox } from '@/components/Checkbox/Checkbox';
-import { DialDropdown } from '@/components/Dropdown/Dropdown';
+import { Dropdown } from '@/components/New/Dropdown/Dropdown';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import { DialIcon } from '@/components/Icon/Icon';
 import {
@@ -38,11 +38,11 @@ import {
   selectCloseIcon,
   selectEmptyStateIcon,
   selectFieldIconClassName,
+  selectListWidthClassName,
   selectOptionBaseClassName,
   selectOptionCheckIcon,
   selectOptionDisabledClassName,
   selectOptionSelectedClassName,
-  selectOptionSingleSelectedClassName,
   selectOverlayBaseClassName,
   selectSearchIcon,
   selectSearchThreshold,
@@ -577,7 +577,6 @@ export const Select: FC<SelectProps> = ({
                 disabled={opt.disabled}
                 className={classNames(
                   selectOptionBaseClassName,
-                  selected && selectOptionSingleSelectedClassName,
                   opt.disabled && selectOptionDisabledClassName,
                 )}
                 onClick={() => !opt.disabled && handleToggle(opt.value)}
@@ -619,7 +618,7 @@ export const Select: FC<SelectProps> = ({
       {labelProps && <Label {...labelProps} htmlFor={fieldId} />}
 
       <div className="flex flex-col gap-1">
-        <DialDropdown
+        <Dropdown
           open={isOpen}
           onOpenChange={setOpen}
           disabled={disabled}
@@ -628,7 +627,7 @@ export const Select: FC<SelectProps> = ({
           placement="bottom-start"
           allowedPlacements={['bottom-start', 'top-start']}
           maxDropdownHeight={searchable ? null : dropdownMenuMaxHeight}
-          listClassName={listClassName}
+          listClassName={mergeClasses(selectListWidthClassName, listClassName)}
           className="w-full"
           renderOverlay={renderOptionsList}
         >
@@ -676,7 +675,7 @@ export const Select: FC<SelectProps> = ({
           >
             {fieldContent}
           </Input>
-        </DialDropdown>
+        </Dropdown>
 
         <ErrorText text={error} />
         {!error && <CaptionText text={caption} />}

--- a/src/components/New/Select/SelectSubMenuItem.tsx
+++ b/src/components/New/Select/SelectSubMenuItem.tsx
@@ -11,7 +11,6 @@ import {
   selectOptionBaseClassName,
   selectOptionCheckIcon,
   selectOptionDisabledClassName,
-  selectOptionSingleSelectedClassName,
   selectSubMenuGap,
 } from './constants';
 
@@ -52,7 +51,6 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
         disabled={opt.disabled}
         className={classNames(
           selectOptionBaseClassName,
-          parentSelected && selectOptionSingleSelectedClassName,
           opt.disabled && selectOptionDisabledClassName,
         )}
         {...getReferenceProps()}
@@ -85,7 +83,6 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
                 disabled={child.disabled}
                 className={classNames(
                   selectOptionBaseClassName,
-                  childSelected && selectOptionSingleSelectedClassName,
                   child.disabled && selectOptionDisabledClassName,
                 )}
                 onClick={() => !child.disabled && onSelect(child.value)}

--- a/src/components/New/Select/SelectSubMenuItem.tsx
+++ b/src/components/New/Select/SelectSubMenuItem.tsx
@@ -1,0 +1,106 @@
+import { IconChevronRight } from '@tabler/icons-react';
+import classNames from 'classnames';
+import { type FC } from 'react';
+
+import { DialIcon } from '@/components/Icon/Icon';
+import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
+import { type SelectOption } from '@/models/select';
+import { SubMenuPanel, useSubMenuFloating } from '@/utils/sub-menu-floating';
+
+import {
+  selectOptionBaseClassName,
+  selectOptionCheckIcon,
+  selectOptionDisabledClassName,
+  selectOptionSingleSelectedClassName,
+  selectSubMenuGap,
+} from './constants';
+
+export interface SelectSubMenuItemProps {
+  opt: SelectOption;
+  selectedValues: string[];
+  onSelect: (value: string) => void;
+}
+
+export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
+  opt,
+  selectedValues,
+  onSelect,
+}) => {
+  const {
+    isOpen,
+    refs,
+    floatingStyles,
+    context,
+    getReferenceProps,
+    getFloatingProps,
+  } = useSubMenuFloating(selectSubMenuGap, 'listbox', !!opt.disabled);
+
+  const parentSelected = opt.children?.some((c) =>
+    selectedValues.includes(c.value),
+  );
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        type="button"
+        role="option"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-selected={!!parentSelected}
+        aria-disabled={!!opt.disabled}
+        disabled={opt.disabled}
+        className={classNames(
+          selectOptionBaseClassName,
+          parentSelected && selectOptionSingleSelectedClassName,
+          opt.disabled && selectOptionDisabledClassName,
+        )}
+        {...getReferenceProps()}
+      >
+        <div className="flex items-center gap-2 w-full min-w-0">
+          {opt.icon && <DialIcon icon={opt.icon} />}
+          <DialEllipsisTooltip text={opt.labelNode ?? opt.label} />
+        </div>
+        <IconChevronRight size={14} className="shrink-0" />
+      </button>
+
+      {isOpen && (
+        <SubMenuPanel
+          refs={refs}
+          floatingStyles={floatingStyles}
+          context={context}
+          getFloatingProps={getFloatingProps}
+          role="listbox"
+          className="w-max py-1"
+        >
+          {opt.children!.map((child) => {
+            const childSelected = selectedValues.includes(child.value);
+            return (
+              <button
+                key={child.value}
+                type="button"
+                role="option"
+                aria-selected={childSelected}
+                aria-disabled={!!child.disabled}
+                disabled={child.disabled}
+                className={classNames(
+                  selectOptionBaseClassName,
+                  childSelected && selectOptionSingleSelectedClassName,
+                  child.disabled && selectOptionDisabledClassName,
+                )}
+                onClick={() => !child.disabled && onSelect(child.value)}
+              >
+                <div className="flex items-center gap-2 w-full min-w-0">
+                  {child.icon && <DialIcon icon={child.icon} />}
+                  <DialEllipsisTooltip text={child.labelNode ?? child.label} />
+                </div>
+
+                {childSelected && selectOptionCheckIcon}
+              </button>
+            );
+          })}
+        </SubMenuPanel>
+      )}
+    </>
+  );
+};

--- a/src/components/New/Select/constants.tsx
+++ b/src/components/New/Select/constants.tsx
@@ -1,0 +1,52 @@
+import {
+  IconCheck,
+  IconClipboardX,
+  IconSearch,
+  IconX,
+} from '@tabler/icons-react';
+
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+
+export const selectOverlayBaseClassName = 'w-full rounded flex flex-col';
+
+export const selectOptionBaseClassName =
+  'flex w-full items-center justify-between gap-2 px-3 h-[34px] dial-small-text text-primary truncate hover:bg-accent-primary-alpha focus:bg-accent-primary-alpha focus:outline-none';
+
+export const selectOptionSelectedClassName = 'bg-accent-primary-alpha';
+
+export const selectOptionSingleSelectedClassName =
+  'bg-accent-primary-alpha border-l border-accent-primary border-1';
+
+export const selectOptionDisabledClassName = 'opacity-75';
+export const dropdownMenuMaxHeight = 352;
+export const selectSubMenuGap = 4;
+
+/** Classes for the chevron rendered as the field's trailing icon. */
+export const selectFieldIconClassName = 'text-secondary transition-transform';
+
+/**
+ * Number of options below which the overlay's search row stays hidden: a list
+ * short enough to scan at a glance does not need to be filtered.
+ */
+export const selectSearchThreshold = 8;
+
+export const selectSearchIcon = (
+  <IconSearch size={DIAL_ICON_SIZE.MD} aria-hidden="true" />
+);
+
+export const selectCloseIcon = (
+  <IconX size={DIAL_ICON_SIZE.SM} aria-hidden="true" />
+);
+
+/** Marks the selected option in single mode, alongside its tinted row. */
+export const selectOptionCheckIcon = (
+  <IconCheck
+    size={DIAL_ICON_SIZE.SM}
+    className="shrink-0 text-accent"
+    aria-hidden
+  />
+);
+
+export const selectEmptyStateIcon = (
+  <IconClipboardX size={DIAL_ICON_SIZE.LG} stroke={0.5} aria-hidden="true" />
+);

--- a/src/components/New/Select/constants.tsx
+++ b/src/components/New/Select/constants.tsx
@@ -5,21 +5,45 @@ import {
   IconX,
 } from '@tabler/icons-react';
 
+import classNames from 'classnames';
+
+import {
+  overlayGap,
+  overlayItemClassName,
+  overlayItemDisabledClassName,
+  overlayItemSelectedClassName,
+  overlaySurfaceClassName,
+} from '@/components/New/constants/overlay';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 
-export const selectOverlayBaseClassName = 'w-full rounded flex flex-col';
+export const selectOverlayBaseClassName = classNames(
+  'w-full flex flex-col',
+  overlaySurfaceClassName,
+);
 
-export const selectOptionBaseClassName =
-  'flex w-full items-center justify-between gap-2 px-3 h-[34px] dial-small-text text-primary truncate hover:bg-accent-primary-alpha focus:bg-accent-primary-alpha focus:outline-none';
+export const selectOptionBaseClassName = classNames(
+  overlayItemClassName,
+  // The row ends with a check icon, so label and mark sit at opposite edges.
+  'justify-between',
+);
 
-export const selectOptionSelectedClassName = 'bg-accent-primary-alpha';
+export const selectOptionSelectedClassName = overlayItemSelectedClassName;
 
-export const selectOptionSingleSelectedClassName =
-  'bg-accent-primary-alpha border-l border-accent-primary border-1';
+/**
+ * Holds the option list to the width of the field.
+ *
+ * `Dropdown` only pins the overlay's *min* width to the trigger and lets
+ * `max-width` run to the available viewport width — as an inline style, so a
+ * single long label stretches the list across the screen and only `!important`
+ * can rein it back in. `--reference-width` is the trigger width the dropdown
+ * publishes, and it is set whenever `matchReferenceWidth` is left on (the
+ * default this component relies on).
+ */
+export const selectListWidthClassName = '!max-w-[var(--reference-width)]';
 
-export const selectOptionDisabledClassName = 'opacity-75';
+export const selectOptionDisabledClassName = overlayItemDisabledClassName;
 export const dropdownMenuMaxHeight = 352;
-export const selectSubMenuGap = 4;
+export const selectSubMenuGap = overlayGap;
 
 /** Classes for the chevron rendered as the field's trailing icon. */
 export const selectFieldIconClassName = 'text-secondary transition-transform';

--- a/src/components/New/constants/overlay.ts
+++ b/src/components/New/constants/overlay.ts
@@ -1,0 +1,30 @@
+import classNames from 'classnames';
+
+/**
+ * Styling shared by the 2.0 floating surfaces — the dropdown menu and the select
+ * option list. They are the same object visually, so they read from one place
+ * rather than each keeping its own copy of the tokens.
+ */
+
+/** The floating panel itself: rounded raised card with a one-unit inset. */
+export const overlaySurfaceClassName =
+  'rounded-xl bg-layer-raised p-1 shadow-md';
+
+/**
+ * A selectable row inside the panel. Keeps a visible focus ring: these rows are
+ * reached by keyboard, and the 1.0 versions suppressed the ring outright.
+ */
+export const overlayItemClassName = classNames(
+  'flex w-full cursor-pointer items-center gap-2 px-3 h-[40px] rounded-lg',
+  'dial-small-text text-primary truncate',
+  'hover:bg-accent-primary-alpha',
+  'focus-visible:outline focus-visible:outline-focus-black',
+);
+
+/** Tint marking the row that is currently selected. */
+export const overlayItemSelectedClassName = 'bg-accent-primary-alpha';
+
+export const overlayItemDisabledClassName = 'opacity-75';
+
+/** Distance between the trigger and its panel, and between nested panels. */
+export const overlayGap = 4;

--- a/src/components/Skeleton/Skeleton.spec.tsx
+++ b/src/components/Skeleton/Skeleton.spec.tsx
@@ -1,23 +1,23 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { DialSkeleton } from './Skeleton';
+import { Skeleton } from './Skeleton';
 import {
-  DialSkeletonVariant,
-  DialSkeletonAvatarSize,
-  DialSkeletonAvatarShape,
+  SkeletonVariant,
+  SkeletonAvatarSize,
+  SkeletonAvatarShape,
 } from '@/types/skeleton';
 
-describe('Dial UI Kit :: DialSkeleton', () => {
+describe('Dial UI Kit :: Skeleton', () => {
   it('renders default skeleton', () => {
-    const { container } = render(<DialSkeleton />);
+    const { container } = render(<Skeleton />);
     expect(container.firstChild).toBeInTheDocument();
   });
 
   it('shows children when loading is false', () => {
     render(
-      <DialSkeleton loading={false}>
+      <Skeleton loading={false}>
         <div role="contentinfo">Loaded Content</div>
-      </DialSkeleton>,
+      </Skeleton>,
     );
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
     expect(screen.getByText('Loaded Content')).toBeInTheDocument();
@@ -25,22 +25,22 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('shows skeleton when loading is true', () => {
     render(
-      <DialSkeleton loading={true}>
+      <Skeleton loading={true}>
         <div role="contentinfo">Loaded Content</div>
-      </DialSkeleton>,
+      </Skeleton>,
     );
     expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
   });
 
   it('renders with avatar', () => {
-    const { container } = render(<DialSkeleton avatar />);
+    const { container } = render(<Skeleton avatar />);
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toBeInTheDocument();
   });
 
   it('renders with square avatar', () => {
     const { container } = render(
-      <DialSkeleton avatar={{ shape: DialSkeletonAvatarShape.Square }} />,
+      <Skeleton avatar={{ shape: SkeletonAvatarShape.Square }} />,
     );
     const avatarElement = container.querySelector('.rounded');
     expect(avatarElement).toBeInTheDocument();
@@ -48,14 +48,14 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders with circle avatar', () => {
     const { container } = render(
-      <DialSkeleton avatar={{ shape: DialSkeletonAvatarShape.Circle }} />,
+      <Skeleton avatar={{ shape: SkeletonAvatarShape.Circle }} />,
     );
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toBeInTheDocument();
   });
 
   it('renders without title', () => {
-    const { container } = render(<DialSkeleton showTitle={false} />);
+    const { container } = render(<Skeleton showTitle={false} />);
     const mainContainer = container.querySelector('.flex.gap-4');
     expect(mainContainer).toBeInTheDocument();
 
@@ -67,7 +67,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders with custom paragraph rows', () => {
     const { container } = render(
-      <DialSkeleton paragraph={{ rows: 5 }} showTitle={false} />,
+      <Skeleton paragraph={{ rows: 5 }} showTitle={false} />,
     );
     const paragraphContainer = container.querySelector('.flex.flex-col.gap-3');
     const rows = paragraphContainer?.querySelectorAll('.h-4');
@@ -75,24 +75,20 @@ describe('Dial UI Kit :: DialSkeleton', () => {
   });
 
   it('applies animation class when active', () => {
-    const { container } = render(<DialSkeleton active />);
+    const { container } = render(<Skeleton active />);
     const animatedElement = container.querySelector('.animate-pulse');
     expect(animatedElement).toBeInTheDocument();
   });
 
   it('does not apply animation class when not active', () => {
-    const { container } = render(<DialSkeleton active={false} />);
+    const { container } = render(<Skeleton active={false} />);
     const animatedElement = container.querySelector('.animate-pulse');
     expect(animatedElement).not.toBeInTheDocument();
   });
 
   it('renders text variant with custom dimensions', () => {
     const { container } = render(
-      <DialSkeleton
-        variant={DialSkeletonVariant.Text}
-        width="200px"
-        height="20px"
-      />,
+      <Skeleton variant={SkeletonVariant.Text} width="200px" height="20px" />,
     );
     const element = container.firstChild as HTMLElement;
     expect(element.style.width).toBe('200px');
@@ -101,11 +97,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders circular variant', () => {
     const { container } = render(
-      <DialSkeleton
-        variant={DialSkeletonVariant.Circular}
-        width={64}
-        height={64}
-      />,
+      <Skeleton variant={SkeletonVariant.Circular} width={64} height={64} />,
     );
     const element = container.firstChild as HTMLElement;
     expect(element).toHaveClass('rounded-full');
@@ -115,8 +107,8 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders rectangular variant', () => {
     const { container } = render(
-      <DialSkeleton
-        variant={DialSkeletonVariant.Rectangular}
+      <Skeleton
+        variant={SkeletonVariant.Rectangular}
         width="300px"
         height="200px"
       />,
@@ -129,19 +121,19 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders default variant', () => {
     const { container } = render(
-      <DialSkeleton variant={DialSkeletonVariant.Default} />,
+      <Skeleton variant={SkeletonVariant.Default} />,
     );
     expect(container.querySelector('.flex.gap-4')).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    const { container } = render(<DialSkeleton className="custom-class" />);
+    const { container } = render(<Skeleton className="custom-class" />);
     expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('renders with large avatar size', () => {
     const { container } = render(
-      <DialSkeleton avatar={{ size: DialSkeletonAvatarSize.Large }} />,
+      <Skeleton avatar={{ size: SkeletonAvatarSize.Large }} />,
     );
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toHaveStyle({ width: '64px', height: '64px' });
@@ -149,7 +141,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders with small avatar size', () => {
     const { container } = render(
-      <DialSkeleton avatar={{ size: DialSkeletonAvatarSize.Small }} />,
+      <Skeleton avatar={{ size: SkeletonAvatarSize.Small }} />,
     );
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toHaveStyle({ width: '32px', height: '32px' });
@@ -157,21 +149,21 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders with default avatar size', () => {
     const { container } = render(
-      <DialSkeleton avatar={{ size: DialSkeletonAvatarSize.Default }} />,
+      <Skeleton avatar={{ size: SkeletonAvatarSize.Default }} />,
     );
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toHaveStyle({ width: '40px', height: '40px' });
   });
 
   it('renders with numeric avatar size', () => {
-    const { container } = render(<DialSkeleton avatar={{ size: 50 }} />);
+    const { container } = render(<Skeleton avatar={{ size: 50 }} />);
     const avatarElement = container.querySelector('.rounded-full');
     expect(avatarElement).toHaveStyle({ width: '50px', height: '50px' });
   });
 
   it('renders with custom title width', () => {
     const { container } = render(
-      <DialSkeleton showTitle={{ width: '50%' }} paragraph={false} />,
+      <Skeleton showTitle={{ width: '50%' }} paragraph={false} />,
     );
     const contentContainer = container.querySelector(
       '.flex-1.flex.flex-col.gap-3',
@@ -182,7 +174,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders with custom paragraph widths array', () => {
     const { container } = render(
-      <DialSkeleton
+      <Skeleton
         paragraph={{ rows: 3, width: ['100%', '80%', '60%'] }}
         showTitle={false}
       />,
@@ -196,7 +188,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
   });
 
   it('renders without paragraph', () => {
-    const { container } = render(<DialSkeleton paragraph={false} />);
+    const { container } = render(<Skeleton paragraph={false} />);
     const contentContainer = container.querySelector(
       '.flex-1.flex.flex-col.gap-3',
     );
@@ -208,7 +200,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('forwards HTML attributes', () => {
     const { container } = render(
-      <DialSkeleton role="status" aria-label="Loading..." />,
+      <Skeleton role="status" aria-label="Loading..." />,
     );
     expect(container.firstChild).toHaveAttribute('aria-label', 'Loading...');
     expect(container.firstChild).toHaveAttribute('role', 'status');
@@ -216,7 +208,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('uses default paragraph widths when not specified', () => {
     const { container } = render(
-      <DialSkeleton paragraph={{ rows: 3 }} showTitle={false} />,
+      <Skeleton paragraph={{ rows: 3 }} showTitle={false} />,
     );
     const paragraphContainer = container.querySelector('.flex.flex-col.gap-3');
     const rows = paragraphContainer?.querySelectorAll('.h-4');
@@ -228,8 +220,8 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders overlay centered above a variant skeleton', () => {
     const { container } = render(
-      <DialSkeleton
-        variant={DialSkeletonVariant.Rectangular}
+      <Skeleton
+        variant={SkeletonVariant.Rectangular}
         width={100}
         height={100}
         overlay={<span data-testid="overlay-icon" />}
@@ -246,8 +238,8 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('does not render overlay wrapper when overlay is not provided', () => {
     const { container } = render(
-      <DialSkeleton
-        variant={DialSkeletonVariant.Rectangular}
+      <Skeleton
+        variant={SkeletonVariant.Rectangular}
         width={100}
         height={100}
       />,
@@ -260,7 +252,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders overlay centered above a default variant skeleton', () => {
     const { container } = render(
-      <DialSkeleton overlay={<span data-testid="overlay-icon" />} />,
+      <Skeleton overlay={<span data-testid="overlay-icon" />} />,
     );
     expect(screen.getByTestId('overlay-icon')).toBeInTheDocument();
     const overlayWrapper = container.querySelector(
@@ -271,15 +263,15 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders all skeleton variants', () => {
     const variants = [
-      DialSkeletonVariant.Default,
-      DialSkeletonVariant.Text,
-      DialSkeletonVariant.Circular,
-      DialSkeletonVariant.Rectangular,
+      SkeletonVariant.Default,
+      SkeletonVariant.Text,
+      SkeletonVariant.Circular,
+      SkeletonVariant.Rectangular,
     ];
 
     variants.forEach((variant) => {
       const { container } = render(
-        <DialSkeleton variant={variant} width={100} height={100} />,
+        <Skeleton variant={variant} width={100} height={100} />,
       );
       expect(container.firstChild).toBeInTheDocument();
     });
@@ -287,7 +279,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
 
   it('renders title and paragraph together', () => {
     const { container } = render(
-      <DialSkeleton showTitle paragraph={{ rows: 2 }} />,
+      <Skeleton showTitle paragraph={{ rows: 2 }} />,
     );
     const contentContainer = container.querySelector(
       '.flex-1.flex.flex-col.gap-3',
@@ -298,7 +290,7 @@ describe('Dial UI Kit :: DialSkeleton', () => {
   });
 
   it('renders only title without paragraph', () => {
-    const { container } = render(<DialSkeleton showTitle paragraph={false} />);
+    const { container } = render(<Skeleton showTitle paragraph={false} />);
     const contentContainer = container.querySelector(
       '.flex-1.flex.flex-col.gap-3',
     );

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { IconPhoto, IconUser } from '@tabler/icons-react';
-import { DialSkeleton } from './Skeleton';
+import { Skeleton } from './Skeleton';
 import {
-  DialSkeletonVariant,
-  DialSkeletonAvatarSize,
-  DialSkeletonAvatarShape,
+  SkeletonVariant,
+  SkeletonAvatarSize,
+  SkeletonAvatarShape,
 } from '@/types/skeleton';
 import { useState, useEffect, type FC } from 'react';
 
-const meta: Meta<typeof DialSkeleton> = {
-  title: 'Feedback/Skeleton',
-  component: DialSkeleton,
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components_2_0/Skeleton',
+  component: Skeleton,
   parameters: {
     layout: 'centered',
   },
@@ -26,7 +26,7 @@ const meta: Meta<typeof DialSkeleton> = {
     },
     variant: {
       control: 'select',
-      options: Object.values(DialSkeletonVariant),
+      options: Object.values(SkeletonVariant),
       description: 'Skeleton variant',
     },
     width: {
@@ -54,7 +54,7 @@ export const Default: Story = {
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
@@ -67,7 +67,7 @@ export const WithAvatar: Story = {
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
@@ -76,14 +76,14 @@ export const WithLargeAvatar: Story = {
   args: {
     active: true,
     avatar: {
-      size: DialSkeletonAvatarSize.Large,
-      shape: DialSkeletonAvatarShape.Square,
+      size: SkeletonAvatarSize.Large,
+      shape: SkeletonAvatarShape.Square,
     },
     paragraph: { rows: 3 },
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
@@ -92,14 +92,14 @@ export const WithSmallCircleAvatar: Story = {
   args: {
     active: true,
     avatar: {
-      size: DialSkeletonAvatarSize.Small,
-      shape: DialSkeletonAvatarShape.Circle,
+      size: SkeletonAvatarSize.Small,
+      shape: SkeletonAvatarShape.Circle,
     },
     paragraph: { rows: 2 },
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
@@ -116,14 +116,14 @@ export const CustomParagraphWidths: Story = {
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
 
 export const TextVariant: Story = {
   args: {
-    variant: DialSkeletonVariant.Text,
+    variant: SkeletonVariant.Text,
     width: '200px',
     height: '20px',
     active: true,
@@ -132,7 +132,7 @@ export const TextVariant: Story = {
 
 export const SmallTextVariant: Story = {
   args: {
-    variant: DialSkeletonVariant.Text,
+    variant: SkeletonVariant.Text,
     width: '100px',
     height: '12px',
     active: true,
@@ -141,7 +141,7 @@ export const SmallTextVariant: Story = {
 
 export const CircularVariant: Story = {
   args: {
-    variant: DialSkeletonVariant.Circular,
+    variant: SkeletonVariant.Circular,
     width: 64,
     height: 64,
     active: true,
@@ -150,7 +150,7 @@ export const CircularVariant: Story = {
 
 export const RectangularVariant: Story = {
   args: {
-    variant: DialSkeletonVariant.Rectangular,
+    variant: SkeletonVariant.Rectangular,
     width: '300px',
     height: '200px',
     active: true,
@@ -159,7 +159,7 @@ export const RectangularVariant: Story = {
 
 export const ImageThumbnailLoading: Story = {
   args: {
-    variant: DialSkeletonVariant.Rectangular,
+    variant: SkeletonVariant.Rectangular,
     width: 100,
     height: 100,
     active: true,
@@ -181,7 +181,7 @@ export const ImageThumbnailLoading: Story = {
 
 export const CircularWithOverlay: Story = {
   args: {
-    variant: DialSkeletonVariant.Circular,
+    variant: SkeletonVariant.Circular,
     width: 40,
     height: 40,
     active: true,
@@ -210,7 +210,7 @@ export const WithoutAnimation: Story = {
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
 };
@@ -228,7 +228,7 @@ const LoadingComponent: FC = () => {
 
   return (
     <div className="w-[600px]">
-      <DialSkeleton loading={loading} avatar paragraph={{ rows: 4 }}>
+      <Skeleton loading={loading} avatar paragraph={{ rows: 4 }}>
         <div className="flex gap-4">
           <div className="size-10 rounded-full bg-accent-primary flex items-center justify-center text-white">
             JD
@@ -241,7 +241,7 @@ const LoadingComponent: FC = () => {
             </p>
           </div>
         </div>
-      </DialSkeleton>
+      </Skeleton>
     </div>
   );
 };
@@ -261,9 +261,9 @@ export const ConditionalLoading: Story = {
 export const MultipleSkeletons: Story = {
   render: () => (
     <div className="w-[600px] space-y-6">
-      <DialSkeleton avatar paragraph={{ rows: 2 }} active />
-      <DialSkeleton avatar paragraph={{ rows: 2 }} active />
-      <DialSkeleton avatar paragraph={{ rows: 2 }} active />
+      <Skeleton avatar paragraph={{ rows: 2 }} active />
+      <Skeleton avatar paragraph={{ rows: 2 }} active />
+      <Skeleton avatar paragraph={{ rows: 2 }} active />
     </div>
   ),
 };
@@ -273,21 +273,21 @@ export const ListSkeleton: Story = {
     <div className="w-[400px] space-y-4">
       {Array.from({ length: 5 }).map((_, index) => (
         <div key={index} className="flex items-center gap-3">
-          <DialSkeleton
-            variant={DialSkeletonVariant.Circular}
+          <Skeleton
+            variant={SkeletonVariant.Circular}
             width={40}
             height={40}
             active
           />
           <div className="flex-1 space-y-2">
-            <DialSkeleton
-              variant={DialSkeletonVariant.Text}
+            <Skeleton
+              variant={SkeletonVariant.Text}
               width="60%"
               height={16}
               active
             />
-            <DialSkeleton
-              variant={DialSkeletonVariant.Text}
+            <Skeleton
+              variant={SkeletonVariant.Text}
               width="40%"
               height={12}
               active
@@ -302,33 +302,28 @@ export const ListSkeleton: Story = {
 export const CardSkeleton: Story = {
   render: () => (
     <div className="w-[300px] border border-primary rounded p-4">
-      <DialSkeleton
-        variant={DialSkeletonVariant.Rectangular}
+      <Skeleton
+        variant={SkeletonVariant.Rectangular}
         width="100%"
         height={200}
         active
         className="mb-4"
       />
-      <DialSkeleton
-        variant={DialSkeletonVariant.Text}
+      <Skeleton
+        variant={SkeletonVariant.Text}
         width="80%"
         height={24}
         active
         className="mb-2"
       />
-      <DialSkeleton
-        variant={DialSkeletonVariant.Text}
+      <Skeleton
+        variant={SkeletonVariant.Text}
         width="100%"
         height={16}
         active
         className="mb-2"
       />
-      <DialSkeleton
-        variant={DialSkeletonVariant.Text}
-        width="90%"
-        height={16}
-        active
-      />
+      <Skeleton variant={SkeletonVariant.Text} width="90%" height={16} active />
     </div>
   ),
 };
@@ -342,7 +337,7 @@ export const CustomColor: Story = {
   },
   render: (args) => (
     <div className="w-[600px]">
-      <DialSkeleton {...args} />
+      <Skeleton {...args} />
     </div>
   ),
   parameters: {
@@ -359,7 +354,7 @@ export const CustomColorVariants: Story = {
   render: () => (
     <div className="space-y-6">
       <div className="p-4 rounded" style={{ backgroundColor: '#1e1b4b' }}>
-        <DialSkeleton
+        <Skeleton
           active
           color="rgba(139, 92, 246, 0.4)"
           avatar
@@ -367,7 +362,7 @@ export const CustomColorVariants: Story = {
         />
       </div>
       <div className="p-4 rounded bg-accent-primary">
-        <DialSkeleton
+        <Skeleton
           active
           color="rgba(255,255,255,0.3)"
           paragraph={{ rows: 2 }}
@@ -375,23 +370,23 @@ export const CustomColorVariants: Story = {
       </div>
       <div className="p-4 rounded">
         <div className="flex gap-3 items-center mb-3">
-          <DialSkeleton
-            variant={DialSkeletonVariant.Circular}
+          <Skeleton
+            variant={SkeletonVariant.Circular}
             width={40}
             height={40}
             active
             color="#f97316"
           />
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
+          <Skeleton
+            variant={SkeletonVariant.Text}
             width="50%"
             height={16}
             active
             color="#f97316"
           />
         </div>
-        <DialSkeleton
-          variant={DialSkeletonVariant.Rectangular}
+        <Skeleton
+          variant={SkeletonVariant.Rectangular}
           width="100%"
           height={100}
           active
@@ -413,18 +408,18 @@ export const CustomColorVariants: Story = {
 export const AllAvatarSizes: Story = {
   render: () => (
     <div className="w-[600px] space-y-6">
-      <DialSkeleton
-        avatar={{ size: DialSkeletonAvatarSize.Small }}
+      <Skeleton
+        avatar={{ size: SkeletonAvatarSize.Small }}
         paragraph={{ rows: 2 }}
         active
       />
-      <DialSkeleton
-        avatar={{ size: DialSkeletonAvatarSize.Default }}
+      <Skeleton
+        avatar={{ size: SkeletonAvatarSize.Default }}
         paragraph={{ rows: 2 }}
         active
       />
-      <DialSkeleton
-        avatar={{ size: DialSkeletonAvatarSize.Large }}
+      <Skeleton
+        avatar={{ size: SkeletonAvatarSize.Large }}
         paragraph={{ rows: 2 }}
         active
       />
@@ -443,18 +438,18 @@ export const AllAvatarSizes: Story = {
 export const AllAvatarShapes: Story = {
   render: () => (
     <div className="w-[600px] space-y-6">
-      <DialSkeleton
+      <Skeleton
         avatar={{
-          size: DialSkeletonAvatarSize.Large,
-          shape: DialSkeletonAvatarShape.Circle,
+          size: SkeletonAvatarSize.Large,
+          shape: SkeletonAvatarShape.Circle,
         }}
         paragraph={{ rows: 2 }}
         active
       />
-      <DialSkeleton
+      <Skeleton
         avatar={{
-          size: DialSkeletonAvatarSize.Large,
-          shape: DialSkeletonAvatarShape.Square,
+          size: SkeletonAvatarSize.Large,
+          shape: SkeletonAvatarShape.Square,
         }}
         paragraph={{ rows: 2 }}
         active
@@ -478,35 +473,23 @@ export const FormLoadingState: Story = {
       <div className="space-y-4">
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Full Name</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="100%"
-            height={36}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="100%" height={36} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Email</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="100%"
-            height={36}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="100%" height={36} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Phone</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="70%"
-            height={36}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="70%" height={36} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Bio</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Rectangular}
+          <Skeleton
+            variant={SkeletonVariant.Rectangular}
             width="100%"
             height={120}
           />
@@ -514,13 +497,13 @@ export const FormLoadingState: Story = {
       </div>
 
       <div className="flex gap-3 justify-end">
-        <DialSkeleton
-          variant={DialSkeletonVariant.Rectangular}
+        <Skeleton
+          variant={SkeletonVariant.Rectangular}
           width={80}
           height={36}
         />
-        <DialSkeleton
-          variant={DialSkeletonVariant.Rectangular}
+        <Skeleton
+          variant={SkeletonVariant.Rectangular}
           width={80}
           height={36}
         />
@@ -540,68 +523,44 @@ export const DetailsPanelLoadingState: Story = {
   render: () => (
     <div className="w-[320px] border border-primary rounded p-4 space-y-4">
       <div className="flex items-center gap-3">
-        <DialSkeleton
-          variant={DialSkeletonVariant.Circular}
-          width={48}
-          height={48}
-        />
+        <Skeleton variant={SkeletonVariant.Circular} width={48} height={48} />
         <div className="flex-1 space-y-2">
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="80%"
-            height={18}
-          />
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="60%"
-            height={14}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="80%" height={18} />
+          <Skeleton variant={SkeletonVariant.Text} width="60%" height={14} />
         </div>
       </div>
 
       <div className="border-t border-primary pt-4 space-y-3">
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Status</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="50%"
-            height={16}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="50%" height={16} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Created</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="70%"
-            height={16}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="70%" height={16} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Last Modified</div>
-          <DialSkeleton
-            variant={DialSkeletonVariant.Text}
-            width="70%"
-            height={16}
-          />
+          <Skeleton variant={SkeletonVariant.Text} width="70%" height={16} />
         </div>
 
         <div className="space-y-2">
           <div className="text-secondary dial-small-text">Tags</div>
           <div className="flex gap-2">
-            <DialSkeleton
-              variant={DialSkeletonVariant.Rectangular}
+            <Skeleton
+              variant={SkeletonVariant.Rectangular}
               width={60}
               height={24}
             />
-            <DialSkeleton
-              variant={DialSkeletonVariant.Rectangular}
+            <Skeleton
+              variant={SkeletonVariant.Rectangular}
               width={80}
               height={24}
             />
-            <DialSkeleton
-              variant={DialSkeletonVariant.Rectangular}
+            <Skeleton
+              variant={SkeletonVariant.Rectangular}
               width={70}
               height={24}
             />

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -6,25 +6,25 @@ import {
 } from 'react';
 import { mergeClasses } from '@/utils/merge-classes';
 import {
-  DialSkeletonVariant,
-  DialSkeletonAvatarSize,
-  DialSkeletonAvatarShape,
+  SkeletonVariant,
+  SkeletonAvatarSize,
+  SkeletonAvatarShape,
 } from '@/types/skeleton';
 import { getAvatarSize } from './utils';
 
-export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
   active?: boolean;
   paragraph?: boolean | { rows?: number; width?: string | string[] };
   avatar?:
     | boolean
     | {
-        size?: number | DialSkeletonAvatarSize;
-        shape?: DialSkeletonAvatarShape;
+        size?: number | SkeletonAvatarSize;
+        shape?: SkeletonAvatarShape;
       };
   showTitle?: boolean | { width?: string };
   loading?: boolean;
   children?: ReactNode;
-  variant?: DialSkeletonVariant;
+  variant?: SkeletonVariant;
   width?: string | number;
   height?: string | number;
   overlay?: ReactNode;
@@ -32,7 +32,7 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * DialSkeleton
+ * Skeleton
  * aliases: PlaceholderUI|ShimmerLoader
  *
  * A placeholder component to show while content is loading.
@@ -41,16 +41,16 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
  * @example
  * ```tsx
  * // Simple skeleton
- * <DialSkeleton />
+ * <Skeleton />
  *
  * // Text skeleton with custom size
- * <DialSkeleton variant={DialSkeletonVariant.Text} width="200px" height="20px" />
+ * <Skeleton variant={SkeletonVariant.Text} width="200px" height="20px" />
  *
  * // Circular avatar skeleton
- * <DialSkeleton variant={DialSkeletonVariant.Circular} width={40} height={40} />
+ * <Skeleton variant={SkeletonVariant.Circular} width={40} height={40} />
  *
  * // Complex skeleton with avatar, showTitle and paragraph
- * <DialSkeleton
+ * <Skeleton
  *   avatar
  *   showTitle
  *   paragraph={{ rows: 3 }}
@@ -58,20 +58,20 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
  * />
  *
  * // Conditional loading
- * <DialSkeleton loading={isLoading}>
+ * <Skeleton loading={isLoading}>
  *   <div>Your content here</div>
- * </DialSkeleton>
+ * </Skeleton>
  *
  * // Custom paragraph widths
- * <DialSkeleton
+ * <Skeleton
  *   paragraph={{ rows: 3, width: ['100%', '80%', '60%'] }}
  * />
  *
  * // Avatar with size and shape
- * <DialSkeleton
+ * <Skeleton
  *   avatar={{
- *     size: DialSkeletonAvatarSize.Large,
- *     shape: DialSkeletonAvatarShape.Square
+ *     size: SkeletonAvatarSize.Large,
+ *     shape: SkeletonAvatarShape.Square
  *   }}
  * />
  * ```
@@ -82,21 +82,21 @@ export interface DialSkeletonProps extends HTMLAttributes<HTMLDivElement> {
  * @param [showTitle=true] - Show title placeholder or configure its appearance
  * @param [loading=true] - Display the skeleton when true
  * @param [children] - Content to be displayed when loading is false
- * @param [variant=DialSkeletonVariant.Default] - Skeleton variant
+ * @param [variant=SkeletonVariant.Default] - Skeleton variant
  * @param [width] - Width of the skeleton
  * @param [height] - Height of the skeleton
  * @param [className] - Additional CSS classes
  * @param [overlay] - Content to overlay on top of the skeleton (e.g., a spinner)
  * @param [color] - Custom background color for the skeleton elements (overrides the default token)
  */
-export const DialSkeleton: FC<DialSkeletonProps> = ({
+export const Skeleton: FC<SkeletonProps> = ({
   active = true,
   paragraph = true,
   avatar = false,
   showTitle = true,
   loading = true,
   children,
-  variant = DialSkeletonVariant.Default,
+  variant = SkeletonVariant.Default,
   width,
   height,
   overlay,
@@ -114,12 +114,12 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
     className,
   );
 
-  if (variant !== DialSkeletonVariant.Default) {
+  if (variant !== SkeletonVariant.Default) {
     const variantClass = mergeClasses(
       baseClass,
-      variant === DialSkeletonVariant.Circular && 'rounded-full',
-      variant === DialSkeletonVariant.Rectangular && 'rounded',
-      variant === DialSkeletonVariant.Text && 'rounded',
+      variant === SkeletonVariant.Circular && 'rounded-full',
+      variant === SkeletonVariant.Rectangular && 'rounded',
+      variant === SkeletonVariant.Text && 'rounded',
       !!overlay && 'relative',
     );
 
@@ -149,7 +149,7 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
   const paragraphConfig = typeof paragraph === 'object' ? paragraph : {};
 
   const avatarSize = getAvatarSize(avatarConfig.size);
-  const avatarShape = avatarConfig.shape ?? DialSkeletonAvatarShape.Circle;
+  const avatarShape = avatarConfig.shape ?? SkeletonAvatarShape.Circle;
   const titleWidth = titleConfig.width ?? '38%';
   const paragraphRows = paragraphConfig.rows ?? 3;
   const paragraphWidth = paragraphConfig.width;
@@ -174,7 +174,7 @@ export const DialSkeleton: FC<DialSkeletonProps> = ({
         <div
           className={mergeClasses(
             baseClass,
-            avatarShape === DialSkeletonAvatarShape.Circle
+            avatarShape === SkeletonAvatarShape.Circle
               ? 'rounded-full'
               : 'rounded',
             'flex-shrink-0',

--- a/src/components/Skeleton/utils.ts
+++ b/src/components/Skeleton/utils.ts
@@ -1,15 +1,13 @@
-import { DialSkeletonAvatarSize } from '@/types/skeleton';
+import { SkeletonAvatarSize } from '@/types/skeleton';
 
-export const getAvatarSize = (
-  size?: number | DialSkeletonAvatarSize,
-): number => {
+export const getAvatarSize = (size?: number | SkeletonAvatarSize): number => {
   if (typeof size === 'number') return size;
   switch (size) {
-    case DialSkeletonAvatarSize.Small:
+    case SkeletonAvatarSize.Small:
       return 32;
-    case DialSkeletonAvatarSize.Large:
+    case SkeletonAvatarSize.Large:
       return 64;
-    case DialSkeletonAvatarSize.Default:
+    case SkeletonAvatarSize.Default:
     default:
       return 40;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export { DialFileName } from './components/FileName/FileName';
 export { DialFolderName } from './components/FolderName/FolderName';
 export { DialResizableContainer } from './components/ResizableContainer/ResizableContainer';
 export { DialConditionalResizableContainer } from './components/ResizableContainer/ConditionalResizableContainer';
-export { DialSkeleton } from './components/Skeleton/Skeleton';
+export { Skeleton } from './components/Skeleton/Skeleton';
 
 // Grid
 export { DialGrid } from './components/Grid/Grid';
@@ -183,9 +183,9 @@ export { FlexibleActionsDirection } from './types/flexible-actions';
 export { DialItemType } from './types/item';
 export { ResizableContainerSide } from './types/resizable-container';
 export {
-  DialSkeletonVariant,
-  DialSkeletonAvatarSize,
-  DialSkeletonAvatarShape,
+  SkeletonVariant,
+  SkeletonAvatarSize,
+  SkeletonAvatarShape,
 } from './types/skeleton';
 
 // Hooks
@@ -330,6 +330,10 @@ export type {
   InlineSelectProps,
   InlineSelectTriggerProps,
 } from './components/New/InlineSelect/InlineSelect';
+export { Select } from './components/New/Select/Select';
+export type { SelectProps } from './components/New/Select/Select';
+export { MultiSelectTags } from './components/New/Select/MultiSelectTags';
+export type { MultiSelectTagsProps } from './components/New/Select/MultiSelectTags';
 export { InfoButton } from './components/New/InfoButton/InfoButton';
 export type { InfoButtonProps } from './components/New/InfoButton/InfoButton';
 export type { LabelProps } from './components/New/Label/Label';

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,12 @@ export { NumberInput } from './components/New/NumberInput/NumberInput';
 export type { NumberInputProps } from './components/New/NumberInput/NumberInput';
 export { Popup } from './components/New/Popup/Popup';
 export type { PopupProps } from './components/New/Popup/Popup';
+export { CloseButton } from './components/New/CloseButton/CloseButton';
+export type { CloseButtonProps } from './components/New/CloseButton/CloseButton';
+export { ConfirmationPopup } from './components/New/ConfirmationPopup/ConfirmationPopup';
+export type { ConfirmationPopupProps } from './components/New/ConfirmationPopup/ConfirmationPopup';
+export { Dropdown } from './components/New/Dropdown/Dropdown';
+export type { DropdownProps } from './components/New/Dropdown/Dropdown';
 export type { TextareaProps } from './components/New/Textarea/Textarea';
 export type { CaptionTextProps } from './components/New/CaptionText/CaptionText';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,12 @@ export { Label } from './components/New/Label/Label';
 export { Textarea } from './components/New/Textarea/Textarea';
 export { Input } from './components/New/Input/Input';
 export type { InputProps } from './components/New/Input/Input';
+export { PasswordInput } from './components/New/PasswordInput/PasswordInput';
+export type { PasswordInputProps } from './components/New/PasswordInput/PasswordInput';
+export { NumberInput } from './components/New/NumberInput/NumberInput';
+export type { NumberInputProps } from './components/New/NumberInput/NumberInput';
+export { Popup } from './components/New/Popup/Popup';
+export type { PopupProps } from './components/New/Popup/Popup';
 export type { TextareaProps } from './components/New/Textarea/Textarea';
 export type { CaptionTextProps } from './components/New/CaptionText/CaptionText';
 export {

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -84,7 +84,7 @@
 }
 
 .dial-kit-static-solid-button {
-  @apply dial-kit-base-button text-control-disable-alpha bg-transparent;
+  @apply dial-kit-base-button text-secondary bg-transparent;
 
   @media (hover: hover) {
     &:hover {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -55,7 +55,7 @@
 }
 
 .dial-tiny-lead-text {
-  @apply font-normal text-[12px]/[16px] tracking-[0.03em];
+  @apply font-normal text-[12px]/[16px] tracking-[0.03em] uppercase;
 }
 
 .dial-tiny-semi-text {

--- a/src/types/skeleton.ts
+++ b/src/types/skeleton.ts
@@ -1,17 +1,17 @@
-export enum DialSkeletonVariant {
+export enum SkeletonVariant {
   Default = 'default',
   Text = 'text',
   Circular = 'circular',
   Rectangular = 'rectangular',
 }
 
-export enum DialSkeletonAvatarSize {
+export enum SkeletonAvatarSize {
   Small = 'small',
   Default = 'default',
   Large = 'large',
 }
 
-export enum DialSkeletonAvatarShape {
+export enum SkeletonAvatarShape {
   Circle = 'circle',
   Square = 'square',
 }


### PR DESCRIPTION
**Description and UI changes:**

Adds the 2.0 (`src/components/New`) counterparts of the select, dropdown and popup families, all built on the existing 2.0 primitives (`Input`, `Button`, `IconButton`, `Label`, `CaptionText`) so they share its sizes, states and tokens.

**New 2.0 components**

| Component | Notes |
| --- | --- |
| `Select` | Field is the 2.0 `Input`, exposed as a `combobox` with `aria-expanded`/`aria-controls` instead of a `div[role="button"]`. Adds `labelProps`, `error`, `caption`, `ariaLabel`, `size` via `ElementSize`, `fieldClassName`. Selected option is marked with a check icon; multi-select tags are removable. |
| `Dropdown` | 2.0 surface and items; menu items keep a visible focus ring. |
| `Popup` | 2.0 surface tokens instead of the legacy `.dial-popup` SCSS; `ariaLabel` names the dialog when `header` is a node; heading id generated per instance. |
| `ConfirmationPopup` | Built on the 2.0 `Popup` + `Button`; danger accent as utilities instead of the `div .dial-danger-popup` descendant rule. |
| `NumberInput` | Wraps the 2.0 `Input`; the numeric key guard can no longer be dropped by passing a custom `onKeyDown`. |
| `PasswordInput` | Reveal toggle is a real `<button>` (keyboard reachable, `aria-pressed`); a disabled field stays masked so its value cannot leak through the disabled-field tooltip. |
| `CloseButton` | Sized through `ElementSize` rather than raw icon pixels; named `"Close"` by default so it is never an unnamed icon button. |

**Shared**

- `New/constants/overlay.ts` — one definition of the floating surface and its rows, so the dropdown menu and the select list cannot drift apart.
- `Input` gains an optional content slot (`children`), rendered inside the field before the input, for values a plain `<input>` cannot hold (multi-select tags, an option's `labelNode`). Previously passing `children` spread them onto the void `<input>` and threw.
- `Select`'s option list is capped to the trigger width, so one long label no longer stretches the popup across the viewport.

**Other changes**

- `Skeleton` moved to the 2.0 naming: `DialSkeletonVariant` / `DialSkeletonAvatarSize` / `DialSkeletonAvatarShape` → `SkeletonVariant` / `SkeletonAvatarSize` / `SkeletonAvatarShape`, plus component, stories, spec and utils updates.
- `dial-kit-static-solid-button` uses `text-secondary`; `dial-tiny-lead-text` is uppercase.
- `FileMetadataPopup` updated for the renamed skeleton enums.
- README: target-size exception row for standard 2.0 fields.

**⚠️ Breaking change — needs docs before merge**

The skeleton enum rename is breaking for consumers. Per `AGENTS.md` it needs a `CHANGELOG.md` entry and a migration guide under `migration-guides/<version>/`, neither of which is in this PR yet.

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [x] component name starts with Dial — n/a: 2.0 components in `src/components/New` intentionally drop the prefix (`Select`, `Dropdown`, `Popup`), matching `Input`, `Button` and `Calendar`
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added
