### PR TITLE
feat: add Switch 2.0 component

### DIFF
--- a/src/components/New/Switch/Switch.spec.tsx
+++ b/src/components/New/Switch/Switch.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, test, expect, vi } from 'vitest';
+import { Switch } from './Switch';
+
+describe('Dial UI Kit :: Switch', () => {
+  test('renders with an accessible name from its label', () => {
+    render(<Switch id="switch" label="Notifications" />);
+    expect(
+      screen.getByRole('switch', { name: 'Notifications' }),
+    ).toBeInTheDocument();
+  });
+
+  test('falls back to aria-label when no visible label is provided', () => {
+    render(<Switch id="switch" aria-label="Notifications" />);
+    expect(
+      screen.getByRole('switch', { name: 'Notifications' }),
+    ).toBeInTheDocument();
+  });
+
+  test('reflects isOn through aria-checked', () => {
+    render(<Switch id="switch" label="Notifications" isOn />);
+    expect(
+      screen.getByRole('switch', { name: 'Notifications' }),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('calls onChange with the toggled value when clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Switch
+        id="switch"
+        label="Notifications"
+        isOn={false}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('switch', { name: 'Notifications' }));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test('clicking the visible label toggles the switch', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Switch
+        id="switch"
+        label="Notifications"
+        isOn={false}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('Notifications'));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    render(<Switch id="switch" label="Notifications" disabled />);
+    expect(
+      screen.getByRole('switch', { name: 'Notifications' }),
+    ).toBeDisabled();
+  });
+
+  test('renders caption text and links it to the switch', () => {
+    render(<Switch id="switch" label="Notifications" caption="Some caption" />);
+    const caption = screen.getByText('Some caption');
+    const control = screen.getByRole('switch', { name: 'Notifications' });
+
+    expect(caption).toBeInTheDocument();
+    expect(control).toHaveAttribute('aria-describedby', caption.id);
+  });
+});

--- a/src/components/New/Switch/Switch.stories.tsx
+++ b/src/components/New/Switch/Switch.stories.tsx
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Switch, type SwitchProps } from './Switch';
+
+const InteractiveSwitch = (args: SwitchProps) => {
+  const [value, setValue] = useState(args.isOn);
+
+  return <Switch {...args} isOn={value} onChange={setValue} />;
+};
+
+const meta = {
+  title: 'Components_2_0/Switch',
+  component: Switch,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A switch (toggle) control from the 2.0 design system, built on a native checkbox.',
+      },
+    },
+  },
+  argTypes: {
+    id: {
+      control: 'text',
+      description: 'The id of the underlying checkbox input',
+    },
+    label: {
+      control: 'text',
+      description: 'Visible label rendered next to the control',
+    },
+    isOn: {
+      control: 'boolean',
+      description: 'The current value of the switch',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the switch is disabled',
+    },
+    onChange: {
+      action: 'changed',
+      control: false,
+      description: 'Callback fired with the new value when toggled',
+    },
+    caption: {
+      control: 'text',
+      description: 'Caption text rendered below the label',
+    },
+  },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: InteractiveSwitch,
+  args: {
+    id: 'default-switch',
+    label: 'Active',
+  },
+};
+
+export const On: Story = {
+  render: InteractiveSwitch,
+  args: {
+    id: 'on-switch',
+    label: 'Active',
+    isOn: true,
+  },
+};
+
+export const Disabled: Story = {
+  render: InteractiveSwitch,
+  args: {
+    id: 'disabled-off-switch',
+    label: 'Active',
+    isOn: false,
+    disabled: true,
+  },
+};
+
+export const DisabledOn: Story = {
+  render: InteractiveSwitch,
+  args: {
+    id: 'disabled-on-switch',
+    label: 'Active',
+    isOn: true,
+    disabled: true,
+  },
+};
+
+export const WithCaption: Story = {
+  render: InteractiveSwitch,
+  args: {
+    id: 'caption-switch',
+    label: 'Active',
+    isOn: true,
+    caption: 'Some caption text',
+  },
+};
+
+export const AllVariants: Story = {
+  args: { id: 'all-variants-switch' },
+  render: () => (
+    <div className="flex min-w-[400px] flex-col gap-y-6 p-8">
+      <div>
+        <div className="text-primary dial-small-semi-text mb-2">Off</div>
+        <InteractiveSwitch id="all-off" label="Active" />
+      </div>
+      <div>
+        <div className="text-primary dial-small-semi-text mb-2">On</div>
+        <InteractiveSwitch id="all-on" label="Active" isOn />
+      </div>
+      <div>
+        <div className="text-primary dial-small-semi-text mb-2">
+          Disabled off
+        </div>
+        <InteractiveSwitch id="all-disabled-off" label="Active" disabled />
+      </div>
+      <div>
+        <div className="text-primary dial-small-semi-text mb-2">
+          Disabled on
+        </div>
+        <InteractiveSwitch id="all-disabled-on" label="Active" isOn disabled />
+      </div>
+      <div>
+        <div className="text-primary dial-small-semi-text mb-2">
+          With caption
+        </div>
+        <InteractiveSwitch
+          id="all-caption"
+          label="Active"
+          isOn
+          caption="Some caption text"
+        />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/New/Switch/Switch.tsx
+++ b/src/components/New/Switch/Switch.tsx
@@ -88,13 +88,7 @@ export const Switch: FC<SwitchProps> = ({
             className={mergeClasses(
               'flex h-[18px] w-[36px] shrink-0 items-center rounded-full p-0.5 transition-colors duration-200',
               isOn ? 'justify-end' : 'justify-start',
-              disabled
-                ? isOn
-                  ? 'bg-controls-disable'
-                  : 'bg-layer-4'
-                : isOn
-                  ? 'bg-controls-accent-primary'
-                  : 'bg-layer-4',
+              isOn && !disabled ? 'bg-control-accent' : 'bg-control-disable',
             )}
           >
             <span

--- a/src/components/New/Switch/Switch.tsx
+++ b/src/components/New/Switch/Switch.tsx
@@ -1,0 +1,131 @@
+import type { ChangeEvent, FC, InputHTMLAttributes, ReactNode } from 'react';
+import { useCallback, useId } from 'react';
+
+import { mergeClasses } from '@/utils/merge-classes';
+import { resolveAccessibleName } from '@/utils/accessible-name';
+
+type NativeInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'checked' | 'onChange' | 'size'
+>;
+
+export interface SwitchProps extends NativeInputProps {
+  label?: ReactNode;
+  isOn?: boolean;
+  disabled?: boolean;
+  onChange?: (value: boolean) => void;
+  caption?: string;
+}
+
+/**
+ * A switch (toggle) control from the 2.0 design system.
+ * aliases: ToggleSwitch|BinaryToggle|Switcher
+ *
+ * @example
+ * ```tsx
+ * <Switch
+ *   id="notifications"
+ *   label="Active"
+ *   isOn={isActive}
+ *   onChange={setIsActive}
+ * />
+ * ```
+ *
+ * @param [label] - Visible label rendered next to the control
+ * @param [isOn=false] - The current value of the switch
+ * @param [disabled=false] - Whether the switch is disabled
+ * @param [onChange] - Callback fired with the new value when toggled
+ * @param [caption] - Caption text rendered below the label
+ */
+export const Switch: FC<SwitchProps> = ({
+  id,
+  label,
+  isOn = false,
+  disabled,
+  onChange,
+  caption,
+  className,
+  ...props
+}) => {
+  const generatedId = useId();
+  const switchId = id ?? generatedId;
+  const captionId = caption ? `${switchId}-caption` : undefined;
+
+  const onToggle = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(e.target.checked);
+    },
+    [onChange],
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center">
+        <input
+          {...props}
+          type="checkbox"
+          role="switch"
+          id={switchId}
+          checked={isOn}
+          aria-checked={isOn}
+          disabled={disabled}
+          onChange={onToggle}
+          aria-label={resolveAccessibleName(
+            typeof label !== 'string' ? props['aria-label'] : undefined,
+          )}
+          aria-describedby={captionId}
+          className="peer sr-only"
+        />
+        <label
+          htmlFor={switchId}
+          className={mergeClasses(
+            'flex items-center gap-2 rounded-full peer-focus-visible:outline peer-focus-visible:outline-offset-2 peer-focus-visible:outline-focus-black',
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+            className,
+          )}
+        >
+          <span
+            className={mergeClasses(
+              'flex h-[18px] w-[36px] shrink-0 items-center rounded-full p-0.5 transition-colors duration-200',
+              isOn ? 'justify-end' : 'justify-start',
+              disabled
+                ? isOn
+                  ? 'bg-controls-disable'
+                  : 'bg-layer-4'
+                : isOn
+                  ? 'bg-controls-accent-primary'
+                  : 'bg-layer-4',
+            )}
+          >
+            <span
+              className={mergeClasses(
+                'size-3.5 shrink-0 rounded-full',
+                disabled
+                  ? 'bg-controls-disable-accent'
+                  : 'bg-controls-enable-primary',
+              )}
+            />
+          </span>
+          {label && (
+            <span
+              className={mergeClasses(
+                'dial-small-text py-[1px]',
+                disabled ? 'text-secondary' : 'text-primary',
+              )}
+            >
+              {label}
+            </span>
+          )}
+        </label>
+      </div>
+      {caption && (
+        <span
+          id={captionId}
+          className="dial-tiny-text text-secondary ml-[44px]"
+        >
+          {caption}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,3 +366,5 @@ export {
 } from './components/New/CaptionText/CaptionText';
 export { Accordion } from './components/New/Accordion/Accordion';
 export type { AccordionProps } from './components/New/Accordion/Accordion';
+export { Switch } from './components/New/Switch/Switch';
+export type { SwitchProps } from './components/New/Switch/Switch';


### PR DESCRIPTION
## Summary
- Adds a `Switch` component under `src/components/New/Switch/` matching the [DIAL Chat 2.0 Figma design](https://www.figma.com/design/QMWaL8m8tFmoekQKxIH569/DIAL-Chat-2.0--Scheduled-tasks?node-id=252-11201) — a toggle built on a native checkbox with `role="switch"`, `aria-checked`, and an accessible name resolved from its visible label.
- Uses 2.0 design tokens matched against Figma variables (`bg-controls-accent-primary` for the "on" track, `controls-enable-primary`/`controls-disable-accent` for the knob) and a 14×14px knob per spec.
- Exports `Switch`/`SwitchProps` from `src/index.ts`, following the existing `New/*` naming convention (no `Dial` prefix).
<img width="2108" height="1624" alt="image" src="https://github.com/user-attachments/assets/2cd41f0e-1ea9-485e-b6a2-14b2746f0af3" />


## Test plan
- [x] `npm run typecheck` — no new errors
- [x] `npm run lint` — clean
- [x] `npm run test` — all passing, 100% line/statement coverage on `Switch.tsx`
- [x] Verified visually in Storybook (`Components_2_0/Switch`) against the Figma reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)