### PR TITLE
fix: calculating delta for DialAnalyticsBarGroup, expand DialAnalyticsCard with deltaUnit prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Versions match the git tags on the `development` branch.
 - **Typography — `dial-code-text` names a monospace face** — it previously inherited the body font despite being the Code style. It resolves through `var(--theme-font-mono, var(--font-fira-code, 'Fira Code'))` before the system monospace stack, mirroring the existing `--theme-font` / `--font-inter` hook. The kit ships no font file; hosts that want Fira Code load it themselves.
 - **Enhanced pointer targets** — standard-size buttons expose a 44×44 pointer target (WCAG 2.5.5, Level AAA) via the `dial-kit-enhanced-target` utility, with no change to their rendered size. See the [Accessibility section of the README](README.md#-accessibility) for the documented exceptions.
 - **MCP server — generation-aware component discovery** — component entries carry `generation` (`1.0` | `2.0`), and a 1.0 component carries `supersededBy` naming its 2.0 replacement (e.g. `DialButton` → `Button`). `searchEntity` ranks 2.0 above 1.0 and reports a **Use instead** column; `getEntityDetails` flags a superseded component and, on a name miss, suggests the other generation's spelling. Both are derived automatically from component location and Storybook category — there is no list to maintain. See the [MCP Server Guide](src/mcp/README.md).
+- **`DialAnalyticsCard` — `deltaUnit`** — optional suffix appended to the delta badge with no space (`delta={9} deltaUnit="s"` → `+9s`).
 
 ### Changed
 

--- a/src/components/Analytics/BarGroup/BarGroup.spec.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.spec.tsx
@@ -163,8 +163,8 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       render(
         <DialAnalyticsBarGroup
           title="Relevance"
-          data={{ score: 0.82 }}
-          compareData={{ score: 0.64 }}
+          data={{ score: 0.64 }}
+          compareData={{ score: 0.82 }}
         />,
       );
 
@@ -177,8 +177,8 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       render(
         <DialAnalyticsBarGroup
           title="Relevance"
-          data={{ score: 0.64 }}
-          compareData={{ score: 0.82 }}
+          data={{ score: 0.82 }}
+          compareData={{ score: 0.64 }}
         />,
       );
 
@@ -187,7 +187,20 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       expect(badge.className).toMatch(/text-error/);
     });
 
