### PR TITLE
feat: Support custom reader and header/footer for Dropdown submenu

### DIFF
--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -959,4 +959,66 @@ describe('Dial UI Kit :: Dropdown', () => {
       screen.queryByText('Should not render either'),
     ).not.toBeInTheDocument();
   });
+
+  test('item.renderItem customizes a top-level item while keeping its click handler', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const itemsWithRenderItem: DropdownItem[] = [
+      {
+        key: 'storage',
+        label: 'Storage',
+        onClick,
+        renderItem: (it) => <span>Custom: {it.label}</span>,
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithRenderItem}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    const menuItem = screen.getByRole('menuitem', { name: 'Custom: Storage' });
+    expect(menuItem).toBeInTheDocument();
+    expect(screen.queryByText('Storage', { exact: true })).toBeNull();
+
+    await user.click(menuItem);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  test('item.renderItem customizes a submenu trigger and its children', async () => {
+    const user = userEvent.setup();
+    const onChildClick = vi.fn();
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        renderItem: (it) => <span>Trigger: {it.label}</span>,
+        children: [
+          {
+            key: 'sub-1',
+            label: 'Sub One',
+            onClick: onChildClick,
+            renderItem: (it) => <span>Child: {it.label}</span>,
+          },
+        ],
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    const trigger = screen.getByRole('menuitem', { name: 'Trigger: More' });
+    await user.hover(trigger);
+
+    const child = await screen.findByRole('menuitem', {
+      name: 'Child: Sub One',
+    });
+
+    await user.click(child);
+    expect(onChildClick).toHaveBeenCalled();
+  });
 });

--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -867,4 +867,96 @@ describe('Dial UI Kit :: Dropdown', () => {
     fireEvent.click(child);
     expect(onChild).not.toHaveBeenCalled();
   });
