### PR TITLE
feat(2.0): align Tabs with design tokens for all states

### DIFF
--- a/src/components/New/Tabs/Tabs.spec.tsx
+++ b/src/components/New/Tabs/Tabs.spec.tsx
@@ -96,6 +96,116 @@ describe('Dial UI Kit :: Tabs', () => {
     expect(screen.getByRole('tab', { name: 'All 0' })).toBeInTheDocument();
   });
 
+  test('gives only the selected tab the gradient underline', () => {
+    render(<Tabs tabs={tabs} activeTabId="shared" onTabChange={vi.fn()} />);
+
+    expect(screen.getByRole('tab', { name: 'Shared' })).toHaveClass(
+      'dial-kit-tab-selected-underline',
+    );
+    expect(screen.getByRole('tab', { name: 'All' })).not.toHaveClass(
+      'dial-kit-tab-selected-underline',
+    );
+  });
+
+  describe('disabled tabs', () => {
+    const withDisabled = [
+      { id: 'all', label: 'All' },
+      { id: 'shared', label: 'Shared', disabled: true },
+      { id: 'published', label: 'Published' },
+    ];
+
+    test('disables the tab and paints it with the disabled tokens', () => {
+      render(
+        <Tabs tabs={withDisabled} activeTabId="all" onTabChange={vi.fn()} />,
+      );
+
+      const disabled = screen.getByRole('tab', { name: 'Shared' });
+
+      expect(disabled).toBeDisabled();
+      expect(disabled).toHaveClass('text-control-disable-alpha');
+      expect(disabled).toHaveClass('border-control-disable-alpha');
+    });
+
+    test('a disabled tab keeps the flat underline even while selected', () => {
+      render(
+        <Tabs tabs={withDisabled} activeTabId="shared" onTabChange={vi.fn()} />,
+      );
+
+      const disabled = screen.getByRole('tab', { name: 'Shared' });
+
+      expect(disabled).toHaveClass('border-control-disable-alpha');
+      expect(disabled).not.toHaveClass('dial-kit-tab-selected-underline');
+    });
+
+    test('does not call onTabChange when a disabled tab is clicked', async () => {
+      const user = userEvent.setup();
+      const onTabChange = vi.fn();
+      render(
+        <Tabs
+          tabs={withDisabled}
+          activeTabId="all"
+          onTabChange={onTabChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('tab', { name: 'Shared' }));
+
+      expect(onTabChange).not.toHaveBeenCalled();
+    });
+
+    test('the arrow keys skip over a disabled tab', async () => {
+      const user = userEvent.setup();
+      const onTabChange = vi.fn();
+      render(
+        <Tabs
+          tabs={withDisabled}
+          activeTabId="all"
+          onTabChange={onTabChange}
+        />,
+      );
+
+      screen.getByRole('tab', { name: 'All' }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(onTabChange).toHaveBeenCalledWith('published');
+    });
+
+    test('End lands on the last enabled tab', async () => {
+      const user = userEvent.setup();
+      const onTabChange = vi.fn();
+      render(
+        <Tabs
+          tabs={[
+            { id: 'all', label: 'All' },
+            { id: 'published', label: 'Published', disabled: true },
+          ]}
+          activeTabId="all"
+          onTabChange={onTabChange}
+        />,
+      );
+
+      screen.getByRole('tab', { name: 'All' }).focus();
+      await user.keyboard('{End}');
+
+      expect(onTabChange).not.toHaveBeenCalled();
+    });
+
+    test('moves the tab stop to the first enabled tab when the active tab is disabled', () => {
+      render(
+        <Tabs tabs={withDisabled} activeTabId="shared" onTabChange={vi.fn()} />,
+      );
+
+      expect(screen.getByRole('tab', { name: 'Shared' })).toHaveAttribute(
+        'tabindex',
+        '-1',
+      );
+      expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute(
+        'tabindex',
+        '0',
+      );
+    });
+  });
+
   describe('keyboard navigation', () => {
     test('the arrow keys move selection and focus', async () => {
       const user = userEvent.setup();

--- a/src/components/New/Tabs/Tabs.stories.tsx
+++ b/src/components/New/Tabs/Tabs.stories.tsx
@@ -66,6 +66,12 @@ const tabsWithCounts = [
   { id: 'published', label: 'Published', count: 0 },
 ];
 
+const tabsWithDisabled = [
+  { id: 'all', label: 'All', count: 12 },
+  { id: 'shared', label: 'Shared with me', disabled: true },
+  { id: 'published', label: 'Published', count: 4, disabled: true },
+];
+
 const noop = () => undefined;
 
 export const Default: Story = {
@@ -85,6 +91,24 @@ export const WithCounts: Story = {
     activeTabId: 'all',
     onTabChange: noop,
     ariaLabel: 'Conversation views',
+  },
+};
+
+export const WithDisabledTabs: Story = {
+  render: InteractiveTabs,
+  args: {
+    tabs: tabsWithDisabled,
+    activeTabId: 'all',
+    onTabChange: noop,
+    ariaLabel: 'Conversation views',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Disabled tabs are greyed out, cannot be clicked, and the arrow keys skip over them.',
+      },
+    },
   },
 };
 
@@ -110,6 +134,17 @@ export const AllVariants: Story = {
           activeTabId="shared"
           onTabChange={() => undefined}
           ariaLabel="Tabs with counts"
+        />
+      </div>
+      <div>
+        <div className="dial-small-semi-text mb-2 text-primary">
+          With disabled tabs
+        </div>
+        <InteractiveTabs
+          tabs={tabsWithDisabled}
+          activeTabId="all"
+          onTabChange={() => undefined}
+          ariaLabel="Tabs with disabled entries"
         />
       </div>
       <div>

--- a/src/components/New/Tabs/Tabs.tsx
+++ b/src/components/New/Tabs/Tabs.tsx
@@ -10,6 +10,8 @@ export interface TabItem {
   label: string;
   /** Optional numeric badge rendered after the label. */
   count?: number;
+  /** Renders the tab greyed out and unselectable, and skips it during keyboard navigation. */
+  disabled?: boolean;
 }
 
 export interface TabsProps {
@@ -41,6 +43,8 @@ const NAVIGATION_KEYS = ['ArrowRight', 'ArrowLeft', 'Home', 'End'];
  * Follows the ARIA tabs pattern with automatic activation: only the active tab is
  * in the tab order, and the arrow keys move both focus and selection. `Home` and
  * `End` jump to the first and last tab, and the arrows wrap around the ends.
+ * Tabs marked `disabled` are greyed out, cannot be clicked, and are skipped by
+ * keyboard navigation.
  *
  * The component renders the tabs only; the panels stay with the consumer.
  *
@@ -74,16 +78,29 @@ export const Tabs: FC<TabsProps> = ({
 }) => {
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
+  // Roving tabindex: the row is a single tab stop. A disabled tab cannot hold it,
+  // so an `activeTabId` pointing at one falls back to the first enabled tab —
+  // otherwise the row would drop out of the tab order entirely.
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  const tabStopId =
+    activeTab && !activeTab.disabled
+      ? activeTab.id
+      : tabs.find((tab) => !tab.disabled)?.id;
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
       if (!NAVIGATION_KEYS.includes(event.key) || tabs.length === 0) return;
 
+      // Disabled tabs are not selectable, so they are not navigation targets either.
+      const selectable = tabs.filter((tab) => !tab.disabled);
+      if (selectable.length === 0) return;
+
       // An `activeTabId` that matches nothing still has to have somewhere to go.
       const activeIndex = Math.max(
-        tabs.findIndex((tab) => tab.id === activeTabId),
+        selectable.findIndex((tab) => tab.id === activeTabId),
         0,
       );
-      const lastIndex = tabs.length - 1;
+      const lastIndex = selectable.length - 1;
 
       let nextIndex = activeIndex;
       switch (event.key) {
@@ -104,7 +121,7 @@ export const Tabs: FC<TabsProps> = ({
       // Arrow keys would otherwise scroll the page along with moving selection.
       event.preventDefault();
 
-      const nextTab = tabs[nextIndex];
+      const nextTab = selectable[nextIndex];
       tabRefs.current[nextTab.id]?.focus();
       if (nextTab.id !== activeTabId) {
         onTabChange(nextTab.id);
@@ -118,13 +135,11 @@ export const Tabs: FC<TabsProps> = ({
       role="tablist"
       aria-label={ariaLabel}
       onKeyDown={handleKeyDown}
-      className={mergeClasses(
-        'flex justify-start gap-1 border-b border-tertiary',
-        className,
-      )}
+      className={mergeClasses('flex justify-start gap-1', className)}
     >
       {tabs.map((tab) => {
         const isActive = activeTabId === tab.id;
+        const isDisabled = !!tab.disabled;
 
         return (
           <button
@@ -135,19 +150,20 @@ export const Tabs: FC<TabsProps> = ({
             type="button"
             role="tab"
             aria-selected={isActive}
-            // Roving tabindex: the tab list is a single tab stop, and the arrow
-            // keys move within it.
-            tabIndex={isActive ? 0 : -1}
+            disabled={isDisabled}
+            tabIndex={tab.id === tabStopId ? 0 : -1}
             onClick={() => onTabChange(tab.id)}
             className={mergeClasses(
-              'dial-small-semi-text dial-kit-enhanced-target',
-              // Pulled a pixel down so the tab's own border sits on top of the row's.
-              '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-start',
+              'dial-small-paragraph-semi-text dial-kit-enhanced-target',
+              'border-b-2 border-transparent flex items-center gap-2 px-3 py-2 text-start',
               'transition-colors motion-reduce:transition-none',
               'focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-focus-black',
-              isActive
-                ? 'border-info text-primary'
-                : 'border-transparent text-secondary hover:text-primary',
+              isDisabled &&
+                'cursor-not-allowed border-control-disable-alpha text-control-disable-alpha',
+              !isDisabled &&
+                (isActive
+                  ? 'dial-kit-tab-selected-underline text-primary'
+                  : 'border-transparent text-secondary'),
               tabClassName,
             )}
           >
@@ -156,9 +172,11 @@ export const Tabs: FC<TabsProps> = ({
               <span
                 className={mergeClasses(
                   'dial-tiny-semi-text rounded-full px-1.5 py-0.5',
-                  isActive
-                    ? 'bg-control-accent-alpha-hover text-accent'
-                    : 'bg-layer-sunken text-secondary',
+                  isDisabled && 'bg-layer-sunken text-control-disable-alpha',
+                  !isDisabled &&
+                    (isActive
+                      ? 'bg-info text-accent'
+                      : 'bg-layer-sunken text-secondary'),
                 )}
               >
                 {tab.count}

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -1,0 +1,28 @@
+/*
+ * The selected tab's 2px underline is a horizontal gradient, which no border
+ * colour can express — so it is painted with `border-image` instead. The
+ * element carries `border-b-2` and zero width on the other three sides, so only
+ * the bottom edge is drawn; `border-image-slice: 1` stretches the gradient
+ * across that edge.
+ *
+ * Applied only to the selected, enabled tab: a disabled tab keeps the flat
+ * `border-control-disable-alpha` underline. `border-image-source` is not
+ * interpolable, so the hover swap is instant rather than transitioned.
+ */
+.dial-kit-tab-selected-underline {
+  border-bottom-style: solid;
+  border-image-slice: 1;
+  border-image-source: linear-gradient(
+    90deg,
+    var(--stroke-control-accent-gradient-from, #5976e9) 0%,
+    var(--stroke-control-accent-gradient-to, #885df2) 100%
+  );
+
+  &:hover:not(:disabled) {
+    border-image-source: linear-gradient(
+      90deg,
+      var(--stroke-control-accent-gradient-hover-from, #6785fb) 0%,
+      var(--stroke-control-accent-gradient-hover-to, #956cfa) 100%
+    );
+  }
+}

--- a/src/styles/tailwind-entry.scss
+++ b/src/styles/tailwind-entry.scss
@@ -9,6 +9,7 @@
 @import './steps.scss';
 @import './pagination.scss';
 @import './markdown-editor.scss';
+@import './tabs.scss';
 
 @layer ui {
   @tailwind base;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,29 @@ const borderColors = {
   'focus-blue': 'var(--stroke-focus-blue, #6785FB)', // blue-200
   'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20
   'error-alpha': 'var(--stroke-error-alpha, #AE2F2F73)', // red-800 alpha-45
+  'control-disable-alpha': 'var(--text-control-disable-alpha, #848E9C)', // grey-700
+};
+
+const visualBgColors = {
+  blue: 'var(--bg-visual-blue, #D6EDF9)', // blue-50
+  'green-1': 'var(--bg-visual-green-1, #CDE8E5)', // green-200
+  'green-2': 'var(--bg-visual-green-2, #D1F0DC)', // green-300
+  brown: 'var(--bg-visual-brown, #FDE8D8)', // brown-300
+  red: 'var(--bg-visual-red, #FCE7F3)', // red-200
+  'violet-1': 'var(--bg-visual-violet-1, #DDE3F9)', // violet-100
+  'violet-2': 'var(--bg-visual-violet-2, #F1E9FF)', // violet-150
+};
+
+const visualTextColors = {
+  blue: 'var(--text-visual-blue, #1189C8)', // blue-250
+  'green-1': 'var(--text-visual-green-1, #059669)', // green-500
+  'green-2': 'var(--text-visual-green-2, #0D6E72)', // green-600
+  'green-3': 'var(--text-visual-green-3, #065F46)', // green-900
+  'brown-1': 'var(--text-visual-brown-1, #D36817)', // brown-400
+  'brown-2': 'var(--text-visual-brown-2, #B45309)', // brown-500
+  red: 'var(--text-visual-red, #9D174D)', // red-900
+  'violet-1': 'var(--text-visual-violet-1, #7C3AED)', // violet-500
+  'violet-2': 'var(--text-visual-violet-2, #3730B7)', // violet-800
 };
 
 const textColors = {
@@ -166,6 +189,7 @@ export default {
       ...backgroundsColors,
       ...backgroundsColorsToRemove,
       ...controlsBgColors,
+      ...visualBgColors,
     },
     borderColor: {
       ...borderColors,
@@ -180,7 +204,12 @@ export default {
       ...borderColorsToRemove,
     },
     placeholderColor: placeholderColor,
-    textColor: { ...textColors, ...textColorsToRemove, ...controlsTextColors },
+    textColor: {
+      ...textColors,
+      ...textColorsToRemove,
+      ...controlsTextColors,
+      ...visualTextColors,
+    },
     gradientColorStops: backgroundsColors,
 
     extend: {


### PR DESCRIPTION
Brings `New/Tabs` in line with the design for every state. `Tabs` has not shipped in any release yet (it landed after tag `0.12.1`), so none of this is consumer-visible and no CHANGELOG entry or migration guide is needed.

## Resting states

| | Before | After |
|---|---|---|
| Label typography | `dial-small-semi-text` (14/20 semibold) | `dial-small-paragraph-text` (14/24 regular) |
| Unselected | `border-transparent text-secondary` + `hover:text-primary` | unchanged, hover removed |
| Selected underline | `border-info` (flat blue) | accent gradient, `#5976E9 → #885DF2` |
| Selected underline, hover | — | `#6785FB → #956CFA` |
| Disabled | — | `#848E9C` text and underline |

Hover now matches the resting state for unselected tabs; only the selected tab's gradient shifts on hover.

## The gradient underline

Tailwind has no `border-image` utility, so the selected underline needs a real rule — new [`src/styles/tabs.scss`](src/styles/tabs.scss):

```scss
.dial-kit-tab-selected-underline {
  border-bottom-style: solid;
  border-image-slice: 1;
  border-image-source: linear-gradient(90deg, …-from, #5976e9) 0%, …-to, #885df2) 100%);

  &:hover:not(:disabled) { /* #6785fb → #956cfa */ }
}
```

The tab already carried `border-b-2` with zero width on the other three sides, so `border-image` paints the bottom edge only — no pseudo-element needed, which matters because `dial-kit-enhanced-target` already owns `::after`.

Two consequences worth knowing:

- **The hover swap is instant.** `border-image-source` is not an interpolable property, so `transition-colors` cannot ease between the two gradients. Animating it would require stacking two pseudo-elements and cross-fading their opacity.
- **Four new CSS variables have hex fallbacks only** — `--stroke-control-accent-gradient-from` / `-to` / `-hover-from` / `-hover-to`, mirroring the existing `--bg-control-accent-gradient-*` pattern. No theme defines them yet, so dark theme shows the light-theme gradient until they are added on the theme side. I deliberately did not chain fallbacks to lookalike existing tokens, because `#956CFA` has no equivalent — a dark theme would re-theme three of four stops and leave the fourth stranded.

## Disabled tabs

New optional `disabled` flag on `TabItem`:

- greyed with `text-control-disable-alpha` / `border-control-disable-alpha`, `cursor-not-allowed`, native `disabled` on the button, greyed count badge
- disabled wins over selected, so a disabled selected tab keeps the flat `#848E9C` underline rather than the gradient
- arrow / `Home` / `End` navigation skips them
- if `activeTabId` points at a disabled tab, the roving tab stop falls back to the first enabled tab — otherwise the whole row drops out of the tab order

`border-control-disable-alpha` is a new border token in `tailwind.config.js`. It points at the **text** variable rather than a new `--stroke-*` one, because no `--stroke-*` carries grey-700 and inventing one would mean consuming themes do not define it — the border would stay `#848E9C` in dark theme while the text moved. Borrowing the already-themed token keeps disabled borders locked to disabled text; there is precedent in the file (`placeholderColor.secondary` borrows `--controls-text-secondary-disable`).

## Verification

- `npx vitest run` — 159 files, 2080 tests passing; `Tabs.spec.tsx` grew from 14 to 21 cases covering the disabled state, the gradient class and the tab-stop fallback
- `npm run lint` clean
- `npm run build:css` compiles both new classes; verified `.dial-kit-tab-selected-underline` and `.border-control-disable-alpha` in `dist/index.css`
- Stories: added `WithDisabledTabs` plus a disabled row in `AllVariants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)