### PR TITLE
feat(mcp): generation-aware component discovery, 2.0 ranked first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,18 @@ Versions match the git tags on the `development` branch.
 - **`ButtonDropdown` (2.0)** — the trigger button now carries `aria-haspopup` and `aria-expanded` itself. `DialDropdown` sets them on a non-focusable wrapper `<span>`, so assistive tech never reached them.
 - **`Calendar` (2.0)** — day cells are named with their full date (e.g. "Sunday, 15 March 2026") instead of a bare day number; the popover is a named dialog; and the field `label` is associated with the `div[role="button"]` trigger, which `<label htmlFor>` cannot label.
 - **`FabButton`, `DialIconButton`, `IconButton` (2.0)** — an icon-only button with only `tooltipProps` is now named from the tooltip text. A tooltip's `aria-describedby` lands on a wrapper element and is suppressed on mobile, so it never reached assistive tech.
+- **MCP server — 2.0 components were invisible to agents** — the manifest generator treated only `Dial*` exports as components, so every generation 2.0 component (`Button`, `Input`, `Select`, `Popup`, …) was filed as a hook and lost its props table and examples entirely. Components are now identified by where they live rather than by their name prefix, which also restores the un-prefixed 1.0 components (`Spinner`, `Skeleton`, `FabButton`) and documents the 2.0 enums (`NotificationVariant`, `CalendarMode`) as types.
+- **MCP server — components exported through a re-export barrel were dropped** — `src/index.ts` reaches the Analytics set through `components/Analytics/index.ts`, which the generator tried to read as a file and skipped. Named re-exports are now followed to the declaring file, adding all five Analytics components to discovery.
+- **MCP server — multi-line JSDoc descriptions broke the markdown tables** in `searchEntity` results. Cells are collapsed to a single line and `|` is escaped.
 
 ### Added
 
 - **Enhanced pointer targets** — standard-size buttons expose a 44×44 pointer target (WCAG 2.5.5, Level AAA) via the `dial-kit-enhanced-target` utility, with no change to their rendered size. See the [Accessibility section of the README](README.md#-accessibility) for the documented exceptions.
+- **MCP server — generation-aware component discovery** — component entries carry `generation` (`1.0` | `2.0`), and a 1.0 component carries `supersededBy` naming its 2.0 replacement (e.g. `DialButton` → `Button`). `searchEntity` ranks 2.0 above 1.0 and reports a **Use instead** column; `getEntityDetails` flags a superseded component and, on a name miss, suggests the other generation's spelling. Both are derived automatically from component location and Storybook category — there is no list to maintain. See the [MCP Server Guide](src/mcp/README.md).
+
+### Changed
+
+- **Storybook — 2.0 stories are all titled `Components_2_0/…`** — the group was split between `Components_2.0/` and `Components_2_0/`, which showed up as two sidebar sections and two MCP categories for one generation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ import * as UIKit from '@epam/ai-dial-ui-kit';
 
 The AI DIAL UI Kit includes a built-in **MCP (Model Context Protocol) server** that enables AI agents to discover components, types, hooks, and utilities programmatically. This allows AI assistants to generate accurate, type-safe component code without hallucination.
 
+Component results are ranked **generation 2.0 first** — the current design system, exported without the `Dial` prefix — and each legacy `Dial*` component points at its 2.0 replacement, so agents land on the right component by default.
+
 For setup, configuration, and detailed resources, see the [MCP Server Guide](./src/mcp/README.md).
 
 ## 🤝 Contributing

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState, type FC } from 'react';
 
-import { DialDropdown } from '@/components/Dropdown/Dropdown';
 import { DialButton, type DialButtonProps } from '@/components/Button/Button';
 import type { DropdownItem } from '@/models/dropdown';
-import { buttonChevronDown, buttonChevronUp } from './constants';
 import { ButtonAppearance, ButtonVariant } from '@/types/button';
+import { Dropdown } from '../New/Dropdown/Dropdown';
+import { buttonChevronDown, buttonChevronUp } from './constants';
 
 export interface DialButtonDropdownProps extends Omit<
   DialButtonProps,
@@ -41,18 +41,13 @@ export const DialButtonDropdown: FC<DialButtonDropdownProps> = ({
   }, [isDropdownOpen]);
 
   return (
-    <div>
-      <DialDropdown
-        items={items}
-        onOpenChange={(open) => setIsDropdownOpen(open)}
-      >
-        <DialButton
-          {...props}
-          iconAfter={icon}
-          variant={variant || ButtonVariant.Primary}
-          appearance={appearance || ButtonAppearance.Solid}
-        />
-      </DialDropdown>
-    </div>
+    <Dropdown items={items} onOpenChange={(open) => setIsDropdownOpen(open)}>
+      <DialButton
+        {...props}
+        iconAfter={icon}
+        variant={variant || ButtonVariant.Primary}
+        appearance={appearance || ButtonAppearance.Solid}
+      />
+    </Dropdown>
   );
 };