+
+  test('submenu renders item.menuHeader above its children', async () => {
+    const user = userEvent.setup();
+    const headerText = 'Sub Header';
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        menuHeader: () => <div>{headerText}</div>,
+        children: [{ key: 'sub-1', label: 'Sub One' }],
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    await user.hover(screen.getByRole('menuitem', { name: /more/i }));
+
+    const subOne = await screen.findByRole('menuitem', { name: 'Sub One' });
+    const headerEl = screen.getByText(headerText);
+
+    expect(
+      headerEl.compareDocumentPosition(subOne) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test('submenu renders item.menuFooter below its children', async () => {
+    const user = userEvent.setup();
+    const footerText = 'Sub Footer';
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        children: [{ key: 'sub-1', label: 'Sub One' }],
+        menuFooter: <div>{footerText}</div>,
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    await user.hover(screen.getByRole('menuitem', { name: /more/i }));
+
+    const subOne = await screen.findByRole('menuitem', { name: 'Sub One' });
+    const footerEl = screen.getByText(footerText);
+
+    expect(
+      subOne.compareDocumentPosition(footerEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  test('item.renderSubMenu fully replaces children/header/footer', async () => {
+    const user = userEvent.setup();
+    const onRenderSubMenu = vi.fn(() => (
+      <div role="none">Custom submenu content</div>
+    ));
+    const itemsWithSub: DropdownItem[] = [
+      {
+        key: 'sub',
+        label: 'More',
+        menuHeader: <div>Should not render</div>,
+        menuFooter: <div>Should not render either</div>,
+        children: [{ key: 'sub-1', label: 'Sub One' }],
+        renderSubMenu: onRenderSubMenu,
+      },
+    ];
+    render(
+      <Dropdown items={itemsWithSub}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+    await user.hover(screen.getByRole('menuitem', { name: /more/i }));
+
+    expect(
+      await screen.findByText('Custom submenu content'),
+    ).toBeInTheDocument();
+    expect(onRenderSubMenu).toHaveBeenCalled();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Sub One' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Should not render')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Should not render either'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -560,24 +560,22 @@ const collectionItems: CollectionItem[] = [
   },
 ];
 
-const badgedCollectionItems: CollectionItem[] = collectionItems.map(
-  (item) => ({
-    ...item,
-    renderItem: () => (
-      <>
-        {item.icon}
-        <span className="flex-1 truncate text-start">
-          <span className="block truncate">{item.label}</span>
-          {item.description && (
-            <span className="block truncate dial-caption-text text-secondary">
-              {item.description}
-            </span>
-          )}
-        </span>
-      </>
-    ),
-  }),
-);
+const badgedCollectionItems: CollectionItem[] = collectionItems.map((item) => ({
+  ...item,
+  renderItem: () => (
+    <>
+      {item.icon}
+      <span className="flex-1 truncate text-start">
+        <span className="block truncate">{item.label}</span>
+        {item.description && (
+          <span className="block truncate dial-caption-text text-secondary">
+            {item.description}
+          </span>
+        )}
+      </span>
+    </>
+  ),
+}));
 
 export const WithCustomItemRender: Story = {
   name: 'Custom item render (renderItem)',

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -1,27 +1,36 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useRef, useState, type ReactNode } from 'react';
 import type { Placement } from '@floating-ui/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
-  IconUser,
-  IconSettings,
-  IconLogout,
   IconChevronDown,
-  IconRowRemove,
-  IconStack,
-  IconExternalLink,
   IconCopy,
-  IconTrash,
   IconDots,
+  IconExternalLink,
+  IconFileText,
+  IconLogout,
+  IconRowRemove,
+  IconSettings,
+  IconStack,
+  IconTrash,
+  IconUser,
 } from '@tabler/icons-react';
+import { useRef, useState, type ReactNode } from 'react';
 
-import { Dropdown, type DropdownProps } from './Dropdown';
-import { DropdownItemType, DropdownTrigger } from '@/types/dropdown';
 import {
   NeutralButton,
   PrimaryButton,
 } from '@/components/New/Button/ButtonWrappers';
-import { type DropdownItem } from '@/models/dropdown';
+import { DangerIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { type DropdownItem } from '@/models/dropdown';
+import { DropdownItemType, DropdownTrigger } from '@/types/dropdown';
+import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
+import {
+  dropdownDividerClassName,
+  dropdownItemBaseClassName,
+} from './constants';
+import { Dropdown, type DropdownProps } from './Dropdown';
 
 const items: DropdownItem[] = [
   {
@@ -530,6 +539,167 @@ export const WithSubMenu: Story = {
       ]}
     >
       <TriggerBtn label="Sub-menu" />
+    </Dropdown>
+  ),
+};
+
+type CollectionItem = DropdownItem & { description?: string };
+
+const collectionItems: CollectionItem[] = [
+  {
+    key: 'roadmap',
+    label: 'Product Roadmap',
+    icon: <IconFileText size={DIAL_ICON_SIZE.SM} />,
+    description: 'Q3 planning document with feature timelines',
+  },
+  {
+    key: 'notes',
+    label: 'Meeting Notes',
+    icon: <IconFileText size={DIAL_ICON_SIZE.SM} />,
+    description: 'Notes from the last product sync',
+  },
+];
+
+export const WithSubMenuCustomContent: Story = {
+  name: 'Sub-menu with fully custom content',
+  // Storybook's dynamic "Show code" snippet re-walks the rendered element tree
+  // at runtime; combined with the portaled submenu panel it blows the stack
+  // (RangeError: Invalid string length) rather than throwing an app error.
+  // Static source avoids that runtime tree walk.
+  parameters: { docs: { source: { type: 'code' } } },
+  render: (args) => (
+    <Dropdown
+      {...args}
+      placement="bottom-start"
+      items={[
+        {
+          key: 'profile',
+          label: 'Profile',
+          icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
+        },
+        {
+          key: 'collection',
+          label: 'My collection',
+          icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+          children: collectionItems,
+          renderSubMenu: () => (
+            <>
+              <div className="px-3 py-2">
+                <span className="dial-small-text font-medium text-secondary">
+                  My collection
+                </span>
+              </div>
+
+              <div role="none" className="py-1">
+                {collectionItems.map((collectionItem) => (
+                  <div
+                    key={collectionItem.key}
+                    className={mergeClasses(
+                      dropdownItemBaseClassName,
+                      'justify-between pr-1',
+                    )}
+                  >
+                    <DialTooltip
+                      tooltip={collectionItem.description}
+                      hideTooltip={!collectionItem.description}
+                      placement="right"
+                      triggerClassName="flex-1"
+                    >
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="flex w-full items-center gap-2 truncate text-start"
+                      >
+                        {collectionItem.icon}
+                        <span className="flex-1 truncate">
+                          {collectionItem.label}
+                        </span>
+                      </button>
+                    </DialTooltip>
+                    <DangerIconButton
+                      aria-label={`Delete ${collectionItem.label}`}
+                      icon={<IconTrash size={DIAL_ICON_SIZE.SM} />}
+                      size={ElementSize.Small}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        window.alert(`Deleted "${collectionItem.label}"`);
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+
+              <div role="separator" className={dropdownDividerClassName} />
+
+              <div className="px-2 pb-2 pt-1">
+                <PrimaryButton
+                  label="Explore"
+                  className="w-full"
+                  onClick={() => window.alert('Explore clicked')}
+                />
+              </div>
+            </>
+          ),
+        },
+        {
+          key: 'logout',
+          label: 'Logout',
+          icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+        },
+      ]}
+    >
+      <TriggerBtn label="Sub-menu footer" />
+    </Dropdown>
+  ),
+};
+
+export const WithSubMenuHeaderAndFooter: Story = {
+  name: 'Sub-menu with header and footer',
+  // See the comment on WithSubMenuCustomContent above.
+  parameters: { docs: { source: { type: 'code' } } },
+  render: (args) => (
+    <Dropdown
+      {...args}
+      placement="bottom-start"
+      items={[
+        {
+          key: 'profile',
+          label: 'Profile',
+          icon: <IconUser size={DIAL_ICON_SIZE.SM} />,
+        },
+        {
+          key: 'collection',
+          label: 'My collection',
+          icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+          children: collectionItems,
+          menuHeader: (
+            <div className="px-3 py-2">
+              <span className="dial-small-text font-medium text-secondary">
+                My collection
+              </span>
+            </div>
+          ),
+          menuFooter: (
+            <>
+              <div role="separator" className={dropdownDividerClassName} />
+              <div className="px-2 pb-2 pt-1">
+                <PrimaryButton
+                  label="Explore"
+                  className="w-full"
+                  onClick={() => window.alert('Explore clicked')}
+                />
+              </div>
+            </>
+          ),
+        },
+        {
+          key: 'logout',
+          label: 'Logout',
+          icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+        },
+      ]}
+    >
+      <TriggerBtn label="Sub-menu header/footer" />
     </Dropdown>
   ),
 };

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -560,6 +560,62 @@ const collectionItems: CollectionItem[] = [
   },
 ];
 
+const badgedCollectionItems: CollectionItem[] = collectionItems.map(
+  (item) => ({
+    ...item,
+    renderItem: () => (
+      <>
+        {item.icon}
+        <span className="flex-1 truncate text-start">
+          <span className="block truncate">{item.label}</span>
+          {item.description && (
+            <span className="block truncate dial-caption-text text-secondary">
+              {item.description}
+            </span>
+          )}
+        </span>
+      </>
+    ),
+  }),
+);
+
+export const WithCustomItemRender: Story = {
+  name: 'Custom item render (renderItem)',
+  render: (args) => (
+    <Dropdown
+      {...args}
+      placement="bottom-start"
+      items={[
+        {
+          key: 'storage',
+          label: 'Storage',
+          icon: <IconSettings size={DIAL_ICON_SIZE.SM} />,
+          renderItem: (it) => (
+            <>
+              {it.icon}
+              <span className="flex-1 truncate text-start">{it.label}</span>
+              <span className="dial-caption-text text-secondary">82%</span>
+            </>
+          ),
+        },
+        {
+          key: 'collection',
+          label: 'My collection',
+          icon: <IconStack size={DIAL_ICON_SIZE.SM} />,
+          children: badgedCollectionItems,
+        },
+        {
+          key: 'logout',
+          label: 'Logout',
+          icon: <IconLogout size={DIAL_ICON_SIZE.SM} />,
+        },
+      ]}
+    >
+      <TriggerBtn label="Custom item render" />
+    </Dropdown>
+  ),
+};
+
 export const WithSubMenuCustomContent: Story = {
   name: 'Sub-menu with fully custom content',
   // Storybook's dynamic "Show code" snippet re-walks the rendered element tree

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -388,25 +388,31 @@ export const Dropdown: FC<DropdownProps> = ({
                 disabled={it.disabled}
                 onClick={handleItemClick(it)}
               >
-                {it.icon && (
-                  <span
-                    className={mergeClasses(
-                      it.danger && 'text-error',
-                      it.disabled && 'text-secondary',
+                {it.renderItem ? (
+                  it.renderItem(it)
+                ) : (
+                  <>
+                    {it.icon && (
+                      <span
+                        className={mergeClasses(
+                          it.danger && 'text-error',
+                          it.disabled && 'text-secondary',
+                        )}
+                      >
+                        <DialIcon icon={it.icon} />
+                      </span>
                     )}
-                  >
-                    <DialIcon icon={it.icon} />
-                  </span>
+                    <span
+                      className={mergeClasses(
+                        'flex-1 truncate text-start',
+                        it.danger && 'text-error',
+                        it.disabled && 'text-secondary',
+                      )}
+                    >
+                      {it.label}
+                    </span>
+                  </>
                 )}
-                <span
-                  className={mergeClasses(
-                    'flex-1 truncate text-start',
-                    it.danger && 'text-error',
-                    it.disabled && 'text-secondary',
-                  )}
-                >
-                  {it.label}
-                </span>
               </button>
             );
           })}

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -64,9 +64,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
         ) : (
           <>
             {item.icon && (
-              <span
-                className={mergeClasses(item.disabled && 'text-secondary')}
-              >
+              <span className={mergeClasses(item.disabled && 'text-secondary')}>
                 <DialIcon icon={item.icon} />
               </span>
             )}

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -59,19 +59,27 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
         )}
         {...getReferenceProps()}
       >
-        {item.icon && (
-          <span className={mergeClasses(item.disabled && 'text-secondary')}>
-            <DialIcon icon={item.icon} />
-          </span>
+        {item.renderItem ? (
+          item.renderItem(item)
+        ) : (
+          <>
+            {item.icon && (
+              <span
+                className={mergeClasses(item.disabled && 'text-secondary')}
+              >
+                <DialIcon icon={item.icon} />
+              </span>
+            )}
+            <span
+              className={mergeClasses(
+                'flex-1 truncate text-start',
+                item.disabled && 'text-secondary',
+              )}
+            >
+              {item.label}
+            </span>
+          </>
         )}
-        <span
-          className={mergeClasses(
-            'flex-1 truncate text-start',
-            item.disabled && 'text-secondary',
-          )}
-        >
-          {item.label}
-        </span>
         <span
           className={mergeClasses(
             'ml-auto shrink-0',
@@ -115,25 +123,31 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
                   )}
                   onClick={handleChildClick(child)}
                 >
-                  {child.icon && (
-                    <span
-                      className={mergeClasses(
-                        child.danger && 'text-error',
-                        child.disabled && 'text-secondary',
+                  {child.renderItem ? (
+                    child.renderItem(child)
+                  ) : (
+                    <>
+                      {child.icon && (
+                        <span
+                          className={mergeClasses(
+                            child.danger && 'text-error',
+                            child.disabled && 'text-secondary',
+                          )}
+                        >
+                          <DialIcon icon={child.icon} />
+                        </span>
                       )}
-                    >
-                      <DialIcon icon={child.icon} />
-                    </span>
+                      <span
+                        className={mergeClasses(
+                          'flex-1 truncate text-start',
+                          child.danger && 'text-error',
+                          child.disabled && 'text-secondary',
+                        )}
+                      >
+                        {child.label}
+                      </span>
+                    </>
                   )}
-                  <span
-                    className={mergeClasses(
-                      'flex-1 truncate text-start',
-                      child.danger && 'text-error',
-                      child.disabled && 'text-secondary',
-                    )}
-                  >
-                    {child.label}
-                  </span>
                 </button>
               ))}
 

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -91,42 +91,58 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
           role="menu"
           surfaceClassName={dropdownSubMenuClassName}
         >
-          {item.children!.map((child) => (
-            <button
-              key={child.key}
-              role="menuitem"
-              type="button"
-              aria-disabled={!!child.disabled}
-              disabled={child.disabled}
-              className={mergeClasses(
-                dropdownItemBaseClassName,
-                child.disabled && dropdownItemDisabledClassName,
-                child.danger && dropdownItemDangerClassName,
-                child.className,
-              )}
-              onClick={handleChildClick(child)}
-            >
-              {child.icon && (
-                <span
+          {item.renderSubMenu ? (
+            item.renderSubMenu()
+          ) : (
+            <>
+              {item.menuHeader &&
+                (typeof item.menuHeader === 'function'
+                  ? item.menuHeader()
+                  : item.menuHeader)}
+
+              {item.children!.map((child) => (
+                <button
+                  key={child.key}
+                  role="menuitem"
+                  type="button"
+                  aria-disabled={!!child.disabled}
+                  disabled={child.disabled}
                   className={mergeClasses(
-                    child.danger && 'text-error',
-                    child.disabled && 'text-secondary',
+                    dropdownItemBaseClassName,
+                    child.disabled && dropdownItemDisabledClassName,
+                    child.danger && dropdownItemDangerClassName,
+                    child.className,
                   )}
+                  onClick={handleChildClick(child)}
                 >
-                  <DialIcon icon={child.icon} />
-                </span>
-              )}
-              <span
-                className={mergeClasses(
-                  'flex-1 truncate text-start',
-                  child.danger && 'text-error',
-                  child.disabled && 'text-secondary',
-                )}
-              >
-                {child.label}
-              </span>
-            </button>
-          ))}
+                  {child.icon && (
+                    <span
+                      className={mergeClasses(
+                        child.danger && 'text-error',
+                        child.disabled && 'text-secondary',
+                      )}
+                    >
+                      <DialIcon icon={child.icon} />
+                    </span>
+                  )}
+                  <span
+                    className={mergeClasses(
+                      'flex-1 truncate text-start',
+                      child.danger && 'text-error',
+                      child.disabled && 'text-secondary',
+                    )}
+                  >
+                    {child.label}
+                  </span>
+                </button>
+              ))}
+
+              {item.menuFooter &&
+                (typeof item.menuFooter === 'function'
+                  ? item.menuFooter()
+                  : item.menuFooter)}
+            </>
+          )}
         </SubMenuPanel>
       )}
     </>

--- a/src/models/dropdown.ts
+++ b/src/models/dropdown.ts
@@ -1,6 +1,13 @@
 import type { DropdownItemType } from '@/types/dropdown';
 import type { ReactNode, MouseEvent } from 'react';
 
+export interface DropdownSubMenuHoverOptions {
+  /** Delay (ms) before the submenu opens/closes on hover. Defaults to `{ open: 80, close: 80 }`. */
+  delay?: number | { open?: number; close?: number };
+  /** Whether pointer movement (not just rest) can trigger the hover open. Defaults to `false`. */
+  move?: boolean;
+}
+
 export interface DropdownItem {
   key: string;
   label?: ReactNode;
@@ -11,4 +18,15 @@ export interface DropdownItem {
   className?: string;
   onClick?: (info: { key: string; domEvent: MouseEvent }) => void;
   children?: DropdownItem[];
+  /** Content rendered above the children list in this item's submenu panel. */
+  menuHeader?: ReactNode | (() => ReactNode);
+  /** Content rendered below the children list in this item's submenu panel. */
+  menuFooter?: ReactNode | (() => ReactNode);
+  /**
+   * Fully replaces the submenu panel content (children/menuHeader/menuFooter are ignored).
+   * Use this to show a custom popup — e.g. a preview or a picker — instead of a plain item list.
+   */
+  renderSubMenu?: () => ReactNode;
+  /** Overrides the default hover-open behavior of this item's submenu. */
+  subMenuHoverOptions?: DropdownSubMenuHoverOptions;
 }

--- a/src/models/dropdown.ts
+++ b/src/models/dropdown.ts
@@ -27,6 +27,13 @@ export interface DropdownItem {
    * Use this to show a custom popup — e.g. a preview or a picker — instead of a plain item list.
    */
   renderSubMenu?: () => ReactNode;
+  /**
+   * Replaces this item's icon + label content while keeping its button element, click
+   * handling, and (for a submenu trigger) the caret intact. Use this for lighter-weight
+   * customization — e.g. a badge or avatar next to the label — without giving up the
+   * default row/list wiring the way `renderSubMenu` does.
+   */
+  renderItem?: (item: DropdownItem) => ReactNode;
   /** Overrides the default hover-open behavior of this item's submenu. */
   subMenuHoverOptions?: DropdownSubMenuHoverOptions;
 }

--- a/src/utils/sub-menu-floating.tsx
+++ b/src/utils/sub-menu-floating.tsx
@@ -19,6 +19,11 @@ import { useState, type ReactNode } from 'react';
 // Hook
 // ---------------------------------------------------------------------------
 
+export interface SubMenuHoverOptions {
+  delay?: number | { open?: number; close?: number };
+  move?: boolean;
+}
+
 /**
  * Shared floating state for right-side submenus.
  * Handles open state, Floating UI positioning and hover/dismiss/role interactions.
@@ -27,6 +32,7 @@ export function useSubMenuFloating(
   gap: number,
   ariaRole: 'menu' | 'listbox' = 'menu',
   disabled = false,
+  hoverOptions?: SubMenuHoverOptions,
 ) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -44,8 +50,8 @@ export function useSubMenuFloating(
 
   const hover = useHover(context, {
     enabled: !disabled,
-    move: false,
-    delay: { open: 80, close: 80 },
+    move: hoverOptions?.move ?? false,
+    delay: hoverOptions?.delay ?? { open: 80, close: 80 },
   });
   const click = useClick(context, { enabled: !disabled });
   const dismiss = useDismiss(context, {


### PR DESCRIPTION
**Description and UI changes:**

Support dropdown menu customization - custom item render, adding footer/header for the submenu, add fully custom submenu render

<img width="1895" height="679" alt="image" src="https://github.com/user-attachments/assets/89d0de54-716d-4159-a954-45194d092c31" />
<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/b627c681-f07c-46be-9473-fe0242090f72" />
<img width="772" height="343" alt="image" src="https://github.com/user-attachments/assets/bf4aa38a-40eb-421b-8c97-ebf1f2b81057" />


Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added