### PR TITLE
fix: do not commit placeholder name when creating with an invalid name

### DIFF
--- a/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.stories.tsx
+++ b/src/components/FileManager/components/FileManagerItemName/FileManagerItemName.stories.tsx
@@ -88,3 +88,60 @@ export const EditableFolder: Story = {
     elementId: 'folder-edit-1',
   },
 };
+
+/**
+ * Reproduces the create-folder scenario from
+ * https://github.com/epam/ai-dial-chat/issues/7968: type a name containing a
+ * forbidden character (e.g. "/"), leave the inline error visible, then blur
+ * the field (click outside, or press Enter which blurs the input). The
+ * creation must be cancelled instead of silently committing the "New
+ * folder" placeholder — see `useEditableItem.saveOnBlur`.
+ */
+const CreatingFolderWrapper = (props: Story['args']) => {
+  const [isCreating, setIsCreating] = useState(true);
+  const [createdFolders, setCreatedFolders] = useState<string[]>([]);
+  const [cancelCount, setCancelCount] = useState(0);
+
+  return (
+    <div className="flex flex-col items-start gap-6">
+      {isCreating && (
+        <DialFileManagerItemName
+          {...props}
+          elementId={props?.elementId ?? 'creating-folder'}
+          type={DialItemType.Folder}
+          name="New folder"
+          creating
+          validate={(v) =>
+            /[/\\]/.test(v) ? 'Folder name cannot contain "/" or "\\"' : null
+          }
+          onCreateFolderSave={(newValue) => {
+            setCreatedFolders((prev) => [...prev, newValue]);
+            setIsCreating(false);
+          }}
+          onCreateFolderCancel={() => {
+            setCancelCount((prev) => prev + 1);
+            setIsCreating(false);
+          }}
+        />
+      )}
+
+      <DialNeutralButton
+        className="Start creating a folder"
+        onClick={() => setIsCreating(true)}
+      />
+
+      <p className="dial-small-text">
+        Created folders: {createdFolders.join(', ') || 'none'}
+        <br />
+        Cancelled attempts: {cancelCount}
+      </p>
+    </div>
+  );
+};
+
+export const CreatingFolderWithInvalidName: Story = {
+  render: (args) => <CreatingFolderWrapper {...args} />,
+  args: {
+    elementId: 'creating-folder-invalid',
+  },
+};

--- a/src/hooks/__tests__/use-editable-item.spec.tsx
+++ b/src/hooks/__tests__/use-editable-item.spec.tsx
@@ -74,15 +74,19 @@ describe('Dial UI Kit :: useEditableItem :: outside click (blur)', () => {
     expect(onSave).toHaveBeenCalledWith('original');
   });
 
-  it('reverts to the default folder name and creates it on blur when invalid (creation)', () => {
+  it('cancels the creation on blur when invalid, instead of committing the default placeholder name', () => {
     const onCreateFolderSave = vi.fn();
+    const onCreateFolderCancel = vi.fn();
     render(
       <Harness
         value="New folder"
         isEditing={false}
         isCreating
         onCreateFolderSave={onCreateFolderSave}
-        // names containing % are invalid here, the default "New folder" is valid
+        onCreateFolderCancel={onCreateFolderCancel}
+        // names containing % are invalid here; the placeholder "New folder"
+        // would itself be valid, but creation must not silently substitute
+        // it for what the user actually typed (see ai-dial-chat #7968).
         onValidate={(v) => (/%/.test(v) ? 'forbidden symbol' : null)}
       />,
     );
@@ -96,7 +100,8 @@ describe('Dial UI Kit :: useEditableItem :: outside click (blur)', () => {
       fireEvent.blur(input);
     });
 
-    expect(onCreateFolderSave).toHaveBeenCalledWith('New folder');
+    expect(onCreateFolderSave).not.toHaveBeenCalled();
+    expect(onCreateFolderCancel).toHaveBeenCalledTimes(1);
   });
 
   it('cancels on blur when both the value and the default are invalid', () => {

--- a/src/hooks/use-editable-item.tsx
+++ b/src/hooks/use-editable-item.tsx
@@ -172,9 +172,13 @@ export function useEditableItem({
 
   /**
    * Commits the edit when focus leaves the input (outside click / blur).
-   * Always exits edit mode: a valid value is saved as-is, while an invalid
-   * value falls back to the default name (`initialValue`) and is committed,
-   * instead of trapping the user inside the field.
+   * Always exits edit mode: a valid value is saved as-is. When renaming an
+   * existing item, an invalid value falls back to the current name
+   * (`initialValue`) and is committed, instead of trapping the user inside
+   * the field. When creating a new item, `initialValue` is only a
+   * placeholder (e.g. "New folder") — an invalid value cancels the creation
+   * instead, since silently committing the placeholder would create an item
+   * the user never asked for.
    */
   const saveOnBlur = useCallback(() => {
     if (committedRef.current) return;
@@ -185,14 +189,22 @@ export function useEditableItem({
       return;
     }
 
-    if (validate(initialValue)) {
+    if (!isCreating && validate(initialValue)) {
       setValue(initialValue);
       resetValidationState();
       commit(initialValue);
     } else {
       cancel();
     }
-  }, [validate, value, initialValue, commit, cancel, resetValidationState]);
+  }, [
+    validate,
+    value,
+    initialValue,
+    commit,
+    cancel,
+    resetValidationState,
+    isCreating,
+  ]);
 
   useEffect(() => {
     if (!isEditing && !isCreating) return;


### PR DESCRIPTION
## Summary
- `useEditableItem.saveOnBlur` fell back to committing `initialValue` whenever the typed value failed validation, regardless of rename vs. create.
- For rename this is a safe no-op (the item already has that name). For **create** (folder/file), it silently created an item with the default placeholder name (e.g. "New folder") instead of respecting the rejection.
- Reported downstream as `ai-dial-chat#7968`: pressing Enter on an invalid folder name (e.g. containing `/`) still created a folder, using the placeholder name, while the inline error stayed visible right up to confirmation.
- Fix: the fallback-to-default-and-commit path now only applies when renaming an existing item (`!isCreating`); creating a new item with an invalid name cancels instead via `onCreateFolderCancel`.

## Test plan
- [x] Updated `use-editable-item.spec.tsx`: the create-with-invalid-name test now asserts `onCreateFolderCancel` fires and `onCreateFolderSave` is never called (previously asserted the opposite — that it silently committed the placeholder).
- [x] `npm run test:run` — full suite passes.
- [x] `npm run typecheck` — no new errors (pre-existing unrelated errors in `use-trigger-view-create-folder.spec.tsx` confirmed present on `development` too).
- [x] `npm run lint` — clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)