### PR TITLE
feat: support null values in DialAnalyticsBar compare mode

### DIFF
--- a/src/components/Analytics/Bar/Bar.spec.tsx
+++ b/src/components/Analytics/Bar/Bar.spec.tsx
@@ -46,6 +46,35 @@ describe('Dial UI Kit :: DialAnalyticsBar', () => {
     expect(fill.style.backgroundColor).toBe('');
   });
 
+  test('shows an em dash and no progress bar when value is null', () => {
+    render(<DialAnalyticsBar title="Score" value={null} />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText('0')).toBeNull();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  test('prefers an explicit valueLabel over the em dash when value is null', () => {
+    render(<DialAnalyticsBar title="Score" value={null} valueLabel="n/a" />);
+
+    expect(screen.getByText('n/a')).toBeInTheDocument();
+    expect(screen.queryByText('—')).toBeNull();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  test('reserves a fixed value column width in inline mode so tracks stay aligned', () => {
+    render(
+      <>
+        <DialAnalyticsBar title="A" value={0.82} inline />
+        <DialAnalyticsBar title="B" value={null} inline />
+      </>,
+    );
+
+    expect(screen.getByText('0.82').className).toMatch(/min-w-\[5ch]/);
+    expect(screen.getByText('—').className).toMatch(/min-w-\[5ch]/);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+  });
+
   test('clamps values above maxValue and uses the full color', () => {
     const { container } = render(
       <DialAnalyticsBar title="Score" value={5} maxValue={1} />,

--- a/src/components/Analytics/Bar/Bar.stories.tsx
+++ b/src/components/Analytics/Bar/Bar.stories.tsx
@@ -71,6 +71,14 @@ export const Empty: Story = {
   },
 };
 
+export const NoValue: Story = {
+  args: {
+    title: 'Relevance',
+    value: null,
+    className: 'w-[280px]',
+  },
+};
+
 export const Full: Story = {
   args: {
     title: 'Relevance',

--- a/src/components/Analytics/Bar/Bar.tsx
+++ b/src/components/Analytics/Bar/Bar.tsx
@@ -11,8 +11,11 @@ import {
 } from './utils';
 
 export interface DialAnalyticsBarProps {
-  /** Current value used to size and color the bar. Omit it when `error` is set. */
-  value?: number;
+  /**
+   * Current value used to size and color the bar. Pass `null` when there is no
+   * data (em dash, no progress bar). Omit it when `error` is set.
+   */
+  value?: number | null;
   /** Upper bound of the scale. Defaults to `1`. */
   maxValue?: number;
   /**
@@ -28,8 +31,8 @@ export interface DialAnalyticsBarProps {
   /** Optional label rendered above the bar, on the left. */
   title?: ReactNode;
   /**
-   * Text rendered above the bar, on the right. Defaults to `value`.
-   * Pass a formatted node (e.g. `"85%"`) to override.
+   * Text rendered above the bar, on the right. Defaults to `value`, or an em dash
+   * (`—`) when `value` is `null`. Pass a formatted node (e.g. `"85%"`) to override.
    */
   valueLabel?: ReactNode;
   /**
@@ -59,7 +62,8 @@ export interface DialAnalyticsBarProps {
  *
  * The fill color is resolved from `colorMap` based on the normalized ratio
  * (`value / maxValue`), so the bar shifts hue as the value grows. An empty bar
- * (value `0`) shows only the `bg-layer-1` track.
+ * (value `0`) shows only the `bg-layer-1` track. A missing value (`null`) shows
+ * an em dash and no progress bar.
  *
  * @example
  * ```tsx
@@ -76,12 +80,12 @@ export interface DialAnalyticsBarProps {
  * />
  * ```
  *
- * @param [value] - Current value used to size and color the bar. Omit it when `error` is set.
+ * @param [value] - Current value used to size and color the bar. Pass `null` for no data (em dash, no bar). Omit when `error` is set.
  * @param [maxValue=1] - Upper bound of the scale.
  * @param [error] - Renders the error state (error-colored bar + error tag).
  * @param [isLoading] - Renders the loading state (loader + empty track).
  * @param [title] - Optional label rendered above the bar, on the left.
- * @param [valueLabel] - Text rendered above the bar, on the right. Defaults to `value`.
+ * @param [valueLabel] - Text rendered above the bar, on the right. Defaults to `value` or `—` when null.
  * @param [colorMap=DEFAULT_ANALYTICS_BAR_COLOR_MAP] - Color bands keyed by ratio.
  * @param [className] - Additional CSS classes for the outer container.
  * @param [titleClassName] - Additional CSS classes for the title label.
@@ -103,11 +107,14 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
   inline,
   ariaLabel,
 }) => {
-  const ratio = getAnalyticsBarRatio(value ?? 0, maxValue);
+  const hasNoValue = value == null;
+  const showBar = Boolean(error || isLoading || !hasNoValue);
+  const ratio = getAnalyticsBarRatio(hasNoValue ? 0 : value, maxValue);
   const color = getAnalyticsBarColor(ratio, colorMap);
-  const displayValue = valueLabel ?? value;
+  const displayValue = valueLabel ?? (hasNoValue ? '—' : value);
   const resolvedAriaLabel =
     ariaLabel ?? (typeof title === 'string' ? title : undefined);
+  const hideFill = error || isLoading;
 
   const valueSlot = error ? (
     <DialAnalyticsErrorTag />
@@ -116,8 +123,9 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
   ) : (
     <span
       className={mergeClasses(
+        'shrink-0 tabular-nums text-end',
         inline
-          ? 'dial-small-text text-primary'
+          ? 'dial-small-text min-w-[5ch] text-primary'
           : 'dial-small-semi-text text-primary',
         valueClassName,
       )}
@@ -126,10 +134,12 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
     </span>
   );
 
-  const barTrack = (
+  const barTrack = showBar ? (
     <div
       role="progressbar"
-      aria-valuenow={error || isLoading ? undefined : value}
+      aria-valuenow={
+        error || isLoading || typeof value !== 'number' ? undefined : value
+      }
       aria-valuemin={0}
       aria-valuemax={maxValue}
       aria-label={resolvedAriaLabel}
@@ -139,14 +149,14 @@ export const DialAnalyticsBar: FC<DialAnalyticsBarProps> = ({
         error ? 'bg-error' : 'bg-layer-1',
       )}
     >
-      {!error && !isLoading && (
+      {!hideFill && (
         <div
           className="h-full rounded-sm transition-[width] duration-300"
           style={{ width: `${ratio * 100}%`, backgroundColor: color }}
         />
       )}
     </div>
-  );
+  ) : null;
 
   const titleSlot = (
     <span

--- a/src/components/Analytics/BarGroup/BarGroup.spec.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.spec.tsx
@@ -214,17 +214,36 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       expect(screen.getByText('Last week')).toBeInTheDocument();
     });
 
-    test('skips entries whose key is absent from compareData', () => {
+    test('shows missing keys with an em dash and no delta badge', () => {
       render(
         <DialAnalyticsBarGroup
           title="Relevance"
-          data={{ accuracy: 0.82, extra: 0.5 }}
-          compareData={{ accuracy: 0.64 }}
+          data={{ accuracy: 0.82, onlyCurrent: 0.5 }}
+          compareData={{ accuracy: 0.64, onlyPrevious: 0.7 }}
         />,
       );
 
+      expect(screen.getByText('onlyCurrent')).toBeInTheDocument();
+      expect(screen.getByText('onlyPrevious')).toBeInTheDocument();
+      // accuracy×2 + onlyCurrent + onlyPrevious — missing sides have no progressbar
+      expect(screen.getAllByRole('progressbar')).toHaveLength(4);
+      expect(screen.getAllByText('—')).toHaveLength(2);
+      expect(screen.getByText('+0.18')).toBeInTheDocument();
+      expect(screen.queryByText('NaN')).toBeNull();
+    });
+
+    test('hides the delta badge when either side is explicitly null', () => {
+      render(
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ score: null, other: 0.5 }}
+          compareData={{ score: 0.64, other: null }}
+        />,
+      );
+
+      expect(screen.getAllByText('—')).toHaveLength(2);
+      expect(screen.queryByText(/^[+-]\d/)).toBeNull();
       expect(screen.getAllByRole('progressbar')).toHaveLength(2);
-      expect(screen.queryByText('extra')).toBeNull();
     });
   });
 

--- a/src/components/Analytics/BarGroup/BarGroup.stories.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.stories.tsx
@@ -180,6 +180,27 @@ export const CompareWithCustomMaxValue: Story = {
   },
 };
 
+export const CompareWithMissingValues: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, onlyCurrent: 0.55 },
+    compareData: { accuracy: 0.64, recall: 0.82, onlyPrevious: 0.71 },
+    compareLabels: ['This week', 'Last week'],
+    className: 'w-[420px]',
+  },
+};
+
+export const CompareInlineWithMissingValues: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, onlyCurrent: 0.55 },
+    compareData: { accuracy: 0.64, recall: 0.82, onlyPrevious: 0.71 },
+    compareLabels: ['This week', 'Last week'],
+    inline: true,
+    className: 'w-[420px]',
+  },
+};
+
 export const WithTitleTooltip: Story = {
   args: {
     title: 'Relevance',

--- a/src/components/Analytics/BarGroup/BarGroup.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.tsx
@@ -14,14 +14,19 @@ export interface DialAnalyticsBarGroupProps {
   titleTooltip?: ReactNode;
   /** Description passed to the accordion header. Defaults to the number of entries. */
   description?: ReactNode;
-  /** Map of metric name to numeric value. Each entry renders one bar. */
-  data: Record<string, number>;
   /**
-   * When provided, enables compare mode: each entry renders a delta badge (computed
-   * as `data[key] - compareData[key]`) and two bars — one for `data` and one for
-   * `compareData`. `onBarClick` is ignored in compare mode.
+   * Map of metric name to numeric value. Each entry renders one bar.
+   * Pass `null` for a key when there is no data (em dash, no progress bar).
    */
-  compareData?: Record<string, number>;
+  data: Record<string, number | null>;
+  /**
+   * When provided, enables compare mode: keys are the union of `data` and
+   * `compareData`. Each entry renders two bars and, when both sides are numeric,
+   * a delta badge (`data[key] - compareData[key]`). A missing key (or explicit
+   * `null`) on either side shows an em dash with no progress bar and no delta.
+   * `onBarClick` is ignored in compare mode.
+   */
+  compareData?: Record<string, number | null>;
   /**
    * Labels shown next to each of the two bars in compare mode.
    * The first label is for `data`, the second for `compareData`.
@@ -42,7 +47,7 @@ export interface DialAnalyticsBarGroupProps {
   /** Renders a loader in place of the bars while the data is being fetched. */
   isLoading?: boolean;
   /** Invoked with the entry key and value when a bar is clicked. When set, each bar becomes an interactive button. */
-  onBarClick?: (key: string, value: number) => void;
+  onBarClick?: (key: string, value: number | null) => void;
   /** Renders every bar on a single row (50% title, 50% bar + value). */
   inline?: boolean;
   /** Additional CSS classes for each bar's title label. */
@@ -78,8 +83,8 @@ export interface DialAnalyticsBarGroupProps {
  * @param title - Title passed to the accordion header.
  * @param [titleTooltip] - Tooltip shown when hovering the accordion header title.
  * @param [description] - Description passed to the accordion header. Defaults to the number of entries.
- * @param data - Map of metric name to numeric value. Each entry renders one bar.
- * @param [compareData] - Enables compare mode: each entry shows a delta badge and two bars.
+ * @param data - Map of metric name to numeric value (or `null` when missing). Each entry renders one bar.
+ * @param [compareData] - Enables compare mode: union of keys, delta badge when both sides are numeric, em dash (no bar) when a side is missing.
  * @param [compareLabels] - Labels for the two bars in compare mode: first for `data`, second for `compareData`.
  * @param [maxValue] - Upper bound passed to every bar.
  * @param [colorMap] - Color map passed to every bar.
@@ -126,6 +131,9 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
   ) : (
     title
   );
+  const compareKeys = compareData
+    ? [...new Set([...Object.keys(data), ...Object.keys(compareData)])]
+    : [];
 
   return (
     <DialAccordion
@@ -144,26 +152,33 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
         {isLoading ? (
           <DialLoader fullWidth={false} className="self-center" />
         ) : compareData ? (
-          entries.map(([key, value]) => {
-            if (!(key in compareData)) return null;
-            const compareValue = compareData[key];
-            const delta = parseFloat((value - compareValue).toFixed(2));
-            const isPositive = delta >= 0;
-            const deltaLabel = isPositive ? `+${delta}` : String(delta);
+          compareKeys.map((key) => {
+            const value = key in data ? data[key] : null;
+            const compareValue = key in compareData ? compareData[key] : null;
+            const canComputeDelta =
+              typeof value === 'number' && typeof compareValue === 'number';
+            const delta = canComputeDelta
+              ? parseFloat((value - compareValue).toFixed(2))
+              : null;
+            const isPositive = delta != null && delta >= 0;
+            const deltaLabel =
+              delta == null ? null : isPositive ? `+${delta}` : String(delta);
             return (
               <div key={key} className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2">
                   <span className="dial-small-text text-primary">{key}</span>
-                  <span
-                    className={mergeClasses(
-                      'dial-tiny-semi-text rounded-[120px] border border-transparent px-2',
-                      isPositive
-                        ? 'bg-success text-success'
-                        : 'bg-error text-error',
-                    )}
-                  >
-                    {deltaLabel}
-                  </span>
+                  {deltaLabel != null && (
+                    <span
+                      className={mergeClasses(
+                        'dial-tiny-semi-text rounded-[120px] border border-transparent px-2',
+                        isPositive
+                          ? 'bg-success text-success'
+                          : 'bg-error text-error',
+                      )}
+                    >
+                      {deltaLabel}
+                    </span>
+                  )}
                 </div>
                 <div className="flex flex-col gap-1.5 pl-2">
                   <DialAnalyticsBar


### PR DESCRIPTION
Added support null values and displayiung '-' for DialAnalyticsBar compare mode
<img width="386" height="90" alt="Screenshot 2026-08-11 at 14 18 42" src="https://github.com/user-attachments/assets/4e4550f4-2582-42a0-97fc-2a9b1105474e" />

<SHORT_DESCRIPTION>

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added