-    test('renders a zero delta with a + prefix and success styles', () => {
+    test('rounds the compare-mode delta to 3 decimal places', () => {
+      render(
+        <DialAnalyticsBarGroup
+          title="DeepEval: Answer Relevancy"
+          data={{ score: 0.917 }}
+          compareData={{ score: 1 }}
+        />,
+      );
+
+      const badge = screen.getByText('+0.083');
+      expect(badge.className).toMatch(/bg-success/);
+    });
+
+    test('hides the delta badge when the rounded delta is zero', () => {
       render(
         <DialAnalyticsBarGroup
           title="Relevance"
@@ -196,8 +209,8 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
         />,
       );
 
-      const badge = screen.getByText('+0');
-      expect(badge.className).toMatch(/bg-success/);
+      expect(screen.queryByText('+0')).toBeNull();
+      expect(screen.queryByText(/^[-+]/)).toBeNull();
     });
 
     test('renders compareLabels as bar titles', () => {
@@ -228,7 +241,7 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       // accuracy×2 + onlyCurrent + onlyPrevious — missing sides have no progressbar
       expect(screen.getAllByRole('progressbar')).toHaveLength(4);
       expect(screen.getAllByText('—')).toHaveLength(2);
-      expect(screen.getByText('+0.18')).toBeInTheDocument();
+      expect(screen.getByText('-0.18')).toBeInTheDocument();
       expect(screen.queryByText('NaN')).toBeNull();
     });
 

--- a/src/components/Analytics/BarGroup/BarGroup.stories.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.stories.tsx
@@ -47,7 +47,7 @@ const meta: Meta<typeof DialAnalyticsBarGroup> = {
     compareData: {
       control: false,
       description:
-        'Enables compare mode: each entry shows a delta badge and two bars — one for `data` and one for `compareData`.',
+        'Enables compare mode: each entry shows a delta badge (`compareData − data`) and two bars — first for `data`, second for `compareData`.',
     },
     compareLabels: {
       control: false,
@@ -154,7 +154,28 @@ export const CompareDefault: Story = {
     title: 'Relevance',
     data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
     compareData: { accuracy: 0.64, recall: 0.82, precision: 0.78, f1: 0.86 },
-    compareLabels: ['This week', 'Last week'],
+    compareLabels: ['Last week', 'This week'],
+    className: 'w-[420px]',
+  },
+};
+
+/** Admin compare repro: baseline 0.917 vs compared 1.00 — badge should be +0.083. */
+export const CompareScoreIncrease: Story = {
+  args: {
+    title: 'DeepEval: Answer Relevancy',
+    data: { score: 0.917 },
+    compareData: { score: 1 },
+    compareLabels: ['Run #849', 'Run #1051'],
+    className: 'w-[420px]',
+  },
+};
+
+export const CompareEqualValues: Story = {
+  args: {
+    title: 'Relevance',
+    data: { score: 0.75 },
+    compareData: { score: 0.75 },
+    compareLabels: ['Last week', 'This week'],
     className: 'w-[420px]',
   },
 };
@@ -164,7 +185,7 @@ export const CompareInline: Story = {
     title: 'Relevance',
     data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
     compareData: { accuracy: 0.64, recall: 0.82, precision: 0.78, f1: 0.86 },
-    compareLabels: ['This week', 'Last week'],
+    compareLabels: ['Last week', 'This week'],
     inline: true,
     className: 'w-[420px]',
   },
@@ -185,7 +206,7 @@ export const CompareWithMissingValues: Story = {
     title: 'Relevance',
     data: { accuracy: 0.82, recall: 0.64, onlyCurrent: 0.55 },
     compareData: { accuracy: 0.64, recall: 0.82, onlyPrevious: 0.71 },
-    compareLabels: ['This week', 'Last week'],
+    compareLabels: ['Last week', 'This week'],
     className: 'w-[420px]',
   },
 };
@@ -195,7 +216,7 @@ export const CompareInlineWithMissingValues: Story = {
     title: 'Relevance',
     data: { accuracy: 0.82, recall: 0.64, onlyCurrent: 0.55 },
     compareData: { accuracy: 0.64, recall: 0.82, onlyPrevious: 0.71 },
-    compareLabels: ['This week', 'Last week'],
+    compareLabels: ['Last week', 'This week'],
     inline: true,
     className: 'w-[420px]',
   },

--- a/src/components/Analytics/BarGroup/BarGroup.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.tsx
@@ -22,9 +22,10 @@ export interface DialAnalyticsBarGroupProps {
   /**
    * When provided, enables compare mode: keys are the union of `data` and
    * `compareData`. Each entry renders two bars and, when both sides are numeric,
-   * a delta badge (`data[key] - compareData[key]`). A missing key (or explicit
-   * `null`) on either side shows an em dash with no progress bar and no delta.
-   * `onBarClick` is ignored in compare mode.
+   * a delta badge (`compareData[key] - data[key]`, three decimal places). A
+   * missing key (or explicit `null`) on either side shows an em dash with no
+   * progress bar and no delta. A rounded delta of `0` is omitted. `onBarClick`
+   * is ignored in compare mode.
    */
   compareData?: Record<string, number | null>;
   /**
@@ -85,7 +86,7 @@ export interface DialAnalyticsBarGroupProps {
  * @param [titleTooltip] - Tooltip shown when hovering the accordion header title.
  * @param [description] - Description passed to the accordion header. Defaults to the number of entries.
  * @param data - Map of metric name to numeric value (or `null` when missing). Each entry renders one bar.
- * @param [compareData] - Enables compare mode: union of keys, delta badge when both sides are numeric, em dash (no bar) when a side is missing.
+ * @param [compareData] - Enables compare mode: union of keys, delta badge (`compareData − data`) when both sides are numeric and the rounded delta is non-zero, em dash (no bar) when a side is missing.
  * @param [compareLabels] - Labels for the two bars in compare mode: first for `data`, second for `compareData`.
  * @param [maxValue] - Upper bound passed to every bar.
  * @param [colorMap] - Color map passed to every bar.
@@ -159,11 +160,15 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
             const canComputeDelta =
               typeof value === 'number' && typeof compareValue === 'number';
             const delta = canComputeDelta
-              ? parseFloat((value - compareValue).toFixed(2))
+              ? parseFloat((compareValue - value).toFixed(3))
               : null;
-            const isPositive = delta != null && delta >= 0;
-            const deltaLabel =
-              delta == null ? null : isPositive ? `+${delta}` : String(delta);
+            const showDelta = delta != null && delta !== 0;
+            const isPositive = showDelta && delta > 0;
+            const deltaLabel = !showDelta
+              ? null
+              : isPositive
+                ? `+${delta}`
+                : String(delta);
             return (
               <div key={key} className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2">

--- a/src/components/Analytics/Card/Card.spec.tsx
+++ b/src/components/Analytics/Card/Card.spec.tsx
@@ -238,6 +238,38 @@ describe('Dial UI Kit :: DialAnalyticsCard', () => {
       expect(screen.getByText('Revenue')).toBeInTheDocument();
       expect(screen.getByText('+3')).toBeInTheDocument();
     });
+
+    test('appends deltaUnit to a positive time delta with inverted error styles', () => {
+      render(
+        <DialAnalyticsCard
+          title="Response time"
+          delta={9}
+          deltaUnit="s"
+          deltaPositive={false}
+          value="248ms"
+        />,
+      );
+
+      const badge = screen.getByText('+9s');
+      expect(badge.className).toMatch(/bg-error/);
+      expect(badge.className).toMatch(/text-error/);
+    });
+
+    test('appends deltaUnit to a negative time delta with inverted success styles', () => {
+      render(
+        <DialAnalyticsCard
+          title="Response time"
+          delta={-19}
+          deltaUnit="s"
+          deltaPositive={true}
+          value="201ms"
+        />,
+      );
+
+      const badge = screen.getByText('-19s');
+      expect(badge.className).toMatch(/bg-success/);
+      expect(badge.className).toMatch(/text-success/);
+    });
   });
 
   describe('loading state', () => {

--- a/src/components/Analytics/Card/Card.stories.tsx
+++ b/src/components/Analytics/Card/Card.stories.tsx
@@ -51,12 +51,17 @@ const meta: Meta<typeof DialAnalyticsCard> = {
     delta: {
       control: { type: 'number' },
       description:
-        'Numeric change shown as a badge next to the title. Values ≥0 use success styles; negative values use error styles. Override with `deltaPositive`.',
+        'Numeric change shown as a badge next to the title. Values ≥0 use success styles; negative values use error styles. Override with `deltaPositive`. Append a unit with `deltaUnit`.',
     },
     deltaPositive: {
       control: 'boolean',
       description:
         'Overrides the sign-based badge style. Use when a positive delta is bad (e.g. response time up) or a negative delta is good (e.g. error rate down).',
+    },
+    deltaUnit: {
+      control: 'text',
+      description:
+        'Suffix appended to the formatted delta with no space (e.g. `"s"` → `+9s`, `-19s`).',
     },
     compareValues: {
       control: false,
@@ -173,13 +178,29 @@ export const Variants: Story = {
 export const CompareDefault: Story = {
   args: {
     title: 'Response time',
-    delta: 12,
+    delta: 9,
+    deltaUnit: 's',
     deltaPositive: false,
     compareValues: [
       { title: 'This week', value: '248ms' },
       { title: 'Last week', value: '220ms' },
     ],
-    description: '+12% slower than last week',
+    description: '+9s slower than last week',
+    className: 'w-[240px]',
+  },
+};
+
+export const CompareTimeDecrease: Story = {
+  args: {
+    title: 'Response time',
+    delta: -19,
+    deltaUnit: 's',
+    deltaPositive: true,
+    compareValues: [
+      { title: 'This week', value: '201ms' },
+      { title: 'Last week', value: '220ms' },
+    ],
+    description: '−19s faster than last week',
     className: 'w-[240px]',
   },
 };
@@ -201,6 +222,8 @@ export const CompareCompact: Story = {
   args: {
     title: 'Avg. latency',
     delta: 5,
+    deltaUnit: 'ms',
+    deltaPositive: false,
     compareValues: [
       { title: 'Current', value: '248ms' },
       { title: 'Previous', value: '236ms' },
@@ -214,6 +237,8 @@ export const CompareCompactNegativeDelta: Story = {
   args: {
     title: 'Avg. latency',
     delta: -8,
+    deltaUnit: 'ms',
+    deltaPositive: true,
     compareValues: [
       { title: 'Current', value: '220ms' },
       { title: 'Previous', value: '240ms' },

--- a/src/components/Analytics/Card/Card.tsx
+++ b/src/components/Analytics/Card/Card.tsx
@@ -31,6 +31,11 @@ export interface DialAnalyticsCardProps {
    */
   deltaPositive?: boolean;
   /**
+   * Suffix appended to the formatted delta with no space (e.g. `"s"` → `+9s`,
+   * `-19s`). Any string is valid (`s`, `ms`, `%`).
+   */
+  deltaUnit?: string;
+  /**
    * When provided, enables compare mode: the value area is split 50/50 with a
    * vertical divider and each side shows its own sub-title and value.
    * `value` is ignored when `compareValues` is set.
@@ -74,7 +79,7 @@ const variantStyles: Record<
  *
  * **Compare mode** — pass `compareValues` to split the value area 50/50 between two
  * metrics, each with its own sub-title. Pair with `delta` to show a change badge next
- * to the card title.
+ * to the card title, and `deltaUnit` for a suffix such as `"s"`.
  *
  * @example
  * ```tsx
@@ -89,7 +94,9 @@ const variantStyles: Record<
  * ```tsx
  * <DialAnalyticsCard
  *   title="Response time"
- *   delta={12}
+ *   delta={9}
+ *   deltaUnit="s"
+ *   deltaPositive={false}
  *   compareValues={[
  *     { title: 'This week', value: '248ms' },
  *     { title: 'Last week', value: '220ms' },
@@ -105,6 +112,8 @@ const variantStyles: Record<
  * @param [isLoading] - Renders a loader in place of the value.
  * @param [className] - Additional CSS classes for the card container.
  * @param [delta] - Numeric change shown as a badge next to the title. ≥0 = success, <0 = error.
+ * @param [deltaPositive] - Overrides sign-based badge colour. Use for lower-is-better metrics.
+ * @param [deltaUnit] - Suffix appended to the formatted delta (e.g. `"s"` → `+9s`).
  * @param [compareValues] - Enables compare mode with two side-by-side metrics.
  */
 export const DialAnalyticsCard: FC<DialAnalyticsCardProps> = ({
@@ -117,11 +126,16 @@ export const DialAnalyticsCard: FC<DialAnalyticsCardProps> = ({
   className,
   delta,
   deltaPositive,
+  deltaUnit,
   compareValues,
 }) => {
   const styles = variantStyles[variant];
   const isDeltaPositive =
     deltaPositive !== undefined ? deltaPositive : (delta ?? 0) >= 0;
+  const deltaLabel =
+    delta === undefined
+      ? null
+      : `${delta >= 0 ? `+${delta}` : String(delta)}${deltaUnit ?? ''}`;
 
   return (
     <div
@@ -143,7 +157,7 @@ export const DialAnalyticsCard: FC<DialAnalyticsCardProps> = ({
                 : 'bg-error text-error',
             )}
           >
-            {delta >= 0 ? `+${delta}` : String(delta)}
+            {deltaLabel}
           </span>
         </div>
       ) : (


### PR DESCRIPTION
**Description and UI changes:**

fix: Compare-mode delta is now: compared − baseline (compareData − data), rounded to 3 decimals, and 0 delta is not shown

feat: expanded DialAnalyticsCard with deltaUnit prop for displaying time deltas
Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added