--- a/src/components/FabButton/FabButton.stories.tsx
+++ b/src/components/FabButton/FabButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FabButton, type FabButtonProps } from './FabButton';
 
 const meta = {
-  title: 'Components_2.0/FabButton',
+  title: 'Components_2_0/FabButton',
   component: FabButton,
   parameters: {
     layout: 'centered',

--- a/src/components/New/Button/Button.stories.tsx
+++ b/src/components/New/Button/Button.stories.tsx
@@ -15,7 +15,7 @@ import { ElementSize } from '@/types/size';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 
 const meta = {
-  title: 'Components_2.0/Button',
+  title: 'Components_2_0/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/src/components/New/ButtonDropdown/ButtonDropdown.stories.tsx
+++ b/src/components/New/ButtonDropdown/ButtonDropdown.stories.tsx
@@ -28,7 +28,7 @@ const longDropdownItems = [
 ];
 
 const meta: Meta<typeof ButtonDropdown> = {
-  title: 'Components_2.0/ButtonDropdown',
+  title: 'Components_2_0/ButtonDropdown',
   component: ButtonDropdown,
   parameters: {
     layout: 'padded',

--- a/src/components/New/Calendar/Calendar.stories.tsx
+++ b/src/components/New/Calendar/Calendar.stories.tsx
@@ -5,7 +5,7 @@ import { CalendarMode } from '@/types/calendar';
 import { Calendar, type CalendarProps, type CalendarValue } from './Calendar';
 
 const meta = {
-  title: 'Components_2.0/Calendar',
+  title: 'Components_2_0/Calendar',
   component: Calendar,
   parameters: {
     layout: 'padded',

--- a/src/components/New/CardShell/CardShell.stories.tsx
+++ b/src/components/New/CardShell/CardShell.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CardShell, type CardShellProps } from './CardShell';
 
 const meta = {
-  title: 'Components_2.0/CardShell',
+  title: 'Components_2_0/CardShell',
   component: CardShell,
   parameters: {
     layout: 'padded',

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -15,7 +15,6 @@ import {
   useRole,
 } from '@floating-ui/react';
 import type { Placement, ReferenceElement } from '@floating-ui/react';
-import classNames from 'classnames';
 import {
   useCallback,
   useEffect,
@@ -379,7 +378,7 @@ export const Dropdown: FC<DropdownProps> = ({
                 role="menuitem"
                 type="button"
                 aria-disabled={!!it.disabled}
-                className={classNames(
+                className={mergeClasses(
                   dropdownItemBaseClassName,
                   it.disabled && dropdownItemDisabledClassName,
                   it.danger && dropdownItemDangerClassName,
@@ -390,7 +389,7 @@ export const Dropdown: FC<DropdownProps> = ({
               >
                 {it.icon && (
                   <span
-                    className={classNames(
+                    className={mergeClasses(
                       it.danger && 'text-error',
                       it.disabled && 'text-secondary',
                     )}
@@ -399,7 +398,7 @@ export const Dropdown: FC<DropdownProps> = ({
                   </span>
                 )}
                 <span
-                  className={classNames(
+                  className={mergeClasses(
                     'flex-1 truncate text-start',
                     it.danger && 'text-error',
                     it.disabled && 'text-secondary',
@@ -463,7 +462,7 @@ export const Dropdown: FC<DropdownProps> = ({
     <>
       <span
         ref={refs.setReference}
-        className={classNames(
+        className={mergeClasses(
           dropdownBaseClassName,
           disabled && '!cursor-not-allowed opacity-75',
           className,
@@ -488,7 +487,7 @@ export const Dropdown: FC<DropdownProps> = ({
               id={listId}
               ref={refs.setFloating}
               style={floatingStyles}
-              className={classNames(
+              className={mergeClasses(
                 dropdownListBaseClassName,
                 !matchReferenceWidth && 'w-max',
                 listClassName,

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -1,8 +1,8 @@
-import classNames from 'classnames';
 import { useCallback, type FC, type MouseEvent } from 'react';
 
 import { DialIcon } from '@/components/Icon/Icon';
 import { type DropdownItem } from '@/models/dropdown';
+import { mergeClasses } from '@/utils/merge-classes';
 import { SubMenuPanel, useSubMenuFloating } from '@/utils/sub-menu-floating';
 
 import {
@@ -10,6 +10,7 @@ import {
   dropdownItemBaseClassName,
   dropdownItemDangerClassName,
   dropdownItemDisabledClassName,
+  dropdownSubMenuClassName,
   submenuCaretIcon,
 } from './constants';
 
@@ -51,7 +52,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
         aria-expanded={isOpen}
         aria-disabled={!!item.disabled}
         disabled={item.disabled}
-        className={classNames(
+        className={mergeClasses(
           dropdownItemBaseClassName,
           item.disabled && dropdownItemDisabledClassName,
           item.className,
@@ -59,12 +60,12 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
         {...getReferenceProps()}
       >
         {item.icon && (
-          <span className={classNames(item.disabled && 'text-secondary')}>
+          <span className={mergeClasses(item.disabled && 'text-secondary')}>
             <DialIcon icon={item.icon} />
           </span>
         )}
         <span
-          className={classNames(
+          className={mergeClasses(
             'flex-1 truncate text-start',
             item.disabled && 'text-secondary',
           )}
@@ -72,7 +73,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
           {item.label}
         </span>
         <span
-          className={classNames(
+          className={mergeClasses(
             'ml-auto shrink-0',
             item.disabled && 'text-secondary',
           )}
@@ -88,46 +89,44 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
           context={context}
           getFloatingProps={getFloatingProps}
           role="menu"
-          className="w-max"
+          surfaceClassName={dropdownSubMenuClassName}
         >
-          <div role="none" className="py-1">
-            {item.children!.map((child) => (
-              <button
-                key={child.key}
-                role="menuitem"
-                type="button"
-                aria-disabled={!!child.disabled}
-                disabled={child.disabled}
-                className={classNames(
-                  dropdownItemBaseClassName,
-                  child.disabled && dropdownItemDisabledClassName,
-                  child.danger && dropdownItemDangerClassName,
-                  child.className,
-                )}
-                onClick={handleChildClick(child)}
-              >
-                {child.icon && (
-                  <span
-                    className={classNames(
-                      child.danger && 'text-error',
-                      child.disabled && 'text-secondary',
-                    )}
-                  >
-                    <DialIcon icon={child.icon} />
-                  </span>
-                )}
+          {item.children!.map((child) => (
+            <button
+              key={child.key}
+              role="menuitem"
+              type="button"
+              aria-disabled={!!child.disabled}
+              disabled={child.disabled}
+              className={mergeClasses(
+                dropdownItemBaseClassName,
+                child.disabled && dropdownItemDisabledClassName,
+                child.danger && dropdownItemDangerClassName,
+                child.className,
+              )}
+              onClick={handleChildClick(child)}
+            >
+              {child.icon && (
                 <span
-                  className={classNames(
-                    'flex-1 truncate text-start',
+                  className={mergeClasses(
                     child.danger && 'text-error',
                     child.disabled && 'text-secondary',
                   )}
                 >
-                  {child.label}
+                  <DialIcon icon={child.icon} />
                 </span>
-              </button>
-            ))}
-          </div>
+              )}
+              <span
+                className={mergeClasses(
+                  'flex-1 truncate text-start',
+                  child.danger && 'text-error',
+                  child.disabled && 'text-secondary',
+                )}
+              >
+                {child.label}
+              </span>
+            </button>
+          ))}
         </SubMenuPanel>
       )}
     </>

--- a/src/components/New/Dropdown/constants.tsx
+++ b/src/components/New/Dropdown/constants.tsx
@@ -1,27 +1,30 @@
 import { IconChevronRight } from '@tabler/icons-react';
-import classNames from 'classnames';
 
 import {
   overlayGap,
   overlayItemClassName,
   overlayItemDisabledClassName,
+  overlaySubMenuClassName,
   overlaySurfaceClassName,
 } from '@/components/New/constants/overlay';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { mergeClasses } from '@/utils/merge-classes';
 
-export const dropdownBaseClassName = classNames(
+export const dropdownBaseClassName = mergeClasses(
   'flex items-center gap-2 align-middle',
   'h-auto px-0 bg-transparent border-0',
 );
 
-export const dropdownListBaseClassName = classNames(
+export const dropdownListBaseClassName = mergeClasses(
   'z-[53] focus-visible:outline-none',
   overlaySurfaceClassName,
 );
 
+export const dropdownSubMenuClassName = overlaySubMenuClassName;
+
 export const dropdownItemBaseClassName = overlayItemClassName;
 
-export const dropdownItemDisabledClassName = classNames(
+export const dropdownItemDisabledClassName = mergeClasses(
   overlayItemDisabledClassName,
   '!cursor-not-allowed',
 );

--- a/src/components/New/FolderPath/FolderPath.stories.tsx
+++ b/src/components/New/FolderPath/FolderPath.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FolderPath, type FolderPathProps } from './FolderPath';
 
 const meta = {
-  title: 'Components_2.0/FolderPath',
+  title: 'Components_2_0/FolderPath',
   component: FolderPath,
   parameters: {
     layout: 'padded',

--- a/src/components/New/Highlight/Highlight.stories.tsx
+++ b/src/components/New/Highlight/Highlight.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Highlight, type HighlightProps } from './Highlight';
 
 const meta = {
-  title: 'Components_2.0/Highlight',
+  title: 'Components_2_0/Highlight',
   component: Highlight,
   parameters: {
     layout: 'padded',

--- a/src/components/New/IconButton/IconButton.stories.tsx
+++ b/src/components/New/IconButton/IconButton.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from './IconButtonWrappers';
 
 const meta = {
-  title: 'Components_2.0/IconButton',
+  title: 'Components_2_0/IconButton',
   component: IconButton,
   parameters: {
     layout: 'centered',

--- a/src/components/New/InlineSelect/InlineSelect.stories.tsx
+++ b/src/components/New/InlineSelect/InlineSelect.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from './InlineSelect';
 
 const meta = {
-  title: 'Components_2.0/InlineSelectTrigger',
+  title: 'Components_2_0/InlineSelectTrigger',
   component: InlineSelectTrigger,
   parameters: {
     layout: 'centered',

--- a/src/components/New/Input/Button/InputButton.tsx
+++ b/src/components/New/Input/Button/InputButton.tsx
@@ -1,7 +1,7 @@
-import classNames from 'classnames';
 import type { FC, ReactNode } from 'react';
 
 import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
 import { IconButton } from '../../IconButton/IconButton';
 import { inputButtonClassName } from './constants';
 
@@ -36,13 +36,13 @@ export const InputButton: FC<InputButtonProps> = ({
 }) => {
   return (
     <div
-      className={classNames(
+      className={mergeClasses(
         'border-l border-tertiary',
         size === ElementSize.Standard ? 'size-[40px]' : 'size-[24px]',
       )}
     >
       <IconButton
-        className={classNames(
+        className={mergeClasses(
           inputButtonClassName,
           size === ElementSize.Small && 'p-1',
           className,

--- a/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -7,7 +7,7 @@ import { EditorThemes } from '@/types/editor';
 import { MarkdownEditor, type MarkdownEditorProps } from './MarkdownEditor';
 
 const meta = {
-  title: 'Components_2.0/MarkdownEditor',
+  title: 'Components_2_0/MarkdownEditor',
   component: MarkdownEditor,
   parameters: {
     layout: 'centered',

--- a/src/components/New/Notification/Notification.stories.tsx
+++ b/src/components/New/Notification/Notification.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from './NotificationWrapper';
 
 const meta = {
-  title: 'Components_2.0/Notification',
+  title: 'Components_2_0/Notification',
   component: Notification,
   parameters: {
     layout: 'padded',

--- a/src/components/New/Popup/Popup.tsx
+++ b/src/components/New/Popup/Popup.tsx
@@ -7,7 +7,6 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react';
-import classNames from 'classnames';
 import { type FC, type MouseEvent, type ReactNode, useId, useRef } from 'react';
 
 import { CloseButton } from '@/components/New/CloseButton/CloseButton';
@@ -144,7 +143,7 @@ export const Popup: FC<PopupProps> = ({
   return (
     <FloatingPortal id={portalId}>
       <FloatingOverlay
-        className={classNames(popupOverlayBaseClassName, overlayClassName)}
+        className={mergeClasses(popupOverlayBaseClassName, overlayClassName)}
       >
         <FloatingFocusManager
           context={context}

--- a/src/components/New/Select/Select.tsx
+++ b/src/components/New/Select/Select.tsx
@@ -1,5 +1,4 @@
 import { IconChevronDown } from '@tabler/icons-react';
-import classNames from 'classnames';
 import {
   type FC,
   type KeyboardEvent,
@@ -492,7 +491,7 @@ export const Select: FC<SelectProps> = ({
         )}
 
       {multiple && selectAll && selectableFiltered.length > 0 && (
-        <div className={classNames(selectOptionBaseClassName, 'mt-2')}>
+        <div className={mergeClasses(selectOptionBaseClassName, 'mt-2')}>
           <DialCheckbox
             id={`${fieldId}-selectAll`}
             label={selectAllLabel}
@@ -524,7 +523,7 @@ export const Select: FC<SelectProps> = ({
                   role="option"
                   aria-selected={selected}
                   aria-disabled={!!opt.disabled}
-                  className={classNames(
+                  className={mergeClasses(
                     selectOptionBaseClassName,
                     selected && selectOptionSelectedClassName,
                     opt.disabled && selectOptionDisabledClassName,
@@ -575,7 +574,7 @@ export const Select: FC<SelectProps> = ({
                 aria-selected={selected}
                 aria-disabled={!!opt.disabled}
                 disabled={opt.disabled}
-                className={classNames(
+                className={mergeClasses(
                   selectOptionBaseClassName,
                   opt.disabled && selectOptionDisabledClassName,
                 )}
@@ -644,7 +643,7 @@ export const Select: FC<SelectProps> = ({
               <IconChevronDown
                 size={isSmall ? DIAL_ICON_SIZE.SM : DIAL_ICON_SIZE.MD}
                 aria-hidden="true"
-                className={classNames(
+                className={mergeClasses(
                   selectFieldIconClassName,
                   isOpen && 'rotate-180',
                 )}
@@ -660,11 +659,10 @@ export const Select: FC<SelectProps> = ({
             wrapperClassName={mergeClasses(
               !disabled && 'cursor-pointer',
               multiple &&
-                hasSelection &&
-                classNames(
+                hasSelection && [
                   '!h-auto flex-wrap py-1.5',
                   isSmall ? 'min-h-[24px]' : 'min-h-[40px]',
-                ),
+                ],
               fieldClassName,
             )}
             className={mergeClasses(

--- a/src/components/New/Select/SelectSubMenuItem.tsx
+++ b/src/components/New/Select/SelectSubMenuItem.tsx
@@ -1,16 +1,17 @@
-import { IconChevronRight } from '@tabler/icons-react';
-import classNames from 'classnames';
 import { type FC } from 'react';
 
 import { DialIcon } from '@/components/Icon/Icon';
 import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import { type SelectOption } from '@/models/select';
+import { mergeClasses } from '@/utils/merge-classes';
 import { SubMenuPanel, useSubMenuFloating } from '@/utils/sub-menu-floating';
 
 import {
   selectOptionBaseClassName,
   selectOptionCheckIcon,
   selectOptionDisabledClassName,
+  selectSubMenuCaretIcon,
+  selectSubMenuClassName,
   selectSubMenuGap,
 } from './constants';
 
@@ -49,7 +50,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
         aria-selected={!!parentSelected}
         aria-disabled={!!opt.disabled}
         disabled={opt.disabled}
-        className={classNames(
+        className={mergeClasses(
           selectOptionBaseClassName,
           opt.disabled && selectOptionDisabledClassName,
         )}
@@ -59,7 +60,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
           {opt.icon && <DialIcon icon={opt.icon} />}
           <DialEllipsisTooltip text={opt.labelNode ?? opt.label} />
         </div>
-        <IconChevronRight size={14} className="shrink-0" />
+        <span className="shrink-0">{selectSubMenuCaretIcon}</span>
       </button>
 
       {isOpen && (
@@ -69,7 +70,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
           context={context}
           getFloatingProps={getFloatingProps}
           role="listbox"
-          className="w-max py-1"
+          surfaceClassName={selectSubMenuClassName}
         >
           {opt.children!.map((child) => {
             const childSelected = selectedValues.includes(child.value);
@@ -81,7 +82,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
                 aria-selected={childSelected}
                 aria-disabled={!!child.disabled}
                 disabled={child.disabled}
-                className={classNames(
+                className={mergeClasses(
                   selectOptionBaseClassName,
                   child.disabled && selectOptionDisabledClassName,
                 )}

--- a/src/components/New/Select/constants.tsx
+++ b/src/components/New/Select/constants.tsx
@@ -12,7 +12,6 @@ import {
   overlayItemDisabledClassName,
   overlayItemSelectedClassName,
   overlaySubMenuClassName,
-  overlaySurfaceClassName,
 } from '@/components/New/constants/overlay';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { mergeClasses } from '@/utils/merge-classes';

--- a/src/components/New/Select/constants.tsx
+++ b/src/components/New/Select/constants.tsx
@@ -1,27 +1,25 @@
 import {
   IconCheck,
+  IconChevronRight,
   IconClipboardX,
   IconSearch,
   IconX,
 } from '@tabler/icons-react';
-
-import classNames from 'classnames';
 
 import {
   overlayGap,
   overlayItemClassName,
   overlayItemDisabledClassName,
   overlayItemSelectedClassName,
+  overlaySubMenuClassName,
   overlaySurfaceClassName,
 } from '@/components/New/constants/overlay';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { mergeClasses } from '@/utils/merge-classes';
 
-export const selectOverlayBaseClassName = classNames(
-  'w-full flex flex-col',
-  overlaySurfaceClassName,
-);
+export const selectOverlayBaseClassName = mergeClasses('w-full flex flex-col');
 
-export const selectOptionBaseClassName = classNames(
+export const selectOptionBaseClassName = mergeClasses(
   overlayItemClassName,
   // The row ends with a check icon, so label and mark sit at opposite edges.
   'justify-between',
@@ -44,6 +42,12 @@ export const selectListWidthClassName = '!max-w-[var(--reference-width)]';
 export const selectOptionDisabledClassName = overlayItemDisabledClassName;
 export const dropdownMenuMaxHeight = 352;
 export const selectSubMenuGap = overlayGap;
+export const selectSubMenuClassName = overlaySubMenuClassName;
+
+/** Marks an option that opens a nested list. Matches the dropdown's caret. */
+export const selectSubMenuCaretIcon = (
+  <IconChevronRight size={DIAL_ICON_SIZE.SM} aria-hidden="true" />
+);
 
 /** Classes for the chevron rendered as the field's trailing icon. */
 export const selectFieldIconClassName = 'text-secondary transition-transform';

--- a/src/components/New/constants/overlay.ts
+++ b/src/components/New/constants/overlay.ts
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { mergeClasses } from '@/utils/merge-classes';
 
 /**
  * Styling shared by the 2.0 floating surfaces — the dropdown menu and the select
@@ -11,10 +11,21 @@ export const overlaySurfaceClassName =
   'rounded-xl bg-layer-raised p-1 shadow-md';
 
 /**
+ * A nested panel opened from a row of the surface above it. It is the same
+ * object as its parent panel, so it reads from `overlaySurfaceClassName` too —
+ * only the width behaviour differs, since a submenu is sized by its own content
+ * rather than by the trigger further up.
+ */
+export const overlaySubMenuClassName = mergeClasses(
+  overlaySurfaceClassName,
+  'w-max',
+);
+
+/**
  * A selectable row inside the panel. Keeps a visible focus ring: these rows are
  * reached by keyboard, and the 1.0 versions suppressed the ring outright.
  */
-export const overlayItemClassName = classNames(
+export const overlayItemClassName = mergeClasses(
   'flex w-full cursor-pointer items-center gap-2 px-3 h-[40px] rounded-lg',
   'dial-small-text text-primary truncate',
   'hover:bg-accent-primary-alpha',

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -7,6 +7,7 @@ An MCP (Model Context Protocol) server that gives AI agents fast, structured acc
 Storybook documents components for humans. The MCP server documents them for AI agents. When an AI assistant needs to build a UI with your components, it can:
 
 - **Discover all available components** — Button, Input, Dropdown, FileManager, Form, etc.
+- **Land on the current generation** — 2.0 components rank first, and legacy 1.0 components point at their replacement
 - **Read exact props and types** — required fields, defaults, enums, component-specific behaviors
 - **Access code examples** — copy-paste usage patterns for common scenarios
 - **Query theming & typography** — available design tokens, CSS classes, color variables
@@ -69,8 +70,18 @@ When implementing or modifying components, forms, or UI built with `@epam/ai-dia
 
 **Always prefer UI kit components over raw HTML elements.** Before reaching for native `<button>`, `<input>`, `<select>`, or other HTML elements:
 
-1. **Look for a UI kit component** — Check if a suitable `Dial*` component exists for your use case
+1. **Look for a UI kit component** — search the MCP server for one that fits the use case
 2. **Use raw elements only as last resort** — If and only if no UI kit component meets the requirements, use native HTML (and document why)
+
+## Generation 2.0 First
+
+The kit ships two generations of components. **Generation 2.0 is the current design system — default to it.**
+
+- 2.0 components are exported **without** the `Dial` prefix: `Button`, `Input`, `Select`, `Popup`.
+- 1.0 components are the legacy `Dial*` set. Most have a 2.0 replacement.
+- `searchEntity("component", …)` ranks 2.0 above 1.0 and reports a **Use instead** column; `getEntityDetails` states the generation and flags a superseded component.
+- Reach for a 1.0 component **only** when it has no 2.0 replacement (nothing in **Use instead**) — e.g. `DialGrid`, `DialFileManager`, `DialTabs`.
+- Do not mix generations for the same control in one screen.
 
 ## MCP Tools
 
@@ -100,7 +111,7 @@ Both tools accept an `entity` enum parameter:
 
 | Value | Content |
 |---|---|
-| `component` | React components (all start with `Dial`) — props, examples, categories |
+| `component` | React components — props, examples, categories, generation. 2.0 components (no `Dial` prefix) rank first; 1.0 components report their 2.0 replacement |
 | `hook` | React hooks and context providers — signatures, descriptions |
 | `util` | Utility functions — signatures, descriptions |
 | `type` | Exported TypeScript types, interfaces, and enums — members, values |
@@ -115,11 +126,12 @@ User: "Build a file upload form with validation and error messages"
 
 Agent:
   1. Calls searchEntity("component", "file upload")
-  2. Finds DialFileInput, DialFormItem, DialButton, DialNotification
+  2. Finds DialFileInput, DialFormItem (1.0, no 2.0 replacement) and Notification (2.0)
   3. Calls getEntityDetails("component", "DialFileInput")  → props, examples
   4. Calls getEntityDetails("component", "DialFormItem")   → how to wire up validation
-  5. Calls getEntityDetails("component", "DialNotification")      → error display
-  6. Generates complete form code with types and error handling
+  5. Calls getEntityDetails("component", "Notification")   → error display
+  6. Calls getEntityDetails("component", "Button")         → the 2.0 submit button
+  7. Generates complete form code with types and error handling
 ```
 
 ## Example: Migrating After a Breaking Change
@@ -147,14 +159,20 @@ The MCP server ships **inside `@epam/ai-dial-ui-kit`**:
 
 The manifest is **generated at build time** by parsing `src/index.ts` (source of truth for public exports):
 
-1. **Parse exports** — enumerate components, types, hooks, utils, constants
+1. **Parse exports** — enumerate components, types, hooks, utils, constants. Named re-export barrels are followed to the declaring file
 2. **Extract metadata** — for each export:
    - Props: from TypeScript interfaces + JSDoc `@param` tags
    - Description: from JSDoc first paragraph
    - Examples: from JSDoc `@example` fenced code blocks
    - Category: from paired `.stories.tsx` file's `title` field
-3. **Build manifest** — write `dist/components-manifest.json`
-4. **Compile server** — bundle `src/mcp/server.ts` → `dist/mcp-server.cjs`
+   - Generation: `2.0` for anything under `src/components/New/`, or whose Storybook category is `Components_2_0` (that covers 2.0 components living outside that folder, e.g. `FabButton`, `Spinner`, `Skeleton`)
+3. **Link generations** — a 1.0 `DialX` gets `supersededBy: "X"` when a 2.0 `X` exists; 2.0 entries are emitted first
+4. **Build manifest** — write `dist/components-manifest.json`
+5. **Compile server** — bundle `src/mcp/server.ts` → `dist/mcp-server.cjs`
+
+### Adding a 2.0 component
+
+Put it under `src/components/New/<Name>/`, export it from `src/index.ts` **without** the `Dial` prefix, and title its story `Components_2_0/<Name>`. Generation, ranking, and the `supersededBy` link on the 1.0 counterpart are then derived automatically — there is no list to maintain.
 
 See [Manifest Schema](#manifest-schema) for details.
 
@@ -183,6 +201,8 @@ interface Manifest {
 interface ComponentEntry {
   name: string;                  // "DialButton"
   category: string;              // from stories title
+  generation: '1.0' | '2.0';     // 2.0 = current design system, prefer it
+  supersededBy?: string;         // on 1.0 only: the 2.0 replacement, e.g. "Button"
   description: string;           // first JSDoc paragraph
   props: {
     name: string;
@@ -236,6 +256,11 @@ interface ExportEntry {
 **Props table is empty for a component**
 - Component must define a `{ComponentName}Props` interface (e.g., `DialButtonProps`)
 - Add JSDoc `@param` tags on the component declaration for descriptions
+
+**Component reports the wrong generation, or an agent keeps picking the 1.0 one**
+- A 2.0 component must either live under `src/components/New/` or carry a `Components_2_0/...` Storybook title — otherwise it is classified as 1.0
+- The `supersededBy` link is derived from names: a 1.0 `DialX` links to a 2.0 `X`. If the 2.0 replacement is named differently, no link is produced
+- Run `npm run build:manifest` and check the summary line — it reports how many components are generation 2.0
 
 **Agents confuse similar components or pick the wrong one**
 - Improve JSDoc descriptions to clearly distinguish purpose and use cases

--- a/src/mcp/generate-manifest.ts
+++ b/src/mcp/generate-manifest.ts
@@ -6,11 +6,13 @@ import {
   existsSync,
   readdirSync,
   mkdirSync,
+  statSync,
 } from 'fs';
 import { resolve, join, dirname, relative, extname } from 'path';
 import type {
   Manifest,
   ComponentEntry,
+  ComponentGeneration,
   TypeEntry,
   ExportEntry,
   PropEntry,
@@ -25,6 +27,13 @@ const ROOT = process.cwd();
 const SRC = join(ROOT, 'src');
 const DIST = join(ROOT, 'dist');
 const INDEX_PATH = join(SRC, 'index.ts');
+
+/** Every component below this path belongs to generation 2.0. */
+const GENERATION_2_0_DIR = 'components/New/';
+/** Storybook category that marks a 2.0 component living outside that path. */
+const GENERATION_2_0_CATEGORY = /^components[_ ]?2[._]0/i;
+const COMPONENTS_DIR = 'components/';
+const DIAL_PREFIX = 'Dial';
 
 // ─── AST helpers ──────────────────────────────────────────────────────────────
 
@@ -94,16 +103,33 @@ function extractJsDocInfo(node: ts.Node, sf: ts.SourceFile): JSDocInfo {
 
 // ─── file helpers ─────────────────────────────────────────────────────────────
 
+// Files are parsed repeatedly (barrel resolution, then metadata extraction), so
+// keep the ASTs for the lifetime of this one-shot build.
+const sourceFileCache = new Map<string, ts.SourceFile>();
+
 function readSf(filePath: string): ts.SourceFile {
+  const cached = sourceFileCache.get(filePath);
+  if (cached) return cached;
   const content = readFileSync(filePath, 'utf-8');
-  return ts.createSourceFile(filePath, content, ts.ScriptTarget.ES2022, true);
+  const sf = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.ES2022,
+    true,
+  );
+  sourceFileCache.set(filePath, sf);
+  return sf;
 }
 
 function resolveModulePath(spec: string, fromDir: string): string | null {
-  const base = resolve(fromDir, spec);
+  // `@/*` maps to `src/*` (tsconfig paths)
+  const base = spec.startsWith('@/')
+    ? resolve(SRC, spec.slice('@/'.length))
+    : resolve(fromDir, spec);
 
-  // Direct hit (spec already has extension)
-  if (existsSync(base)) return base;
+  // Direct hit (spec already has extension). A directory is not a hit — it must
+  // fall through to the `index` lookup below, or reading it throws EISDIR.
+  if (existsSync(base) && !statSync(base).isDirectory()) return base;
 
   // Try common extensions
   for (const ext of ['.tsx', '.ts', '.jsx', '.js']) {
@@ -122,6 +148,72 @@ function resolveModulePath(spec: string, fromDir: string): string | null {
 
 function relSrc(absPath: string): string {
   return relative(SRC, absPath).replace(/\\/g, '/');
+}
+
+/** How many `export { X } from './y'` hops to follow before giving up. */
+const MAX_REEXPORT_DEPTH = 3;
+
+function declaresName(sf: ts.SourceFile, name: string): boolean {
+  let found = false;
+
+  ts.forEachChild(sf, (node) => {
+    if (found) return;
+    if (ts.isVariableStatement(node)) {
+      found = node.declarationList.declarations.some(
+        (d) => ts.isIdentifier(d.name) && d.name.text === name,
+      );
+    } else if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isEnumDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
+      found = node.name.text === name;
+    }
+  });
+
+  return found;
+}
+
+/**
+ * Follow named re-export barrels (`export { X } from './y'`) to the file that
+ * actually declares `X` — `src/index.ts` reaches some components, such as the
+ * Analytics set, only through one. Returns `filePath` unchanged when there is
+ * nothing to follow. `export *` barrels are not traversed; none are on the
+ * public export path today.
+ */
+function resolveDeclaringFile(
+  name: string,
+  filePath: string,
+  depth = 0,
+): string {
+  if (depth >= MAX_REEXPORT_DEPTH) return filePath;
+
+  const sf = readSf(filePath);
+  if (declaresName(sf, name)) return filePath;
+
+  let next: string | null = null;
+  const dir = dirname(filePath);
+
+  ts.forEachChild(sf, (node) => {
+    if (next) return;
+    if (!ts.isExportDeclaration(node)) return;
+    if (!node.moduleSpecifier || !node.exportClause) return;
+    if (!ts.isNamedExports(node.exportClause)) return;
+    const reExports = node.exportClause.elements.some(
+      (el) => el.name.text === name,
+    );
+    if (!reExports) return;
+    next = resolveModulePath(
+      (node.moduleSpecifier as ts.StringLiteral).text,
+      dir,
+    );
+  });
+
+  return next ? resolveDeclaringFile(name, next, depth + 1) : filePath;
 }
 
 // ─── index.ts parsing ─────────────────────────────────────────────────────────
@@ -198,7 +290,14 @@ function parseIndexFile(): IndexExport[] {
       for (const element of node.exportClause.elements) {
         const isTypeOnly = node.isTypeOnly || element.isTypeOnly;
         const name = element.name.text;
-        records.push({ name, isTypeOnly, resolvedPath, section });
+        // `export { Local as Public }` — barrels re-export the local name
+        const localName = element.propertyName?.text ?? name;
+        records.push({
+          name,
+          isTypeOnly,
+          resolvedPath: resolveDeclaringFile(localName, resolvedPath),
+          section,
+        });
       }
       return;
     }
@@ -407,6 +506,50 @@ function appendLazyDescriptionNote(
   return description ? `${description}\n\n${lazyNote}` : lazyNote;
 }
 
+/**
+ * Whether an export from the `component` section of `index.ts` should be
+ * documented as a component. The `Dial` prefix is being dropped as components
+ * move to generation 2.0, so the prefix alone can no longer decide this —
+ * anything that is a PascalCase export out of `src/components/` qualifies.
+ * Enums and types that happen to live there are filtered out downstream, when
+ * `buildComponentEntry` finds no component declaration and returns `null`.
+ */
+function isComponentExport(rec: IndexExport): boolean {
+  if (rec.name.startsWith(DIAL_PREFIX)) return true;
+  if (!relSrc(rec.resolvedPath).startsWith(COMPONENTS_DIR)) return false;
+  return /^[A-Z][A-Za-z0-9]*$/.test(rec.name);
+}
+
+/**
+ * Generation 2.0 components mostly live under `components/New/`, but a few
+ * (`FabButton`, `Spinner`, `Skeleton`) sit next to the 1.0 set and declare
+ * themselves through their Storybook category instead.
+ */
+function resolveGeneration(
+  rec: IndexExport,
+  category: string,
+): ComponentGeneration {
+  if (relSrc(rec.resolvedPath).startsWith(GENERATION_2_0_DIR)) return '2.0';
+  return GENERATION_2_0_CATEGORY.test(category) ? '2.0' : '1.0';
+}
+
+/**
+ * Link each 1.0 component to its 2.0 replacement, matching `DialX` → `X`.
+ * Mutates the entries in place.
+ */
+function linkSupersededComponents(components: ComponentEntry[]): void {
+  const names2_0 = new Set(
+    components.filter((c) => c.generation === '2.0').map((c) => c.name),
+  );
+
+  for (const comp of components) {
+    if (comp.generation !== '1.0') continue;
+    if (!comp.name.startsWith(DIAL_PREFIX)) continue;
+    const replacement = comp.name.slice(DIAL_PREFIX.length);
+    if (names2_0.has(replacement)) comp.supersededBy = replacement;
+  }
+}
+
 function buildComponentEntry(rec: IndexExport): ComponentEntry | null {
   const sf = readSf(rec.resolvedPath);
   let description = '';
@@ -452,6 +595,7 @@ function buildComponentEntry(rec: IndexExport): ComponentEntry | null {
   const entry: ComponentEntry = {
     name: rec.name,
     category,
+    generation: resolveGeneration(rec, category),
     description: finalDescription,
     props,
     examples,
@@ -714,12 +858,16 @@ function buildManifest(): Manifest {
 
     try {
       if (rec.section === 'component' && !rec.isTypeOnly) {
-        // Only Dial* names are components; others (wrappers, providers) go to hooks
-        if (rec.name.startsWith('Dial')) {
-          const entry = buildComponentEntry(rec);
-          if (entry) components.push(entry);
+        const entry = isComponentExport(rec) ? buildComponentEntry(rec) : null;
+        if (entry) {
+          components.push(entry);
         } else {
-          hooks.push(buildExportEntry(rec));
+          // Enums and types are exported from this section too (e.g. the 2.0
+          // `NotificationVariant`); document them as types so components can
+          // reference them. Anything else is a wrapper, provider, or helper.
+          const typeEntry = buildTypeEntry(rec);
+          if (typeEntry) types.push(typeEntry);
+          else hooks.push(buildExportEntry(rec));
         }
       } else if (rec.section === 'types' || rec.section === 'models') {
         const entry = buildTypeEntry(rec);
@@ -739,6 +887,14 @@ function buildManifest(): Manifest {
       console.warn(`Skipping ${rec.name}: ${(e as Error).message}`);
     }
   }
+
+  linkSupersededComponents(components);
+
+  // Emit 2.0 first so anything reading the manifest directly — or taking an
+  // unranked slice of it — sees the current generation before the legacy one.
+  components.sort((a, b) =>
+    a.generation === b.generation ? 0 : a.generation === '2.0' ? -1 : 1,
+  );
 
   // Deduplicate types by name (enums may appear in both 'types' and 'models' sections)
   const seenTypes = new Set<string>();
@@ -780,8 +936,12 @@ function main(): void {
   console.log(
     `Manifest written to ${outPath.replace(ROOT, '.').replace(/\\/g, '/')}`,
   );
+  const count2_0 = manifest.components.filter(
+    (c) => c.generation === '2.0',
+  ).length;
   console.log(
-    `  ${manifest.components.length} components, ${manifest.types.length} types, ` +
+    `  ${manifest.components.length} components (${count2_0} generation 2.0), ` +
+      `${manifest.types.length} types, ` +
       `${manifest.hooks.length} hooks, ${manifest.utils.length} utils, ` +
       `${manifest.constants.length} constants${ext ? '' : ''}`,
   );

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -132,6 +132,7 @@ const ENTITY_HINT = ENTITY_KINDS.join(' | ');
 function cell(value: string): string {
   return value
     .replace(/\s*\n\s*/g, ' ')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .trim();
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -128,13 +128,36 @@ const ENTITY_HINT = ENTITY_KINDS.join(' | ');
 
 // ─── format helpers ───────────────────────────────────────────────────────────
 
+/** Collapse a value into something safe to put in a markdown table cell. */
+function cell(value: string): string {
+  return value
+    .replace(/\s*\n\s*/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim();
+}
+
+const GENERATION_GUIDANCE =
+  'Components come in two generations. Generation 2.0 is the current design system — prefer it. ' +
+  'Reach for a 1.0 component only when it has no 2.0 equivalent (no `supersededBy` on the entry).';
+
 function formatComponent(comp: ComponentEntry): string {
   const lines: string[] = [
     `# ${comp.name}`,
     `**Category:** ${comp.category}`,
+    `**Generation:** ${comp.generation}`,
     `**Source:** \`${comp.sourceFile}\``,
     '',
   ];
+
+  if (comp.supersededBy) {
+    lines.push(
+      `> ⚠️ **Generation 1.0 — superseded by \`${comp.supersededBy}\`.** ` +
+        `Use \`${comp.supersededBy}\` for new code and prefer it when touching existing code; ` +
+        `see getEntityDetails(entity: "component", name: "${comp.supersededBy}"). ` +
+        `Only stay on \`${comp.name}\` if the 2.0 replacement is missing something you need.`,
+      '',
+    );
+  }
 
   if (comp.description) lines.push(comp.description, '');
 
@@ -241,7 +264,15 @@ function collectTypeRefs(comp: ComponentEntry): string[] {
 
 // ─── search ───────────────────────────────────────────────────────────────────
 
+/**
+ * Score bonus that ranks a generation 2.0 component above its 1.0 counterpart.
+ * Applied only to entries that already matched, so it never pulls an unrelated
+ * 2.0 component into the results.
+ */
+const GENERATION_2_0_BONUS = 30;
+
 function searchComponents(query: string): ComponentEntry[] {
+  // The manifest is emitted 2.0-first, so an unranked slice already prefers it.
   if (!query.trim()) return manifest.components.slice(0, 20);
   const q = query.toLowerCase();
   return manifest.components
@@ -255,6 +286,7 @@ function searchComponents(query: string): ComponentEntry[] {
       else if (name.includes(q)) score = 60;
       if (desc.includes(q)) score += 20;
       if (cat.includes(q)) score += 10;
+      if (score > 0 && c.generation === '2.0') score += GENERATION_2_0_BONUS;
       return { c, score };
     })
     .filter((s) => s.score > 0)
@@ -314,7 +346,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'searchEntity',
       description:
-        'Search for UI kit entities (components, hooks, utils, types, constants) by name or description. Returns a summary list of matches. For typography and theming, returns the full reference content regardless of query.\n\nExamples:\n  searchEntity("component", "button") → lists Button-related components\n  searchEntity("hook", "click") → lists hooks with "click" in name/description\n  searchEntity("typography") → returns full typography CSS class reference',
+        'Search for UI kit entities (components, hooks, utils, types, constants) by name or description. Returns a summary list of matches. For typography and theming, returns the full reference content regardless of query.\n\nComponents come in two generations and results are ranked 2.0 first. Generation 2.0 is the current design system (exported without the `Dial` prefix — `Button`, `Input`, `Select`); generation 1.0 is the legacy set (`Dial*`). Default to the 2.0 component. A 1.0 result carries "Use instead" when a 2.0 replacement exists — pick that replacement. Only use a 1.0 component when it has no replacement listed.\n\nExamples:\n  searchEntity("component", "button") → Button (2.0) ranked above DialButton (1.0)\n  searchEntity("hook", "click") → lists hooks with "click" in name/description\n  searchEntity("typography") → returns full typography CSS class reference',
       inputSchema: {
         type: 'object',
         properties: {
@@ -336,7 +368,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'getEntityDetails',
       description:
-        'Get full documentation for a specific UI kit entity by exact name — props table, examples, signatures, type members, etc. For typography and theming, returns the full reference content (name not required).\n\nExamples:\n  getEntityDetails("component", "DialButton") → full props + examples\n  getEntityDetails("type", "ButtonSize") → enum values\n  getEntityDetails("hook", "useClickOutside") → signature + description\n  getEntityDetails("theming") → full CSS variable and token reference',
+        'Get full documentation for a specific UI kit entity by exact name — props table, examples, signatures, type members, etc. For typography and theming, returns the full reference content (name not required).\n\nA component response states its generation. If it reports being superseded by a 2.0 component, look that one up instead of using the 1.0 entry.\n\nExamples:\n  getEntityDetails("component", "Button") → full props + examples for the 2.0 button\n  getEntityDetails("component", "DialButton") → 1.0 button, flagged as superseded by `Button`\n  getEntityDetails("type", "ButtonSize") → enum values\n  getEntityDetails("hook", "useClickOutside") → signature + description\n  getEntityDetails("theming") → full CSS variable and token reference',
       inputSchema: {
         type: 'object',
         properties: {
@@ -416,8 +448,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
       const header = query
-        ? `Found ${results.length} component(s) matching "${query}":`
-        : `First ${results.length} components (pass a query to filter):`;
+        ? `Found ${results.length} component(s) matching "${query}", best match first:`
+        : `First ${results.length} components, generation 2.0 first (pass a query to filter):`;
       return {
         content: [
           {
@@ -425,10 +457,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: [
               header,
               '',
-              '| Name | Category | Description |',
-              '|------|----------|-------------|',
+              GENERATION_GUIDANCE,
+              '',
+              '| Name | Gen | Use instead | Category | Description |',
+              '|------|-----|-------------|----------|-------------|',
               ...results.map(
-                (c) => `| \`${c.name}\` | ${c.category} | ${c.description} |`,
+                (c) =>
+                  `| \`${c.name}\` | ${c.generation} | ` +
+                  `${c.supersededBy ? `\`${c.supersededBy}\`` : '—'} | ` +
+                  `${cell(c.category)} | ${cell(c.description)} |`,
               ),
               '',
               'Use getEntityDetails(entity: "component", name: "...") for full props and examples.',
@@ -463,7 +500,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               '| Name | Kind | Description |',
               '|------|------|-------------|',
               ...results.map(
-                (t) => `| \`${t.name}\` | ${t.kind} | ${t.description ?? ''} |`,
+                (t) =>
+                  `| \`${t.name}\` | ${t.kind} | ${cell(t.description ?? '')} |`,
               ),
               '',
               'Use getEntityDetails(entity: "type", name: "...") for members and values.',
@@ -503,7 +541,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             '',
             '| Name | Description |',
             '|------|-------------|',
-            ...results.map((e) => `| \`${e.name}\` | ${e.description ?? ''} |`),
+            ...results.map(
+              (e) => `| \`${e.name}\` | ${cell(e.description ?? '')} |`,
+            ),
             '',
             `Use getEntityDetails(entity: "${entity}", name: "...") for full signature.`,
           ].join('\n'),
@@ -531,8 +571,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (entity === 'component') {
       const comp = manifest.components.find((c) => c.name === entityName);
       if (!comp) {
+        // The `Dial` prefix is dropped in generation 2.0, so a miss is often
+        // just the other generation's spelling of the same component.
+        const alt = manifest.components.find(
+          (c) =>
+            c.name === `Dial${entityName}` ||
+            c.name === entityName.replace(/^Dial/, ''),
+        );
         throw new Error(
-          `Component "${entityName}" not found. Use searchEntity(entity: "component") to browse available components.`,
+          `Component "${entityName}" not found.${
+            alt
+              ? ` Did you mean "${alt.name}" (generation ${alt.generation})?`
+              : ''
+          } Use searchEntity(entity: "component") to browse available components.`,
         );
       }
       return { content: [{ type: 'text', text: formatComponent(comp) }] };

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -13,9 +13,22 @@ export interface LazyComponentEntry {
   nextDynamicExample: string;
 }
 
+/**
+ * Component generation. `2.0` components live under `src/components/New/` and
+ * are exported without the `Dial` prefix; everything else is `1.0`.
+ */
+export type ComponentGeneration = '1.0' | '2.0';
+
 export interface ComponentEntry {
   name: string;
   category: string;
+  /** `2.0` components are the current design system and should be preferred. */
+  generation: ComponentGeneration;
+  /**
+   * Present on `1.0` components that have a `2.0` replacement — the name of
+   * that replacement (e.g. `DialButton` → `Button`).
+   */
+  supersededBy?: string;
   description: string;
   props: PropEntry[];
   examples: string[];

--- a/src/utils/sub-menu-floating.tsx
+++ b/src/utils/sub-menu-floating.tsx
@@ -80,10 +80,19 @@ interface SubMenuPanelProps {
   context: ReturnType<typeof useSubMenuFloating>['context'];
   getFloatingProps: ReturnType<typeof useSubMenuFloating>['getFloatingProps'];
   role: 'menu' | 'listbox';
+  /**
+   * Replaces the surface tokens — radius, background, shadow, inset. The 2.0
+   * menus pass their own overlay surface so a submenu is the same object as the
+   * panel that opened it; the 1.0 menus keep the default.
+   */
+  surfaceClassName?: string;
   /** Extra classes appended to the default floating container classes. */
   className?: string;
   children: ReactNode;
 }
+
+/** Surface of the 1.0 submenus, kept as the default for their sake. */
+const subMenuSurfaceClassName = 'rounded bg-layer-0 shadow';
 
 /**
  * Shared floating panel wrapper (FloatingPortal → FloatingFocusManager → container div).
@@ -95,6 +104,7 @@ export const SubMenuPanel = ({
   context,
   getFloatingProps,
   role,
+  surfaceClassName,
   className,
   children,
 }: SubMenuPanelProps) => (
@@ -110,7 +120,8 @@ export const SubMenuPanel = ({
         style={floatingStyles}
         role={role}
         className={classNames(
-          'z-[53] overflow-auto rounded bg-layer-0 text-primary shadow focus-visible:outline-none',
+          'z-[53] overflow-auto text-primary focus-visible:outline-none',
+          surfaceClassName ?? subMenuSurfaceClassName,
           className,
         )}
         {...getFloatingProps()}


### PR DESCRIPTION
**Description and UI changes:**

Agents using the MCP server could not find the generation 2.0 components at all. The manifest generator classified an export as a component only if its name started with `Dial`, so every 2.0 component (`Button`, `Input`, `Select`, `Popup`, …) was filed as a hook and lost its props table and examples. No amount of prompt-level instruction could work around that — the data simply was not there.

Components are now identified by **where they live** rather than by their name prefix. Each entry carries its `generation` (`1.0` | `2.0`), and a 1.0 component carries `supersededBy` naming its 2.0 replacement — 26 links, derived from names and Storybook category, so there is no list to maintain. `searchEntity` ranks 2.0 above 1.0 and reports a **Use instead** column; `getEntityDetails` flags a superseded component and, on a name miss, suggests the other generation's spelling. Both tool descriptions state the rule, so it reaches agents whose project never copied the instruction block.

The manifest goes from **80 to 133 components, 49 of them generation 2.0**.

Fixed along the way:

- named re-export barrels are followed to the declaring file, restoring the five Analytics components that resolved to a directory (`EISDIR`)
- enums exported from the component section (`NotificationVariant`, `CalendarMode`) are documented as types instead of hooks
- multi-line JSDoc descriptions and unescaped `|` no longer break the markdown tables in search results
- 2.0 story titles are unified under `Components_2_0/`, which was split between two spellings and showed up as two sidebar sections and two MCP categories for one generation

**Dropdown / Select submenu surface (UI):**

A 2.0 submenu did not look like the panel that opened it — it rendered on the 1.0 surface (`rounded bg-layer-0 shadow`) with its own `py-1` padding wrapper. `SubMenuPanel` now takes an optional `surfaceClassName`; the 2.0 dropdown and select pass the shared `overlaySubMenuClassName` (the overlay surface plus `w-max`, since a submenu is sized by its own content), and the 1.0 menus keep the old surface as the default. The select's submenu caret is moved into `constants.tsx` so it matches the dropdown's, and `DialButtonDropdown` now renders the 2.0 `Dropdown` and drops its redundant wrapper `<div>`. `classNames` is replaced with `mergeClasses` in the touched 2.0 files, per the styling rules.

Issues:

- n/a

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added

_No new components in this PR — the New Component Checklist does not apply._
