### PR TITLE
fix: missing tooltip and onClick handler for compare view in AnalyticsBarGroup

### DIFF
--- a/src/components/Analytics/BarGroup/BarGroup.spec.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.spec.tsx
@@ -118,6 +118,53 @@ describe('Dial UI Kit :: DialAnalyticsBarGroup', () => {
       // Only the accordion header is a button.
       expect(screen.getAllByRole('button')).toHaveLength(1);
     });
+
+    test('in compare mode wraps the whole entry and forwards key and value on click', () => {
+      const onBarClick = vi.fn();
+      render(
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ accuracy: 0.82 }}
+          compareData={{ accuracy: 0.64 }}
+          onBarClick={onBarClick}
+        />,
+      );
+
+      const entryButton = screen.getByRole('button', { name: /accuracy/i });
+      fireEvent.click(entryButton);
+
+      expect(onBarClick).toHaveBeenCalledTimes(1);
+      expect(onBarClick).toHaveBeenCalledWith('accuracy', 0.82);
+    });
+
+    test('in compare mode forwards null when the data key is missing', () => {
+      const onBarClick = vi.fn();
+      render(
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ other: 0.5 }}
+          compareData={{ accuracy: 0.64 }}
+          onBarClick={onBarClick}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /accuracy/i }));
+
+      expect(onBarClick).toHaveBeenCalledTimes(1);
+      expect(onBarClick).toHaveBeenCalledWith('accuracy', null);
+    });
+
+    test('in compare mode does not wrap entries when onBarClick is omitted', () => {
+      render(
+        <DialAnalyticsBarGroup
+          title="Relevance"
+          data={{ accuracy: 0.82 }}
+          compareData={{ accuracy: 0.64 }}
+        />,
+      );
+
+      expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
   });
 
   describe('inline mode', () => {

--- a/src/components/Analytics/BarGroup/BarGroup.stories.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.stories.tsx
@@ -159,6 +159,17 @@ export const CompareDefault: Story = {
   },
 };
 
+export const CompareClickable: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
+    compareData: { accuracy: 0.64, recall: 0.82, precision: 0.78, f1: 0.86 },
+    compareLabels: ['Last week', 'This week'],
+    onBarClick: (key, value) => alert(`${key}: ${value}`),
+    className: 'w-[420px]',
+  },
+};
+
 /** Admin compare repro: baseline 0.917 vs compared 1.00 — badge should be +0.083. */
 export const CompareScoreIncrease: Story = {
   args: {
@@ -219,6 +230,22 @@ export const CompareInlineWithMissingValues: Story = {
     compareLabels: ['Last week', 'This week'],
     inline: true,
     className: 'w-[420px]',
+  },
+};
+
+export const CompareWithBarDescriptions: Story = {
+  args: {
+    title: 'Relevance',
+    data: { accuracy: 0.82, recall: 0.64, precision: 0.91, f1: 0.74 },
+    compareData: { accuracy: 0.64, recall: 0.82, precision: 0.78, f1: 0.86 },
+    compareLabels: ['Last week', 'This week'],
+    barDescriptions: {
+      accuracy: 'Proportion of correct predictions out of all predictions',
+      recall: 'Proportion of actual positives correctly identified',
+      precision:
+        'Proportion of positive predictions that are actually positive',
+      f1: 'Harmonic mean of precision and recall',
+    },
   },
 };
 

--- a/src/components/Analytics/BarGroup/BarGroup.tsx
+++ b/src/components/Analytics/BarGroup/BarGroup.tsx
@@ -24,8 +24,7 @@ export interface DialAnalyticsBarGroupProps {
    * `compareData`. Each entry renders two bars and, when both sides are numeric,
    * a delta badge (`compareData[key] - data[key]`, three decimal places). A
    * missing key (or explicit `null`) on either side shows an em dash with no
-   * progress bar and no delta. A rounded delta of `0` is omitted. `onBarClick`
-   * is ignored in compare mode.
+   * progress bar and no delta. A rounded delta of `0` is omitted.
    */
   compareData?: Record<string, number | null>;
   /**
@@ -47,7 +46,11 @@ export interface DialAnalyticsBarGroupProps {
   nonCollapsible?: boolean;
   /** Renders a loader in place of the bars while the data is being fetched. */
   isLoading?: boolean;
-  /** Invoked with the entry key and value when a bar is clicked. When set, each bar becomes an interactive button. */
+  /**
+   * Invoked with the entry key and value when a bar is clicked. When set, each
+   * bar becomes an interactive button. In compare mode the whole entry (label,
+   * delta, both bars) is the click target.
+   */
   onBarClick?: (key: string, value: number | null) => void;
   /** Renders every bar on a single row (50% title, 50% bar + value). */
   inline?: boolean;
@@ -57,10 +60,7 @@ export interface DialAnalyticsBarGroupProps {
   barValueClassName?: string;
   /** Additional CSS classes for each bar's outer container (e.g. for custom hover effects). */
   barClassName?: string;
-  /**
-   * Map of bar key to tooltip content. When provided, hovering each bar shows its description.
-   * Not applied in compare mode.
-   */
+  /** Map of bar key to tooltip content. When provided, hovering each bar shows its description. */
   barDescriptions?: Record<string, ReactNode>;
   /** Additional CSS classes for the accordion container. */
   className?: string;
@@ -93,12 +93,12 @@ export interface DialAnalyticsBarGroupProps {
  * @param [defaultExpanded=true] - Whether the accordion is expanded initially.
  * @param [nonCollapsible] - Renders the group permanently expanded without a toggle or chevron.
  * @param [isLoading] - Renders a loader in place of the bars while the data is being fetched.
- * @param [onBarClick] - Invoked with the entry key and value when a bar is clicked.
+ * @param [onBarClick] - Invoked with the entry key and value when a bar (or, in compare mode, the whole entry) is clicked.
  * @param [inline] - Renders every bar on a single row (50% title, 50% bar + value).
  * @param [barTitleClassName] - Additional CSS classes for each bar's title label.
  * @param [barValueClassName] - Additional CSS classes for each bar's value label.
  * @param [barClassName] - Additional CSS classes for each bar's outer container.
- * @param [barDescriptions] - Map of bar key to tooltip content. Hovering each bar shows its description. Not applied in compare mode.
+ * @param [barDescriptions] - Map of bar key to tooltip content. Hovering each bar shows its description.
  * @param [className] - Additional CSS classes for the accordion container.
  */
 export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
@@ -136,6 +136,8 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
   const compareKeys = compareData
     ? [...new Set([...Object.keys(data), ...Object.keys(compareData)])]
     : [];
+  const barClickClassName =
+    'cursor-pointer rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary';
 
   return (
     <DialAccordion
@@ -169,10 +171,22 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
               : isPositive
                 ? `+${delta}`
                 : String(delta);
-            return (
-              <div key={key} className="flex flex-col gap-1.5">
+
+            const barDescription = barDescriptions?.[key];
+            const barLabel = (
+              <span className="dial-small-text text-secondary">{key}</span>
+            );
+
+            const entryContent = (
+              <>
                 <div className="flex items-center gap-2">
-                  <span className="dial-small-text text-primary">{key}</span>
+                  {barDescription ? (
+                    <DialTooltip tooltip={barDescription}>
+                      {barLabel}
+                    </DialTooltip>
+                  ) : (
+                    barLabel
+                  )}
                   {deltaLabel != null && (
                     <span
                       className={mergeClasses(
@@ -208,6 +222,28 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
                     ariaLabel={`${key} compare`}
                   />
                 </div>
+              </>
+            );
+
+            if (onBarClick) {
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => onBarClick(key, value)}
+                  className={mergeClasses(
+                    'flex flex-col gap-1.5',
+                    barClickClassName,
+                  )}
+                >
+                  {entryContent}
+                </button>
+              );
+            }
+
+            return (
+              <div key={key} className="flex flex-col gap-1.5">
+                {entryContent}
               </div>
             );
           })
@@ -230,7 +266,7 @@ export const DialAnalyticsBarGroup: FC<DialAnalyticsBarGroupProps> = ({
               <button
                 type="button"
                 onClick={() => onBarClick(key, value)}
-                className="cursor-pointer rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+                className={barClickClassName}
               >
                 {bar}
               </button>


### PR DESCRIPTION
**Description and UI changes:**

1. In compare mode, onBarClick(key, value) now fires when the whole entry is clicked (label, delta badge, and both bars), matching normal mode
2. In compare mode added description tooltip for bars label

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added