### PR TITLE
fix: DialGrid row background falls back to deepest legacy layer (Issue epam/ai-dial-admin-frontend#4108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versions match the git tags on the `development` branch.
 
 ### Fixed
 
+- **`DialGrid` — the legacy-token fallback inverted the raised/sunken relationship** — when a host defines the legacy DIAL layers but not `--bg-layer-raised`, the row surface fell back to `--bg-layer-0`, the _deepest_ layer in that palette (`#000000` in the DIAL dark theme), while odd rows fell back to the lighter `--bg-layer-2`. A grid whose base surface sits below its own sunken rows reads as inside-out, and pure black matches no other surface in the theme. The fallback is now `--bg-layer-3`, the elevated layer, which is what consumers already use for their own grid surfaces. The light default when no theme is present is unchanged (`#FCFCFC`).
 - **`Notification` (2.0)** — the variant icon is hidden from assistive tech. The `loading` spinner carries its own `role="status"`, so it previously formed a live region nested inside the notification's, announcing the content twice.
 - **`FolderPath`** — the `<nav>` landmark is named "Folder path" instead of inheriting `DialBreadcrumb`'s "Breadcrumb" default, which misdescribed a path with no navigable segments. Added an `ariaLabel` prop to override. Decorative folder and separator icons are now `aria-hidden`.
 - **`InlineSelect`** — the trigger now exposes `aria-expanded`, so screen readers can tell whether the dropdown is open, and accepts an `ariaLabel` prop naming the control (previously it announced only its current value).

--- a/src/components/Grid/constants.ts
+++ b/src/components/Grid/constants.ts
@@ -3,7 +3,7 @@ export const checkboxClass = '.ag-checkbox-input';
 
 export const GRID_THEME_COLORS = {
   accentColor: 'var(--bg-control-accent, var(--bg-accent-primary, #5C8DEA))',
-  backgroundColor: 'var(--bg-layer-raised, var(--bg-layer-0, #FCFCFC))',
+  backgroundColor: 'var(--bg-layer-raised, var(--bg-layer-3, #FCFCFC))',
   oddRowBackgroundColor: 'var(--bg-layer-sunken, var(--bg-layer-2, #EEF1F7))',
   selectedRowBackgroundColor:
     'var(--controls-bg-accent-primary-alpha-active, var(--bg-accent-primary-alpha, #7DA4FF26))',


### PR DESCRIPTION
**Description and UI changes:**

Follow-up to #806. That PR added legacy-token fallbacks to `GRID_THEME_COLORS` so hosts still on the old DIAL layer tokens get a dark grid instead of the light default. The fallback it chose for the row surface points the wrong way:

```ts
backgroundColor:       'var(--bg-layer-raised, var(--bg-layer-0, #FCFCFC))'  // deepest layer
oddRowBackgroundColor: 'var(--bg-layer-sunken, var(--bg-layer-2, #EEF1F7))'  // lighter layer
```

In the legacy palette the layers ascend from deepest to most elevated (`bg-layer-0` `#000000` → `bg-layer-4` `#242C42`). So a host that defines the legacy tokens but not `--bg-layer-raised` gets:

- base rows at `--bg-layer-0` = **`#000000`**, pure black, matching no other surface in the theme
- odd rows at `--bg-layer-2` = `#161B2D`, **lighter than the base row**

The raised/sunken relationship is inverted — the base surface sits below its own sunken rows.

This PR points the legacy fallback at `--bg-layer-3` (`#1D2439`), the elevated layer that consumers already use for their own grid surfaces, which also keeps `--bg-layer-2` correctly reading as sunken beneath it. One line:

```diff
-  backgroundColor: 'var(--bg-layer-raised, var(--bg-layer-0, #FCFCFC))',
+  backgroundColor: 'var(--bg-layer-raised, var(--bg-layer-3, #FCFCFC))',
```

The innermost light default (`#FCFCFC`) is untouched, so the documented "default color palette is light when no themes presented" behaviour is unchanged. Only the legacy-token step moves.

**How this surfaced:** in DIAL Admin the Assets lists (Models, Applications, Prompts, Files, …) render through `DialFileManager` → `DialGrid`, so they pick up this theme while other grids in the app use the host's own. With ui-kit `0.13.0-dev.36` the rows were `#FCFCFC` under light theme text — invisible content. `dev.45` (#806) made the text readable but turned the rows pure black, still inconsistent with every other grid in the app.

**Wider context, not addressed here:** `--bg-layer-raised` / `--bg-layer-sunken` are among ~37 tokens referenced by `dist/index.css` that the DIAL themes service (`epam/ai-dial-chat-themes`, `static/config.json`) does not define — it ships only `bg-layer-0`…`bg-layer-4`. The rest (`--bg-control-*`, `--stroke-focus-black`, `--text-control-*`, …) still fall through to light defaults on dark-themed hosts, which is why ui-kit inputs render with light backgrounds there. The durable fix is for the themes service to ship the 2.0 token set; per-component legacy fallbacks like this one are a stopgap. Happy to open a separate issue to track that if useful.

Issues:

- Issue epam/ai-dial-admin-frontend#4108

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` — the issue lives in `epam/ai-dial-admin-frontend`, so it is fully qualified

**New Component Checklist:**

n/a — no new component; a single constant value changed, no API or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
