### PR TITLE
fix: allow typing when full NumberInput value is selected and within max constraint

### DIFF
--- a/src/components/New/Input/utils.ts
+++ b/src/components/New/Input/utils.ts
@@ -59,14 +59,21 @@ export const handleKeyDown = (
     return;
   }
 
-  // Check if the resulting value would be within range
-  if (min !== undefined || max !== undefined) {
+  // Check if the resulting value would be within range. Native `type="number"`
+  // inputs never expose selectionStart/selectionEnd (always null), so the
+  // replaced-text range can't be computed reliably there — skip the
+  // pre-check and let onChange validate the final value instead.
+  if (
+    (min !== undefined || max !== undefined) &&
+    e.currentTarget.selectionStart !== null
+  ) {
     const currentValue = e.currentTarget.value;
-    const cursorPosition = e.currentTarget.selectionStart || 0;
+    const selectionStart = e.currentTarget.selectionStart;
+    const selectionEnd = e.currentTarget.selectionEnd ?? selectionStart;
     const newValue =
-      currentValue.slice(0, cursorPosition) +
+      currentValue.slice(0, selectionStart) +
       e.key +
-      currentValue.slice(cursorPosition);
+      currentValue.slice(selectionEnd);
     const numericValue = parseFloat(newValue);
 
     if (!isNaN(numericValue)) {


### PR DESCRIPTION
**Description and UI changes:**

allow typing when full NumberInput value is selected and within max constraint

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [x] component name starts with Dial
- [x] custom css classes has dial- prefix
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added