### PR TITLE
feat(2.0): rebuild Search on the 2.0 Input and add a large field size

### DIFF
--- a/src/components/New/IconButton/IconButton.tsx
+++ b/src/components/New/IconButton/IconButton.tsx
@@ -17,6 +17,13 @@ import { getButtonClassNames } from '../Button/utils';
 
 type TooltipProps = Omit<DialTooltipProps, 'children'>;
 
+/** Square footprint per size, matching the field heights in `input.scss`. */
+const SIZE_CLASS: Record<ElementSize, string> = {
+  [ElementSize.Small]: 'size-[24px]',
+  [ElementSize.Standard]: 'size-[40px] dial-kit-enhanced-target',
+  [ElementSize.Large]: 'size-[48px] dial-kit-enhanced-target',
+};
+
 export interface IconButtonProps extends DetailedHTMLProps<
   ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
@@ -75,9 +82,9 @@ export const IconButton: FC<IconButtonProps> = ({
   const btnClassName = mergeClasses(
     'dial-kit-base-icon-button dial-kit-base-button',
     variant && getButtonClassNames(variant, appearance),
-    size === ElementSize.Small
-      ? 'size-[24px]'
-      : 'size-[40px] dial-kit-enhanced-target',
+    // 24px is below the AAA target size, so only the larger tiers get the
+    // enhanced pointer target — see the accessibility rules in AGENTS.md.
+    SIZE_CLASS[size],
     className,
   );
 

--- a/src/components/New/Input/Button/InputButton.tsx
+++ b/src/components/New/Input/Button/InputButton.tsx
@@ -5,6 +5,13 @@ import { mergeClasses } from '@/utils/merge-classes';
 import { IconButton } from '../../IconButton/IconButton';
 import { inputButtonClassName } from './constants';
 
+/** Matches the field heights in `input.scss`, so the button fills its end. */
+const BOX_SIZE_CLASS: Record<ElementSize, string> = {
+  [ElementSize.Small]: 'size-[24px]',
+  [ElementSize.Standard]: 'size-[40px]',
+  [ElementSize.Large]: 'size-[48px]',
+};
+
 export interface InputButtonProps {
   icon: ReactNode;
   disabled?: boolean;
@@ -36,10 +43,7 @@ export const InputButton: FC<InputButtonProps> = ({
 }) => {
   return (
     <div
-      className={mergeClasses(
-        'border-l border-tertiary',
-        size === ElementSize.Standard ? 'size-[40px]' : 'size-[24px]',
-      )}
+      className={mergeClasses('border-l border-tertiary', BOX_SIZE_CLASS[size])}
     >
       <IconButton
         className={mergeClasses(

--- a/src/components/New/Input/Input.spec.tsx
+++ b/src/components/New/Input/Input.spec.tsx
@@ -265,6 +265,32 @@ describe('Dial UI Kit :: DialInput', () => {
       expect(getField()).not.toHaveClass('py-2');
     });
 
+    test('renders the large variant when size is large', () => {
+      render(
+        <Input
+          id="large-size"
+          placeholder="Placeholder"
+          size={ElementSize.Large}
+        />,
+      );
+
+      expect(getField()).toHaveClass('dial-kit-input-large', 'gap-x-2', 'pl-4');
+      expect(getField()).not.toHaveClass('dial-kit-input-small');
+    });
+
+    test('scales the input button with the large field', () => {
+      render(
+        <Input
+          id="large-with-button"
+          placeholder="Placeholder"
+          size={ElementSize.Large}
+          inputButtonProps={{ icon: <span>x</span> }}
+        />,
+      );
+
+      expect(screen.getByRole('button')).toHaveClass('size-[48px]');
+    });
+
     test('passes the size down to the prefix field', () => {
       render(
         <Input

--- a/src/components/New/Input/Input.stories.tsx
+++ b/src/components/New/Input/Input.stories.tsx
@@ -36,8 +36,9 @@ const meta = {
     ...inputBaseArgTypes,
     size: {
       control: { type: 'inline-radio' },
-      options: [ElementSize.Standard, ElementSize.Small],
-      description: 'Field height: standard is 40px, small is 24px',
+      options: [ElementSize.Standard, ElementSize.Small, ElementSize.Large],
+      description:
+        'Field height: standard is 40px, small is 24px, large is 48px',
     },
   },
   args: {
@@ -78,6 +79,7 @@ export const Small: Story = {
 export const Sizes: Story = {
   render: () => {
     const sizes = [
+      { size: ElementSize.Large, label: 'Large (48px)' },
       { size: ElementSize.Standard, label: 'Standard (40px)' },
       { size: ElementSize.Small, label: 'Small (24px)' },
     ];
@@ -88,10 +90,11 @@ export const Sizes: Story = {
 
         <div className="flex flex-col gap-y-8">
           {sizes.map(({ size, label }) => {
-            const iconSize =
-              size === ElementSize.Small
-                ? DIAL_ICON_SIZE.SM
-                : DIAL_ICON_SIZE.MD;
+            const iconSize = {
+              [ElementSize.Small]: DIAL_ICON_SIZE.SM,
+              [ElementSize.Standard]: DIAL_ICON_SIZE.MD,
+              [ElementSize.Large]: DIAL_ICON_SIZE.LG,
+            }[size];
 
             return (
               <div key={size} className="flex flex-col gap-y-3">

--- a/src/components/New/Input/Input.tsx
+++ b/src/components/New/Input/Input.tsx
@@ -20,6 +20,47 @@ import { Label, type LabelProps } from '../Label/Label';
 import { InputButton, type InputButtonProps } from './Button/InputButton';
 import { handleKeyDown } from './utils';
 
+/**
+ * Per-size metrics for the field. Height and typography are not here: they live
+ * in `input.scss`, because a utility class would lose the cascade to the
+ * unlayered `.dial-kit-input` — see the comment on `.dial-kit-input-small`.
+ */
+const SIZE_CLASSES: Record<
+  ElementSize,
+  {
+    /** Gap between the field's slots, plus the height/typography modifier. */
+    field: string;
+    /** Inline padding, used only when no prefix / input button occupies the edge. */
+    paddingStart: string;
+    paddingEnd: string;
+    /** Gap between the label, the field and the caption. */
+    stackGap: string;
+    postfixText: string;
+  }
+> = {
+  [ElementSize.Small]: {
+    field: 'dial-kit-input-small gap-x-1',
+    paddingStart: 'pl-2',
+    paddingEnd: 'pr-2',
+    stackGap: 'gap-1',
+    postfixText: 'dial-tiny-text',
+  },
+  [ElementSize.Standard]: {
+    field: 'gap-x-2 py-2',
+    paddingStart: 'pl-3',
+    paddingEnd: 'pr-3',
+    stackGap: 'gap-2',
+    postfixText: 'dial-small-text',
+  },
+  [ElementSize.Large]: {
+    field: 'dial-kit-input-large gap-x-2 py-3',
+    paddingStart: 'pl-4',
+    paddingEnd: 'pr-4',
+    stackGap: 'gap-2',
+    postfixText: 'dial-body-text',
+  },
+};
+
 // `size` shadows the native input attribute (a character-width number) on
 // purpose: every 2.0 control sizes itself through the ElementSize enum.
 export interface InputProps extends Omit<
@@ -110,7 +151,7 @@ export const Input: FC<InputProps> = ({
     <div
       className={mergeClasses(
         'flex flex-col',
-        size === ElementSize.Small ? 'gap-1' : 'gap-2',
+        SIZE_CLASSES[size].stackGap,
         containerClassName,
       )}
     >
@@ -152,7 +193,7 @@ const InputWrapper: FC<InputWrapperProps> = ({
   size = ElementSize.Standard,
   ...props
 }) => {
-  const isSmall = size === ElementSize.Small;
+  const sizeClasses = SIZE_CLASSES[size];
   const innerRef = useRef<HTMLInputElement | null>(null);
   const ref = useMergeRefs([inputRef, innerRef]);
 
@@ -210,11 +251,11 @@ const InputWrapper: FC<InputWrapperProps> = ({
         ref={wrapperRef}
         className={mergeClasses(
           'dial-kit-input flex flex-row items-center justify-between',
-          isSmall ? 'dial-kit-input-small gap-x-1' : 'gap-x-2 py-2',
+          sizeClasses.field,
           invalid && 'dial-kit-input-error',
           disabled && 'dial-kit-input-disable',
-          !prefix && (isSmall ? 'pl-2' : 'pl-3'),
-          !inputButtonProps && (isSmall ? 'pr-2' : 'pr-3'),
+          !prefix && sizeClasses.paddingStart,
+          !inputButtonProps && sizeClasses.paddingEnd,
           wrapperClassName,
         )}
         aria-label="input-container"
@@ -256,10 +297,7 @@ const InputWrapper: FC<InputWrapperProps> = ({
 
         {postfix && (
           <p
-            className={mergeClasses(
-              'text-secondary',
-              isSmall ? 'dial-tiny-text' : 'dial-small-text',
-            )}
+            className={mergeClasses('text-secondary', sizeClasses.postfixText)}
           >
             {' '}
             {postfix}

--- a/src/components/New/Search/Search.spec.tsx
+++ b/src/components/New/Search/Search.spec.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { ElementSize } from '@/types/size';
+import { Search } from './Search';
+
+/** Mirrors how a consumer wires the controlled field. */
+const ControlledSearch = ({ initial = '' }: { initial?: string }) => {
+  const [value, setValue] = useState<string | undefined>(initial);
+
+  return (
+    <Search
+      id="search"
+      placeholder="Search"
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+describe('Dial UI Kit :: Search', () => {
+  test('renders a text box with the default placeholder', () => {
+    render(<Search id="search" />);
+
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  test('reports every edit through onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Search id="search" placeholder="Search" onChange={onChange} />);
+
+    await user.type(screen.getByPlaceholderText('Search'), 'a');
+
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  test('reports an emptied field as undefined', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Search id="search" placeholder="Search" value="a" onChange={onChange} />,
+    );
+
+    await user.clear(screen.getByPlaceholderText('Search'));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  test('calls onBlur when the field loses focus', async () => {
+    const user = userEvent.setup();
+    const onBlur = vi.fn();
+    render(<Search id="search" placeholder="Search" onBlur={onBlur} />);
+
+    await user.click(screen.getByPlaceholderText('Search'));
+    await user.tab();
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('disables the field', () => {
+    render(<Search id="search" placeholder="Search" disabled />);
+
+    expect(screen.getByPlaceholderText('Search')).toBeDisabled();
+  });
+
+  describe('clear button', () => {
+    test('is absent while the field is empty', () => {
+      render(<Search id="search" placeholder="Search" />);
+
+      expect(
+        screen.queryByRole('button', { name: 'Clear search' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('is absent on a disabled field that holds a value', () => {
+      render(<Search id="search" placeholder="Search" value="a" disabled />);
+
+      expect(
+        screen.queryByRole('button', { name: 'Clear search' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('empties the field when pressed', async () => {
+      const user = userEvent.setup();
+      render(<ControlledSearch initial="hello" />);
+
+      await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+      expect(screen.getByPlaceholderText('Search')).toHaveValue('');
+    });
+
+    test('returns focus to the input so it is not lost with the button', async () => {
+      const user = userEvent.setup();
+      render(<ControlledSearch initial="hello" />);
+
+      await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+      expect(screen.getByPlaceholderText('Search')).toHaveFocus();
+    });
+
+    test('takes its accessible name from clearLabel', () => {
+      render(
+        <Search
+          id="search"
+          placeholder="Search"
+          value="a"
+          clearLabel="Reset filter"
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Reset filter' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('size', () => {
+    // jsdom does no layout, so only the variant class is observable here.
+    test.each([
+      [ElementSize.Small, 'dial-kit-input-small'],
+      [ElementSize.Large, 'dial-kit-input-large'],
+    ])('passes %s down to the field', (size, expected) => {
+      render(<Search id="search" placeholder="Search" size={size} />);
+
+      expect(screen.getByLabelText('input-container')).toHaveClass(expected);
+    });
+
+    test('scales the magnifier with the field', () => {
+      const { rerender } = render(
+        <Search id="search" placeholder="Search" size={ElementSize.Small} />,
+      );
+      const magnifier = () =>
+        screen.getByLabelText('input-container').querySelector('svg');
+
+      expect(magnifier()).toHaveAttribute('width', '16');
+
+      rerender(
+        <Search id="search" placeholder="Search" size={ElementSize.Large} />,
+      );
+
+      expect(magnifier()).toHaveAttribute('width', '24');
+    });
+  });
+
+  describe('withoutBorder', () => {
+    test('adds the borderless modifier to the field wrapper', () => {
+      render(<Search id="search" placeholder="Search" withoutBorder />);
+
+      expect(screen.getByLabelText('input-container')).toHaveClass(
+        'dial-kit-input-borderless',
+      );
+    });
+
+    test('is off by default', () => {
+      render(<Search id="search" placeholder="Search" />);
+
+      expect(screen.getByLabelText('input-container')).not.toHaveClass(
+        'dial-kit-input-borderless',
+      );
+    });
+  });
+
+  test('keeps a consumer inputRef working alongside the internal one', async () => {
+    const user = userEvent.setup();
+    let node: HTMLInputElement | null = null;
+    render(
+      <Search
+        id="search"
+        placeholder="Search"
+        size={ElementSize.Small}
+        inputRef={(element) => {
+          node = element;
+        }}
+      />,
+    );
+
+    await user.click(screen.getByPlaceholderText('Search'));
+
+    expect(node).toBe(screen.getByPlaceholderText('Search'));
+  });
+});

--- a/src/components/New/Search/Search.stories.tsx
+++ b/src/components/New/Search/Search.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState, type FC } from 'react';
+
+import { ElementSize } from '@/types/size';
+import { Search, type SearchProps } from './Search';
+
+const InteractiveSearch = (args: SearchProps) => {
+  const [value, setValue] = useState(args.value as string | undefined);
+
+  return <Search {...args} value={value} onChange={setValue} />;
+};
+
+const meta = {
+  title: 'Components_2_0/Search',
+  component: Search,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A search field from the 2.0 design system, built on `Input`. Controlled: it renders the `value` it is given and reports edits through `onChange`, which receives `undefined` for an empty field. The clear button shows only while there is something to clear and hands focus back to the input.',
+      },
+    },
+  },
+  argTypes: {
+    id: {
+      control: 'text',
+      description: 'Unique identifier for the input element',
+    },
+    value: { control: 'text', description: 'Current query' },
+    placeholder: { control: 'text', description: 'Placeholder text' },
+    size: {
+      control: 'select',
+      options: [ElementSize.Standard, ElementSize.Small, ElementSize.Large],
+      description:
+        'Field height — standard is 40px, small is 24px, large is 48px',
+      table: { defaultValue: { summary: ElementSize.Standard } },
+    },
+    withoutBorder: {
+      control: 'boolean',
+      description: 'Renders the field without its border and background',
+    },
+    clearLabel: {
+      control: 'text',
+      description: 'Accessible name of the clear button',
+    },
+    disabled: { control: 'boolean', description: 'Disables the field' },
+    invalid: { control: 'boolean', description: 'Applies error styling' },
+    onChange: {
+      action: 'changed',
+      control: false,
+      description: 'Fired with the new query, or `undefined` when emptied',
+    },
+    onBlur: {
+      action: 'blurred',
+      control: false,
+      description: 'Fired when the field loses focus',
+    },
+  },
+} satisfies Meta<typeof Search>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: InteractiveSearch,
+  args: { id: 'search', placeholder: 'Search' },
+};
+
+export const Filled: Story = {
+  render: InteractiveSearch,
+  args: { id: 'search-filled', placeholder: 'Search', value: 'Conversations' },
+};
+
+export const Small: Story = {
+  render: InteractiveSearch,
+  args: {
+    id: 'search-small',
+    placeholder: 'Search',
+    size: ElementSize.Small,
+    value: 'Conversations',
+  },
+};
+
+export const Large: Story = {
+  render: InteractiveSearch,
+  args: {
+    id: 'search-large',
+    placeholder: 'Search',
+    size: ElementSize.Large,
+    value: 'Conversations',
+  },
+};
+
+export const WithoutBorder: Story = {
+  render: InteractiveSearch,
+  args: {
+    id: 'search-borderless',
+    placeholder: 'Search',
+    withoutBorder: true,
+    value: 'Conversations',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Sits flush in a toolbar or panel header. The border stays at full width and turns transparent, so toggling it never shifts the layout.',
+      },
+    },
+  },
+};
+
+export const WithLabelAndCaption: Story = {
+  render: InteractiveSearch,
+  args: {
+    id: 'search-labelled',
+    placeholder: 'Search',
+    labelProps: { label: 'Find a conversation' },
+    caption: 'Matches titles and message text',
+  },
+};
+
+const AllVariantsComponent: FC = () => {
+  const states: { label: string; props: Partial<SearchProps> }[] = [
+    { label: 'Empty', props: {} },
+    { label: 'Filled', props: { value: 'Conversations' } },
+    {
+      label: 'Borderless',
+      props: { value: 'Conversations', withoutBorder: true },
+    },
+    { label: 'Invalid', props: { value: 'Conversations', invalid: true } },
+    { label: 'Disabled', props: { disabled: true } },
+    {
+      label: 'Disabled filled',
+      props: { value: 'Conversations', disabled: true },
+    },
+  ];
+
+  return (
+    <div className="flex min-w-[640px] flex-row gap-8 p-8">
+      {[ElementSize.Large, ElementSize.Standard, ElementSize.Small].map(
+        (size) => (
+          <div key={size} className="flex-1">
+            <div className="dial-small-semi-text mb-4 capitalize text-primary">
+              Size: {size}
+            </div>
+            <div className="flex flex-col gap-4">
+              {states.map(({ label, props }) => (
+                <div key={label}>
+                  <div className="dial-tiny-text mb-1 text-secondary">
+                    {label}
+                  </div>
+                  <InteractiveSearch
+                    id={`search-${size}-${label.replace(/\s/g, '-')}`}
+                    placeholder="Search"
+                    size={size}
+                    {...props}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ),
+      )}
+    </div>
+  );
+};
+
+export const AllVariants: Story = {
+  args: { id: 'search-all' },
+  render: () => <AllVariantsComponent />,
+};

--- a/src/components/New/Search/Search.tsx
+++ b/src/components/New/Search/Search.tsx
@@ -1,0 +1,125 @@
+import { IconSearch, IconX } from '@tabler/icons-react';
+import { useCallback, useRef, type FC } from 'react';
+
+import { useMergeRefs } from '@floating-ui/react';
+
+import { GhostIconButton } from '@/components/New/IconButton/IconButtonWrappers';
+import { Input, type InputProps } from '@/components/New/Input/Input';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
+
+/** The magnifier tracks the field height; the clear button stays small at every size. */
+const SEARCH_ICON_SIZE: Record<ElementSize, DIAL_ICON_SIZE> = {
+  [ElementSize.Small]: DIAL_ICON_SIZE.SM,
+  [ElementSize.Standard]: DIAL_ICON_SIZE.MD,
+  [ElementSize.Large]: DIAL_ICON_SIZE.LG,
+};
+
+export interface SearchProps extends Omit<
+  InputProps,
+  | 'type'
+  | 'iconBefore'
+  | 'iconAfter'
+  | 'inputButtonProps'
+  | 'prefix'
+  | 'postfix'
+  | 'children'
+> {
+  /**
+   * Drops the field's border and background so the input sits flush in a
+   * toolbar or panel header. The border is kept transparent rather than removed,
+   * so toggling this never shifts the layout by a pixel.
+   */
+  withoutBorder?: boolean;
+  /** Accessible name of the clear button. */
+  clearLabel?: string;
+}
+
+/**
+ * A search field with a leading magnifier and a clear button, built on {@link Input}.
+ * aliases: SearchField|QueryInput|SearchBox
+ * Design system 2.0
+ *
+ * Fully controlled: it renders exactly the `value` it is given and reports every
+ * edit through `onChange`, which receives `undefined` for an empty field. The
+ * clear button appears only while there is something to clear, and returns focus
+ * to the input once pressed so keyboard users are not dropped to the page body.
+ *
+ * `type` and both icon slots are owned by this component; every other
+ * {@link Input} prop is passed through.
+ *
+ * @example
+ * ```tsx
+ * <Search
+ *   id="search"
+ *   value={query}
+ *   placeholder="Search"
+ *   onChange={setQuery}
+ * />
+ * ```
+ *
+ * @param [size=ElementSize.Standard] - Field height: standard is 40px, small is 24px
+ * @param [placeholder="Search..."] - Placeholder shown while the field is empty
+ * @param [withoutBorder=false] - Renders the field without its border and background
+ * @param [clearLabel="Clear search"] - Accessible name of the clear button
+ * @param [disabled=false] - Disables the field and hides the clear button
+ */
+export const Search: FC<SearchProps> = ({
+  size = ElementSize.Standard,
+  placeholder = 'Search...',
+  withoutBorder = false,
+  clearLabel = 'Clear search',
+  disabled,
+  value,
+  onChange,
+  wrapperClassName,
+  inputRef,
+  ...props
+}) => {
+  const innerRef = useRef<HTMLInputElement | null>(null);
+  const ref = useMergeRefs([inputRef, innerRef]);
+
+  // Nothing to clear on an empty field, and a disabled one cannot be cleared.
+  const showClear = !!value && !disabled;
+
+  const onClear = useCallback(() => {
+    onChange?.(undefined);
+    // The button unmounts with the value it cleared, so focus would otherwise
+    // fall back to the document body mid-interaction.
+    innerRef.current?.focus();
+  }, [onChange]);
+
+  return (
+    <Input
+      {...props}
+      size={size}
+      value={value}
+      disabled={disabled}
+      onChange={onChange}
+      placeholder={placeholder}
+      inputRef={ref}
+      wrapperClassName={mergeClasses(
+        withoutBorder && 'dial-kit-input-borderless',
+        wrapperClassName,
+      )}
+      iconBefore={
+        <IconSearch
+          size={SEARCH_ICON_SIZE[size]}
+          className="text-secondary"
+          aria-hidden="true"
+        />
+      }
+      iconAfter={
+        showClear ? (
+          <GhostIconButton
+            size={ElementSize.Small}
+            aria-label={clearLabel}
+            icon={<IconX size={DIAL_ICON_SIZE.SM} aria-hidden="true" />}
+            onClick={onClear}
+          />
+        ) : undefined
+      }
+    />
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,4 +373,6 @@ export { Tag } from './components/New/Tag/Tag';
 export type { TagProps } from './components/New/Tag/Tag';
 export { TagInput } from './components/New/TagInput/TagInput';
 export type { TagInputProps } from './components/New/TagInput/TagInput';
+export { Search } from './components/New/Search/Search';
+export type { SearchProps } from './components/New/Search/Search';
 export { matchesAccept } from './utils/file-accept';

--- a/src/styles/input.scss
+++ b/src/styles/input.scss
@@ -34,6 +34,26 @@
   @apply h-[24px] dial-tiny-text;
 }
 
+/* Same cascade constraint as the small variant above. */
+.dial-kit-input-large {
+  @apply h-[48px] dial-body-paragraph-text;
+}
+
+/*
+ * For fields that sit flush in a toolbar or panel header. Same cascade reason as
+ * `.dial-kit-input-small` above: a `border-transparent` utility would lose to
+ * `.dial-kit-input`, so the modifier has to be a component class and has to stay
+ * after the base rule. The border is kept at full width and made transparent
+ * rather than removed, so toggling it never shifts the layout.
+ */
+.dial-kit-input-borderless {
+  @apply border-transparent bg-transparent;
+
+  &:not(:disabled):hover {
+    @apply border-transparent;
+  }
+}
+
 .dial-kit-input-disable,
 .dial-kit-input-disable:not(:placeholder-shown) {
   @apply cursor-not-allowed bg-layer-sunken text-control-disable-alpha;


### PR DESCRIPTION
## Search — rewritten as a 2.0 component

`src/components/New/Search/` was a byte-for-byte copy of the 1.0 component, still importing `DialInput`. It is now built on `New/Input`, exported as `Search` / `SearchProps` (2.0 drops the `Dial` prefix, matching `Tabs`/`Tag`/`Switch`), and modelled on `PasswordInput` — the existing 2.0 wrapper of the same shape.

Beyond the imports:

- **Fully controlled.** The `useState` + `useEffect` value mirror is gone; it renders the `value` it is given.
- **`onChange` reports `undefined` for an empty field** (1.0 gave `''`), so `Search` no longer narrows its parent's signature.
- **The clear button is a real button.** 1.0 put `aria-label="Clear search"` and `role="button"` on the bare `<svg>`, which is not focusable — keyboard users had no way to reach it. It is now a `GhostIconButton` with the icon `aria-hidden`, plus a `clearLabel` prop for translation.
- **Focus returns to the input after clearing.** The button unmounts with the value it cleared, so focus was landing on `<body>` mid-interaction.
- **`withoutBorder` no longer needs `!important`.** 1.0 used `!border-0 ps-5 [&>div]:!border-0` because utilities lose the cascade to the unlayered `.dial-kit-input`. Replaced by a `.dial-kit-input-borderless` modifier that keeps the border at full width and makes it transparent, so toggling it does not shift layout.
- **`constants.ts` deleted.** `SIZE_CONFIG` existed to hand-size the 1.0 input; `Input` owns height and typography now, and its `Large` entry was dead (all zeros).

## `ElementSize.Large` now exists

`Large` was in the enum and in `Input`'s JSDoc but implemented nowhere: `Input` branched only on `isSmall`, so a `Large` field rendered as `Standard`, and `InputButton` sized it as the **24px small** button.

`Input` now maps every size through one table, backed by a new `.dial-kit-input-large` modifier — 48px, `dial-body-paragraph-text` (16/26), `pl-4`/`pr-4` — extrapolating the existing 24px/40px progression. `IconButton` and `InputButton` follow at 48px. Every field built on `Input` (`PasswordInput`, `NumberInput`, `Select`, `TagInput`, `Search`) gains the tier.

No CHANGELOG entry: no released tag contains `src/components/New/` at all, so none of this is consumer-visible yet.

## Verification

- `npx vitest run` — 160 files, 2098 tests passing
- `npm run lint` clean; `tsc --noEmit` reports no errors in the touched files
- `npm run build:css` compiles `.dial-kit-input-large` to `height:48px;font-size:16px;line-height:26px` and `.size-[48px]` to `width:48px;height:48px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)