### PR TITLE
fix: add bodyClassName prop to Popup

### DIFF
--- a/src/components/New/Popup/Popup.spec.tsx
+++ b/src/components/New/Popup/Popup.spec.tsx
@@ -149,6 +149,17 @@ describe('Dial UI Kit :: Popup', () => {
     expect(header).toHaveClass('custom-header-class');
   });
 
+  test('applies bodyClassName to the scrollable body wrapper', () => {
+    render(
+      <Popup open header="Body class test" bodyClassName="custom-body-class">
+        <div>Body</div>
+      </Popup>,
+    );
+
+    const body = screen.getByText('Body').parentElement;
+    expect(body).toHaveClass('custom-body-class');
+  });
+
   test('does not close on outside click when closeOnOutsideClick is false', () => {
     const onClose = vi.fn();
 

--- a/src/components/New/Popup/Popup.tsx
+++ b/src/components/New/Popup/Popup.tsx
@@ -30,6 +30,8 @@ export interface PopupProps {
   overlayClassName?: string;
   titleClassName?: string;
   headerClassName?: string;
+  /** Additional CSS classes applied to the scrollable body wrapper around `children`. */
+  bodyClassName?: string;
   children?: ReactNode;
   footer?: ReactNode;
   onClose?: (e?: MouseEvent<HTMLButtonElement> | null) => void;
@@ -78,6 +80,7 @@ export interface PopupProps {
  * @param [overlayClassName] - Additional CSS classes applied to the overlay
  * @param [titleClassName] - Additional CSS classes applied to the title element
  * @param [headerClassName] - Additional CSS classes applied to the popup header container
+ * @param [bodyClassName] - Additional CSS classes applied to the scrollable body wrapper around `children`
  * @param [children] - Body content
  * @param [footer] - Footer area for actions
  * @param [onClose] - Callback fired when the popup requests to close
@@ -96,6 +99,7 @@ export const Popup: FC<PopupProps> = ({
   overlayClassName,
   titleClassName,
   headerClassName,
+  bodyClassName,
   children,
   footer,
   onClose,
@@ -182,7 +186,9 @@ export const Popup: FC<PopupProps> = ({
               )}
             </div>
 
-            <div className="grow overflow-auto">{children}</div>
+            <div className={mergeClasses('grow overflow-auto', bodyClassName)}>
+              {children}
+            </div>
 
             {footer}
           </div>


### PR DESCRIPTION
## Summary
- The previous `DialPopup` exposed its scrollable body wrapper via `aria-label="popup-description"`, which consumers used as a CSS hook (e.g. `[&>[aria-label='popup-description']]:flex ... :flex-col`) to turn it into a flex column so a full-height child could grow to fill it.
- The redesigned `Popup` (`src/components/New/Popup/Popup.tsx`) dropped that attribute with no replacement when introduced, silently breaking that pattern.
- Concretely, in `ai-dial-chat`, `DialFileManagerModal` migrated from `DialPopup` to `Popup` in #8241 and lost this hook — the file list now collapses to content height with a large empty gap below it, since the grid's `grow`/`min-h-0` flex classes have no flex-container ancestor inside the popup body anymore.
- Fix: add a `bodyClassName` prop (consistent with the existing `headerClassName`/`overlayClassName`/`titleClassName` props) so consumers can style the body wrapper directly instead of relying on a selector reaching into an unmarked child.

## Test plan
- [x] New test: `applies bodyClassName to the scrollable body wrapper`.
- [x] `npx vitest run src/components/New/Popup/Popup.spec.tsx` — 14/14 pass.
- [x] `npx eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)