### PR TITLE
feat: Added Y-scale to AnalyticsHistogram

### DIFF
--- a/src/components/Analytics/Card/Card.tsx
+++ b/src/components/Analytics/Card/Card.tsx
@@ -1,6 +1,7 @@
 import type { FC, ReactNode } from 'react';
 
 import { DialAnalyticsErrorTag } from '@/components/Analytics/ErrorTag/ErrorTag';
+import { DialEllipsisTooltip } from '@/components/EllipsisTooltip/EllipsisTooltip';
 import { DialLoader } from '@/components/Loader/Loader';
 import type { AnalyticsCardCompareItem } from '@/models/analytics';
 import { AnalyticsCardVariant } from '@/types/analytics';
@@ -78,7 +79,8 @@ const variantStyles: Record<
  *   description (the `description` prop is ignored in this variant).
  *
  * **Compare mode** — pass `compareValues` to split the value area 50/50 between two
- * metrics, each with its own sub-title. Pair with `delta` to show a change badge next
+ * metrics, each with its own sub-title. Long sub-titles truncate to a single line and
+ * show the full text in a tooltip. Pair with `delta` to show a change badge next
  * to the card title, and `deltaUnit` for a suffix such as `"s"`.
  *
  * @example
@@ -171,16 +173,18 @@ export const DialAnalyticsCard: FC<DialAnalyticsCardProps> = ({
       ) : compareValues ? (
         <div className="flex items-center gap-3">
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="dial-tiny-text text-secondary">
-              {compareValues[0].title}
-            </span>
+            <DialEllipsisTooltip
+              text={compareValues[0].title}
+              className="dial-tiny-text text-secondary"
+            />
             <span className={styles.value}>{compareValues[0].value}</span>
           </div>
           <div className="h-4 w-px flex-shrink-0 bg-controls-disable-accent" />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="dial-tiny-text text-secondary">
-              {compareValues[1].title}
-            </span>
+            <DialEllipsisTooltip
+              text={compareValues[1].title}
+              className="dial-tiny-text text-secondary"
+            />
             <span className={styles.value}>{compareValues[1].value}</span>
           </div>
         </div>

--- a/src/components/Analytics/Histogram/Histogram.spec.tsx
+++ b/src/components/Analytics/Histogram/Histogram.spec.tsx
@@ -22,13 +22,44 @@ describe('Dial UI Kit :: DialAnalyticsHistogram', () => {
   });
 
   test('renders an interval legend under each column', () => {
-    render(<DialAnalyticsHistogram title="Distribution" values={[0.5]} />);
+    const { container } = render(
+      <DialAnalyticsHistogram title="Distribution" values={[0.5]} />,
+    );
+    const xAxis = container.querySelector('[data-histogram-x-axis]');
+    expect(xAxis).not.toBeNull();
     // leading zero bucket, range bands, then the exact full band -> "1"
-    expect(screen.getByText('0')).toBeInTheDocument();
-    expect(screen.getByText('0-0.1')).toBeInTheDocument();
-    expect(screen.getByText('0.1-0.2')).toBeInTheDocument();
-    expect(screen.getByText('0.9-1')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(xAxis).toHaveTextContent('0');
+    expect(xAxis).toHaveTextContent('0-0.1');
+    expect(xAxis).toHaveTextContent('0.1-0.2');
+    expect(xAxis).toHaveTextContent('0.9-1');
+    expect(xAxis).toHaveTextContent('1');
+  });
+
+  test('renders a Y-axis scaled to the dataset total, not the tallest bin', () => {
+    const values = [
+      0.02, 0.05, 0.07, 0.12, 0.18, 0.22, 0.25, 0.28, 0.31, 0.34, 0.41, 0.43,
+      0.44, 0.48, 0.52, 0.55, 0.61, 0.68, 0.73, 0.79, 0.84, 0.88, 0.91, 0.95, 1,
+      1,
+    ];
+    const { container } = render(
+      <DialAnalyticsHistogram title="Distribution" values={values} />,
+    );
+
+    const ticks = [
+      ...(container.querySelectorAll('[data-histogram-y-axis] span') ?? []),
+    ].map((el) => el.textContent);
+    expect(ticks).toEqual(['26', '13', '0']);
+    expect(container.querySelectorAll('[data-histogram-grid]')).toHaveLength(3);
+
+    const populated = screen.getByRole('img', { name: '4 out of 26 values' });
+    expect(populated.style.height).toBe(`${(4 / 26) * 100}%`);
+  });
+
+  test('scales bars to the even Y-axis max when the dataset size is odd', () => {
+    render(<DialAnalyticsHistogram title="Distribution" values={[0, 0, 0]} />);
+
+    const zero = screen.getByRole('img', { name: '3 out of 3 values' });
+    expect(zero.style.height).toBe('75%');
   });
 
   test('renders the zero bucket with #FF4E50 color and a transparent border', () => {
@@ -97,9 +128,11 @@ describe('Dial UI Kit :: DialAnalyticsHistogram', () => {
     ).toBeNull();
     expect(screen.getAllByRole('img')).toHaveLength(1);
     // they still occupy a slot rendered as an aria-hidden spacer
-    expect(container.querySelectorAll('[aria-hidden="true"]').length).toBe(
-      DEFAULT_ANALYTICS_BAR_COLOR_MAP.length,
-    );
+    expect(
+      container.querySelectorAll(
+        '[aria-hidden="true"]:not([data-histogram-y-axis])',
+      ).length,
+    ).toBe(DEFAULT_ANALYTICS_BAR_COLOR_MAP.length);
   });
 
   test('exposes the share of the total as the column label/tooltip', () => {
@@ -220,7 +253,7 @@ describe('Dial UI Kit :: DialAnalyticsHistogram', () => {
 
   describe('loading state', () => {
     test('renders a loader instead of the columns', () => {
-      render(
+      const { container } = render(
         <DialAnalyticsHistogram
           title="Distribution"
           values={[0.5]}
@@ -231,6 +264,7 @@ describe('Dial UI Kit :: DialAnalyticsHistogram', () => {
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(screen.queryByRole('img', { name: /out of/ })).toBeNull();
       expect(screen.getByText('Distribution')).toBeInTheDocument();
+      expect(container.querySelector('[data-histogram-y-axis]')).toBeNull();
     });
   });
 });

--- a/src/components/Analytics/Histogram/Histogram.stories.tsx
+++ b/src/components/Analytics/Histogram/Histogram.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof DialAnalyticsHistogram> = {
     docs: {
       description: {
         component:
-          'A histogram that distributes values across the bands of a color map and draws one column per band. Column heights are relative to the most populated band; empty columns are outlined, populated ones are filled with their band color. Hovering a column reveals its share of the total.',
+          'A histogram that distributes values across the bands of a color map and draws one column per band. Column heights are relative to the Y-axis max (an even ceiling of the dataset size). A left Y-axis shows count ticks with horizontal grid lines; hovering a column reveals its share of the total.',
       },
     },
   },

--- a/src/components/Analytics/Histogram/Histogram.tsx
+++ b/src/components/Analytics/Histogram/Histogram.tsx
@@ -6,7 +6,12 @@ import { DialTooltip } from '@/components/Tooltip/Tooltip';
 import type { AnalyticsBarColorStop } from '@/models/analytics';
 import { mergeClasses } from '@/utils/merge-classes';
 import type { AnalyticsHistogramColumn } from './utils';
-import { buildHistogramColumns, formatHistogramColumnLabel } from './utils';
+import {
+  buildHistogramColumns,
+  formatHistogramColumnLabel,
+  getHistogramYMax,
+  getHistogramYTicks,
+} from './utils';
 
 const HISTOGRAM_HEIGHT_PX = 128;
 
@@ -59,10 +64,12 @@ const buildCompareTooltip = (
 
 /**
  * A histogram that distributes `values` across the bands of a color map and draws a
- * column per band. Each column's height is relative to the most populated band; empty
- * columns are outlined, populated columns are filled with their band color. A baseline
- * separates the columns from the interval labels, and hovering a column reveals a
- * tooltip with its share of the total.
+ * column per band. Each column's height is relative to the Y-axis max (an even
+ * ceiling of the dataset size — the "out of N" in the tooltip). Empty columns
+ * are outlined, populated columns are filled with their band color. A left
+ * Y-axis (count) and horizontal grid lines provide scale; interval labels run
+ * along the bottom. Hovering a column reveals a tooltip with its share of the
+ * total.
  * aliases: Distribution|ColumnChart|FrequencyChart
  * Design system 1.0
  *
@@ -103,30 +110,24 @@ export const DialAnalyticsHistogram: FC<DialAnalyticsHistogramProps> = ({
     ? buildHistogramColumns(compareValues, colorMap)
     : undefined;
 
-  const globalMax = rawCompareColumns
-    ? Math.max(
-        0,
-        ...[...rawPrimaryColumns, ...rawCompareColumns].map((c) => c.count),
-      )
-    : undefined;
-
-  const normalize = (
-    cols: AnalyticsHistogramColumn[],
-  ): AnalyticsHistogramColumn[] =>
-    globalMax !== undefined
-      ? cols.map((col) => ({
-          ...col,
-          ratio: globalMax > 0 ? col.count / globalMax : 0,
-        }))
-      : cols;
-
-  const columns = normalize(rawPrimaryColumns);
-  const compareColumns = rawCompareColumns
-    ? normalize(rawCompareColumns)
-    : undefined;
-
   const total = values.length;
   const compareTotal = compareValues?.length ?? 0;
+  const scaleTotal = Math.max(total, compareTotal);
+  const yMax = getHistogramYMax(scaleTotal);
+  const yTicks = getHistogramYTicks(scaleTotal);
+
+  const scaleToYMax = (
+    cols: AnalyticsHistogramColumn[],
+  ): AnalyticsHistogramColumn[] =>
+    cols.map((col) => ({
+      ...col,
+      ratio: yMax > 0 ? col.count / yMax : 0,
+    }));
+
+  const columns = scaleToYMax(rawPrimaryColumns);
+  const compareColumns = rawCompareColumns
+    ? scaleToYMax(rawCompareColumns)
+    : undefined;
 
   const renderBar = (
     column: AnalyticsHistogramColumn,
@@ -186,94 +187,125 @@ export const DialAnalyticsHistogram: FC<DialAnalyticsHistogramProps> = ({
           <DialLoader fullWidth={false} />
         </div>
       ) : (
-        <div className="flex flex-col gap-1">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-1">
           <div
-            className="flex items-end gap-1 border-b border-primary"
+            data-histogram-y-axis
+            aria-hidden="true"
+            className="relative"
             style={{ height: HISTOGRAM_HEIGHT_PX }}
           >
-            {compareColumns
-              ? columns.map((column, index) => {
-                  const compareCol = compareColumns[index];
-                  const primaryLabel = `${column.count} out of ${total} ${valueTitle}`;
-                  const compareLabel = `${compareCol.count} out of ${compareTotal} ${valueTitle}`;
-                  return (
-                    <div key={index} className="flex h-full flex-1 items-end">
-                      {renderBar(
-                        column,
-                        buildCompareTooltip(
-                          valueSetLabel,
-                          column.count,
-                          total,
-                          valueTitle,
-                          column,
-                        ),
-                        primaryLabel,
-                        true,
-                      )}
-                      {renderBar(
-                        compareCol,
-                        buildCompareTooltip(
-                          compareValueSetLabel,
-                          compareCol.count,
-                          compareTotal,
-                          valueTitle,
-                          compareCol,
-                        ),
-                        compareLabel,
-                        false,
-                      )}
-                    </div>
-                  );
-                })
-              : columns.map((column, index) => {
-                  const label = `${column.count} out of ${total} ${valueTitle}`;
-
-                  if (column.count === 0) {
-                    return (
-                      <div
-                        key={index}
-                        className="flex h-full flex-1 items-end"
-                        aria-hidden="true"
-                      >
-                        <div
-                          className="min-h-2 w-full rounded-sm"
-                          style={{ height: `${column.ratio * 100}%` }}
-                        />
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <DialTooltip
-                      key={index}
-                      placement="bottom"
-                      tooltip={label}
-                      triggerClassName="flex h-full flex-1 items-end"
-                    >
-                      <div
-                        role="img"
-                        aria-label={label}
-                        className={mergeClasses(
-                          'flex min-h-2 w-full items-center justify-center rounded-sm border',
-                          'border-transparent',
-                        )}
-                        style={{
-                          height: `${column.ratio * 100}%`,
-                          backgroundColor: column.color,
-                        }}
-                      >
-                        {showCount && column.count > 0 && (
-                          <span className="dial-tiny-semi-text text-primary">
-                            {column.count}
-                          </span>
-                        )}
-                      </div>
-                    </DialTooltip>
-                  );
-                })}
+            {yTicks.map((tick, index) => (
+              <span
+                key={tick}
+                className="dial-tiny-text absolute right-0 whitespace-nowrap text-secondary"
+                style={{
+                  top: `${(index / (yTicks.length - 1)) * 100}%`,
+                  transform: 'translateY(-50%)',
+                }}
+              >
+                {tick}
+              </span>
+            ))}
           </div>
 
-          <div className="flex gap-1">
+          <div className="relative min-w-0">
+            {yTicks.map((tick, index) => (
+              <div
+                key={tick}
+                data-histogram-grid
+                className="pointer-events-none absolute inset-x-0 border-t border-primary"
+                style={{ top: `${(index / (yTicks.length - 1)) * 100}%` }}
+              />
+            ))}
+            <div
+              className="relative flex items-end gap-1"
+              style={{ height: HISTOGRAM_HEIGHT_PX }}
+            >
+              {compareColumns
+                ? columns.map((column, index) => {
+                    const compareCol = compareColumns[index];
+                    const primaryLabel = `${column.count} out of ${total} ${valueTitle}`;
+                    const compareLabel = `${compareCol.count} out of ${compareTotal} ${valueTitle}`;
+                    return (
+                      <div key={index} className="flex h-full flex-1 items-end">
+                        {renderBar(
+                          column,
+                          buildCompareTooltip(
+                            valueSetLabel,
+                            column.count,
+                            total,
+                            valueTitle,
+                            column,
+                          ),
+                          primaryLabel,
+                          true,
+                        )}
+                        {renderBar(
+                          compareCol,
+                          buildCompareTooltip(
+                            compareValueSetLabel,
+                            compareCol.count,
+                            compareTotal,
+                            valueTitle,
+                            compareCol,
+                          ),
+                          compareLabel,
+                          false,
+                        )}
+                      </div>
+                    );
+                  })
+                : columns.map((column, index) => {
+                    const label = `${column.count} out of ${total} ${valueTitle}`;
+
+                    if (column.count === 0) {
+                      return (
+                        <div
+                          key={index}
+                          className="flex h-full flex-1 items-end"
+                          aria-hidden="true"
+                        >
+                          <div
+                            className="min-h-2 w-full rounded-sm"
+                            style={{ height: `${column.ratio * 100}%` }}
+                          />
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <DialTooltip
+                        key={index}
+                        placement="bottom"
+                        tooltip={label}
+                        triggerClassName="flex h-full flex-1 items-end"
+                      >
+                        <div
+                          role="img"
+                          aria-label={label}
+                          className={mergeClasses(
+                            'flex min-h-2 w-full items-center justify-center rounded-sm border',
+                            'border-transparent',
+                          )}
+                          style={{
+                            height: `${column.ratio * 100}%`,
+                            backgroundColor: column.color,
+                          }}
+                        >
+                          {showCount && column.count > 0 && (
+                            <span className="dial-tiny-semi-text text-primary">
+                              {column.count}
+                            </span>
+                          )}
+                        </div>
+                      </DialTooltip>
+                    );
+                  })}
+            </div>
+          </div>
+
+          <div />
+          <div data-histogram-x-axis className="flex gap-1">
             {columns.map((column, index) => (
               <span
                 key={index}

--- a/src/components/Analytics/Histogram/utils.spec.ts
+++ b/src/components/Analytics/Histogram/utils.spec.ts
@@ -4,6 +4,8 @@ import {
   formatHistogramColumnLabel,
   formatHistogramInterval,
   getHistogramColumnIndex,
+  getHistogramYMax,
+  getHistogramYTicks,
 } from './utils';
 import { DEFAULT_ANALYTICS_BAR_COLOR_MAP } from '@/components/Analytics/Bar/utils';
 
@@ -73,6 +75,29 @@ describe('Dial UI Kit :: DialAnalyticsHistogram utils', () => {
     test('carries band color and bounds', () => {
       const columns = buildHistogramColumns([0.05], map);
       expect(columns[1]).toMatchObject({ from: 0, to: 0.1, color: '#F26B5B' });
+    });
+  });
+
+  describe('getHistogramYMax', () => {
+    test('uses an even ceiling so the midpoint tick is an integer', () => {
+      expect(getHistogramYMax(48)).toBe(48);
+      expect(getHistogramYMax(26)).toBe(26);
+      expect(getHistogramYMax(4)).toBe(4);
+      expect(getHistogramYMax(3)).toBe(4);
+      expect(getHistogramYMax(1)).toBe(2);
+    });
+
+    test('keeps a 0–2 scale when there is no data', () => {
+      expect(getHistogramYMax(0)).toBe(2);
+    });
+  });
+
+  describe('getHistogramYTicks', () => {
+    test('returns top, middle, and baseline ticks', () => {
+      expect(getHistogramYTicks(48)).toEqual([48, 24, 0]);
+      expect(getHistogramYTicks(26)).toEqual([26, 13, 0]);
+      expect(getHistogramYTicks(4)).toEqual([4, 2, 0]);
+      expect(getHistogramYTicks(0)).toEqual([2, 1, 0]);
     });
   });
 

--- a/src/components/Analytics/Histogram/utils.ts
+++ b/src/components/Analytics/Histogram/utils.ts
@@ -85,6 +85,24 @@ export const buildHistogramColumns = (
   return [zeroColumn, ...bandColumns];
 };
 
+/**
+ * Top of the Y-axis for a dataset of `total` values (the "out of N" in the
+ * tooltip). Rounds odd totals up so the midpoint tick is an integer
+ * (Figma: 0, 24, 48). Empty data still gets a 0–2 scale so the axis is visible.
+ */
+export const getHistogramYMax = (total: number): number => {
+  if (total <= 0) return 2;
+  return total % 2 === 0 ? total : total + 1;
+};
+
+/**
+ * Three Y-axis ticks from top to bottom: `yMax`, `yMax / 2`, `0`.
+ */
+export const getHistogramYTicks = (total: number): number[] => {
+  const yMax = getHistogramYMax(total);
+  return [yMax, yMax / 2, 0];
+};
+
 /** Formats a column's interval bound for the axis label (trims float noise). */
 export const formatHistogramInterval = (value: number): string =>
   `${Math.round(value * 100) / 100}`;


### PR DESCRIPTION
**Description and UI changes:**

1. Implemented Y-scale on AnalyticsHistogram based on values count

<img width="680" height="136" alt="Screenshot 2026-08-19 at 12 07 27" src="https://github.com/user-attachments/assets/a7ae753a-af54-4fe7-909f-8908d5409321" />


2. Fiexed AnalyticsCard subtitle alignment for compare mode
Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [ ] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added