### PR TITLE
feat(2.0): add CollapsibleSidebar and ResizableContainer, fix segmented control rim and disabled button states

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ not AAA:
 | `Checkbox` box | 20×20 rendered | Reaches 24×24 through `dial-kit-minimum-target`; a 44px target would overhang 12px per side and swallow the adjacent label. Clicking the label toggles the checkbox, so the practical target is wider |
 | `Slider` track row | 24px tall | The pointer target spans the full track width but is only 24px tall; a 44px row would add 20px of dead space to every form the slider sits in, and the thumb is dragged rather than tapped |
 | `SegmentedControl` segment | 32px tall | Sits 4px from its neighbours inside a 40px track, so a 44px target would overhang 6px per side and swallow the adjacent segments; the segment is already wider than 24px on both axes |
+| `ResizableContainer` resize handle | 10px wide pointer strip | The handle has to sit exactly on the panel boundary, so a 44px-wide strip would swallow content on both sides of it — essential to the control. It is a focusable `separator`, so the resize is also available from the keyboard with the arrow keys |
 
 Give small-variant controls at least 20px of surrounding space if you need to reach
 AAA in a specific layout, or use the standard size instead.

--- a/src/components/New/CollapsibleSidebar/CollapsibleSidebar.spec.tsx
+++ b/src/components/New/CollapsibleSidebar/CollapsibleSidebar.spec.tsx
@@ -1,0 +1,247 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { CollapsibleSidebar } from './CollapsibleSidebar';
+
+const getSidebar = (name = 'Sidebar') =>
+  screen.getByRole('complementary', { name });
+
+describe('Dial UI Kit :: CollapsibleSidebar', () => {
+  test('renders children in a region named by ariaLabel', () => {
+    render(
+      <CollapsibleSidebar title="Filters" ariaLabel="Filters sidebar">
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    expect(getSidebar('Filters sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Child content')).toBeVisible();
+  });
+
+  test('is expanded by default and the toggle names the collapse action', () => {
+    render(
+      <CollapsibleSidebar title="Filters">
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    const toggle = screen.getByRole('button', { name: 'Collapse sidebar' });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(getSidebar()).toHaveStyle({ width: '280px' });
+    // The vertical title belongs to the collapsed rail only.
+    expect(screen.getByText('Filters')).not.toBeVisible();
+  });
+
+  test('the toggle points at the content region it operates', () => {
+    render(
+      <CollapsibleSidebar title="Filters">
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    const contentId = screen
+      .getByRole('button', { name: 'Collapse sidebar' })
+      .getAttribute('aria-controls');
+
+    expect(contentId).toBeTruthy();
+    expect(document.getElementById(contentId as string)).toContainElement(
+      screen.getByText('Child content'),
+    );
+  });
+
+  test('collapses to the rail width and reveals the title on toggle', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsibleSidebar title="Filters" width={320}>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    const toggle = screen.getByRole('button', { name: 'Expand sidebar' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(getSidebar()).toHaveStyle({ width: '48px' });
+    expect(screen.getByText('Filters')).toBeVisible();
+    // Kept mounted so the content does not lose its state, but hidden from view.
+    expect(screen.getByText('Child content')).not.toBeVisible();
+  });
+
+  test('expands again on a second toggle', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsibleSidebar title="Filters">
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    await user.click(screen.getByRole('button', { name: 'Expand sidebar' }));
+
+    expect(screen.getByText('Child content')).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Collapse sidebar' }),
+    ).toBeInTheDocument();
+  });
+
+  test('starts collapsed when defaultOpened is false', () => {
+    render(
+      <CollapsibleSidebar title="Filters" defaultOpened={false}>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    expect(getSidebar()).toHaveStyle({ width: '48px' });
+    expect(
+      screen.getByRole('button', { name: 'Expand sidebar' }),
+    ).toBeInTheDocument();
+  });
+
+  test('honours a custom collapsedWidth', () => {
+    render(
+      <CollapsibleSidebar
+        title="Filters"
+        collapsedWidth={64}
+        defaultOpened={false}
+      >
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    expect(getSidebar()).toHaveStyle({ width: '64px' });
+  });
+
+  test('controlled: follows isOpened and keeps up with a changing width', () => {
+    const { rerender } = render(
+      <CollapsibleSidebar title="Filters" width={240} isOpened={false}>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    expect(getSidebar()).toHaveStyle({ width: '48px' });
+
+    rerender(
+      <CollapsibleSidebar title="Filters" width={240} isOpened>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+    expect(getSidebar()).toHaveStyle({ width: '240px' });
+
+    rerender(
+      <CollapsibleSidebar title="Filters" width={360} isOpened>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+    expect(getSidebar()).toHaveStyle({ width: '360px' });
+  });
+
+  test('controlled: reports the next state without changing its own', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <CollapsibleSidebar
+        title="Filters"
+        isOpened={false}
+        onToggle={onToggle}
+        width={220}
+      >
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Expand sidebar' }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith(true, expect.any(Object));
+    expect(getSidebar()).toHaveStyle({ width: '48px' });
+  });
+
+  test('uncontrolled: reports the next state as well', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <CollapsibleSidebar title="Filters" onToggle={onToggle}>
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    expect(onToggle).toHaveBeenCalledWith(false, expect.any(Object));
+  });
+
+  test('renders additional buttons only while expanded', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsibleSidebar
+        title="Filters"
+        additionalButtons={<button type="button">Extra</button>}
+      >
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Extra' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Extra' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('uses custom toggle labels', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsibleSidebar
+        title="Filters"
+        collapseLabel="Свернуть панель"
+        expandLabel="Развернуть панель"
+      >
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Свернуть панель' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Развернуть панель' }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the toggle label as a tooltip on hover', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsibleSidebar title="Filters">
+        <div>Child content</div>
+      </CollapsibleSidebar>,
+    );
+
+    await user.hover(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Collapse sidebar',
+    );
+  });
+
+  test('gives every sidebar its own content id', () => {
+    render(
+      <>
+        <CollapsibleSidebar title="First" ariaLabel="First">
+          <div>First content</div>
+        </CollapsibleSidebar>
+        <CollapsibleSidebar title="Second" ariaLabel="Second">
+          <div>Second content</div>
+        </CollapsibleSidebar>
+      </>,
+    );
+
+    const [first, second] = screen
+      .getAllByRole('button', { name: 'Collapse sidebar' })
+      .map((toggle) => toggle.getAttribute('aria-controls'));
+
+    expect(first).not.toEqual(second);
+  });
+});

--- a/src/components/New/CollapsibleSidebar/CollapsibleSidebar.stories.tsx
+++ b/src/components/New/CollapsibleSidebar/CollapsibleSidebar.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconSettings } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ButtonAppearance, ButtonVariant } from '@/types/button';
+import { Button } from '../Button/Button';
+import { IconButton } from '../IconButton/IconButton';
+import {
+  CollapsibleSidebar,
+  type CollapsibleSidebarProps,
+} from './CollapsibleSidebar';
+
+const SidebarContent = (
+  <div className="flex flex-col gap-4">
+    <p className="dial-small-text text-primary">
+      This is the collapsible content.
+    </p>
+    <p className="dial-small-paragraph-text text-secondary">
+      Any custom content goes here — text, lists, forms or buttons. It stays
+      mounted while the sidebar is collapsed, so scroll position and form state
+      survive the toggle.
+    </p>
+    <Button label="Action" className="w-fit" variant={ButtonVariant.Primary} />
+  </div>
+);
+
+const Layout = (args: CollapsibleSidebarProps) => (
+  <div className="flex h-[280px] bg-layer-base">
+    <CollapsibleSidebar {...args} />
+    <div className="flex flex-1 items-center justify-center">
+      <p className="dial-small-text text-secondary">Main content area</p>
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Components_2_0/CollapsibleSidebar',
+  component: CollapsibleSidebar,
+  tags: ['collapse', 'sidebar', 'panel'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A side panel that collapses to a narrow rail carrying its title vertically. The toggle is a real `aria-expanded` control naming the content region it operates, and the content stays mounted while collapsed so its state survives. The container paints no background and no radius — it sits on the surface it belongs to.',
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Name of the panel, shown vertically while collapsed',
+    },
+    width: {
+      control: { type: 'number' },
+      description: 'Width in px while expanded',
+    },
+    collapsedWidth: {
+      control: { type: 'number' },
+      description: 'Width in px while collapsed',
+    },
+    defaultOpened: {
+      control: { type: 'boolean' },
+      description: 'Initial open state when uncontrolled',
+    },
+    isOpened: {
+      control: { type: 'boolean' },
+      description: 'Controlled open state',
+    },
+    children: {
+      control: false,
+      description: 'Content shown while expanded',
+    },
+    additionalButtons: {
+      control: false,
+      description: 'Extra footer controls, rendered while expanded',
+    },
+    onToggle: { control: false },
+  },
+  args: {
+    title: 'Panel',
+    width: 300,
+    children: SidebarContent,
+  },
+  render: Layout,
+} satisfies Meta<CollapsibleSidebarProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InitiallyCollapsed: Story = {
+  args: {
+    title: 'Filters',
+    defaultOpened: false,
+  },
+};
+
+export const Narrow: Story = {
+  args: {
+    title: 'Menu',
+    width: 200,
+  },
+};
+
+export const WithAdditionalButtons: Story = {
+  args: {
+    title: 'Settings',
+    additionalButtons: (
+      <IconButton
+        variant={ButtonVariant.Primary}
+        appearance={ButtonAppearance.Ghost}
+        aria-label="Panel settings"
+        tooltipProps={{ tooltip: 'Panel settings' }}
+        icon={<IconSettings size={DIAL_ICON_SIZE.MD} aria-hidden="true" />}
+      />
+    ),
+  },
+};
+
+const ControlledStory = (args: CollapsibleSidebarProps) => {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <div className="flex h-[280px] bg-layer-base">
+      <CollapsibleSidebar
+        {...args}
+        isOpened={opened}
+        onToggle={(next) => setOpened(next)}
+      />
+      <div className="flex flex-col items-start gap-2 p-4">
+        <Button
+          variant={ButtonVariant.Neutral}
+          appearance={ButtonAppearance.Outlined}
+          label={opened ? 'Close from outside' : 'Open from outside'}
+          onClick={() => setOpened((value) => !value)}
+        />
+        <p className="dial-small-text text-secondary">
+          State: {opened ? 'Open' : 'Closed'}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const Controlled: Story = {
+  args: {
+    title: 'Filters',
+    width: 320,
+  },
+  render: ControlledStory,
+};

--- a/src/components/New/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/src/components/New/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -1,0 +1,196 @@
+import {
+  useId,
+  useState,
+  type FC,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+
+import { IconChevronsLeft, IconChevronsRight } from '@tabler/icons-react';
+
+import { DIAL_ICON_SIZE } from '@/constants/icon';
+import { ButtonAppearance, ButtonVariant } from '@/types/button';
+import { ElementSize } from '@/types/size';
+import { mergeClasses } from '@/utils/merge-classes';
+
+import { IconButton } from '../IconButton/IconButton';
+
+/** Width of the collapsed rail — wide enough for the 40px toggle button. */
+const COLLAPSED_WIDTH = 48;
+
+export interface CollapsibleSidebarProps {
+  /** Content shown while the sidebar is expanded. */
+  children: ReactNode;
+  /** Name of the panel, rendered as vertical text while collapsed. */
+  title: ReactNode;
+  /** Width in px while expanded. Defaults to `280`. */
+  width?: number;
+  /** Width in px while collapsed. Defaults to `48`. */
+  collapsedWidth?: number;
+  /** Controlled open state. When provided, the component becomes controlled. */
+  isOpened?: boolean;
+  /** Initial open state when uncontrolled. Defaults to `true`. */
+  defaultOpened?: boolean;
+  /** Fired when the toggle is clicked. Receives the next open state. */
+  onToggle?: (nextOpened: boolean, e: MouseEvent<HTMLButtonElement>) => void;
+  /** Extra controls rendered in the footer next to the toggle, expanded only. */
+  additionalButtons?: ReactNode;
+  /** Accessible name of the sidebar region. Defaults to `'Sidebar'`. */
+  ariaLabel?: string;
+  /** Name and tooltip of the toggle while expanded. Defaults to `'Collapse sidebar'`. */
+  collapseLabel?: string;
+  /** Name and tooltip of the toggle while collapsed. Defaults to `'Expand sidebar'`. */
+  expandLabel?: string;
+  /** Additional CSS classes for the outer container. */
+  className?: string;
+  /** Additional CSS classes for the vertical title. */
+  titleClassName?: string;
+  /** Additional CSS classes for the content region. */
+  contentClassName?: string;
+  /** Additional CSS classes for the footer holding the toggle. */
+  footerClassName?: string;
+}
+
+/**
+ * A side panel that collapses to a narrow rail carrying its title vertically.
+ * aliases: ToggleSidebar|CollapsiblePanel|SidePanel
+ * Design system 2.0
+ *
+ * Works as a controlled component when `isOpened` is provided, otherwise it keeps
+ * its own state from `defaultOpened`. The width is derived from the open state, so
+ * changing `width` on an open sidebar takes effect immediately.
+ *
+ * The panel is an `aside` named by `ariaLabel`, and the toggle is a real
+ * `aria-expanded` control pointing at the content region. Content stays mounted
+ * while collapsed — hidden with `display: none` — so scroll position and any
+ * form state inside it survive a collapse.
+ *
+ * The container paints no background and no radius: it is meant to sit on the
+ * surface it belongs to. Pass `className` for either.
+ *
+ * @example
+ * ```tsx
+ * <CollapsibleSidebar title="Filters" width={320}>
+ *   <FilterForm />
+ * </CollapsibleSidebar>
+ *
+ * <CollapsibleSidebar
+ *   title="Filters"
+ *   isOpened={opened}
+ *   onToggle={setOpened}
+ * >
+ *   <FilterForm />
+ * </CollapsibleSidebar>
+ * ```
+ *
+ * @param children - Content shown while the sidebar is expanded.
+ * @param title - Name of the panel, rendered as vertical text while collapsed.
+ * @param [width=280] - Width in px while expanded.
+ * @param [collapsedWidth=48] - Width in px while collapsed.
+ * @param [isOpened] - Controlled open state.
+ * @param [defaultOpened=true] - Initial open state when uncontrolled.
+ * @param [onToggle] - Fired when the toggle is clicked. Receives the next open state.
+ * @param [additionalButtons] - Extra footer controls, rendered while expanded.
+ * @param [ariaLabel='Sidebar'] - Accessible name of the sidebar region.
+ * @param [collapseLabel='Collapse sidebar'] - Name and tooltip of the toggle while expanded.
+ * @param [expandLabel='Expand sidebar'] - Name and tooltip of the toggle while collapsed.
+ * @param [className] - Additional CSS classes for the outer container.
+ * @param [titleClassName] - Additional CSS classes for the vertical title.
+ * @param [contentClassName] - Additional CSS classes for the content region.
+ * @param [footerClassName] - Additional CSS classes for the footer.
+ */
+export const CollapsibleSidebar: FC<CollapsibleSidebarProps> = ({
+  children,
+  title,
+  width = 280,
+  collapsedWidth = COLLAPSED_WIDTH,
+  isOpened,
+  defaultOpened = true,
+  onToggle,
+  additionalButtons,
+  ariaLabel = 'Sidebar',
+  collapseLabel = 'Collapse sidebar',
+  expandLabel = 'Expand sidebar',
+  className,
+  titleClassName,
+  contentClassName,
+  footerClassName,
+}) => {
+  const isControlled = isOpened !== undefined;
+  const [internalOpened, setInternalOpened] = useState(defaultOpened);
+  const opened = isControlled ? isOpened : internalOpened;
+
+  // Generated rather than fixed: two sidebars on one page would otherwise share
+  // a content id and both toggles would point at the first one.
+  const contentId = `collapsible-sidebar-content-${useId()}`;
+
+  const toggleLabel = opened ? collapseLabel : expandLabel;
+
+  const changeVisibility = (e: MouseEvent<HTMLButtonElement>) => {
+    const next = !opened;
+
+    if (!isControlled) {
+      setInternalOpened(next);
+    }
+
+    onToggle?.(next, e);
+  };
+
+  return (
+    <aside
+      aria-label={ariaLabel}
+      style={{ width: `${opened ? width : collapsedWidth}px` }}
+      className={mergeClasses('flex flex-col justify-between', className)}
+    >
+      <div
+        id={contentId}
+        // Kept mounted while collapsed so the content does not lose its state.
+        // Hidden through the attribute rather than a `hidden` class: that also
+        // takes it out of the accessibility tree, and it holds even where the
+        // utility layer has not been loaded.
+        hidden={!opened}
+        className={mergeClasses(
+          'min-h-0 flex-1 overflow-auto p-4',
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+      <div
+        hidden={opened}
+        className={mergeClasses(
+          'rotate-180 px-3 py-4 [writing-mode:tb-rl] dial-small-text text-primary',
+          titleClassName,
+        )}
+      >
+        {title}
+      </div>
+      <div
+        className={mergeClasses(
+          'flex h-12 shrink-0 flex-row items-center gap-2 border-t border-tertiary py-1',
+          opened ? 'justify-end px-2' : 'justify-center',
+          footerClassName,
+        )}
+      >
+        {opened && additionalButtons}
+        <IconButton
+          variant={ButtonVariant.Primary}
+          appearance={ButtonAppearance.Ghost}
+          size={ElementSize.Standard}
+          onClick={changeVisibility}
+          aria-label={toggleLabel}
+          aria-expanded={opened}
+          aria-controls={contentId}
+          tooltipProps={{ tooltip: toggleLabel }}
+          icon={
+            opened ? (
+              <IconChevronsLeft size={DIAL_ICON_SIZE.MD} aria-hidden="true" />
+            ) : (
+              <IconChevronsRight size={DIAL_ICON_SIZE.MD} aria-hidden="true" />
+            )
+          }
+        />
+      </div>
+    </aside>
+  );
+};

--- a/src/components/New/ResizableContainer/ConditionalResizableContainer.spec.tsx
+++ b/src/components/New/ResizableContainer/ConditionalResizableContainer.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { ConditionalResizableContainer } from './ConditionalResizableContainer';
+
+const BOUNDS = { minWidth: 150, maxWidth: 500 };
+
+describe('Dial UI Kit :: ConditionalResizableContainer', () => {
+  test('wraps children in a resizable container by default', () => {
+    render(
+      <ConditionalResizableContainer {...BOUNDS} defaultWidth={260}>
+        <div>Panel content</div>
+      </ConditionalResizableContainer>,
+    );
+
+    expect(screen.getByText('Panel content')).toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  test('renders children on their own when disabled', () => {
+    const { container } = render(
+      <ConditionalResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        enabled={false}
+      >
+        <div>Panel content</div>
+      </ConditionalResizableContainer>,
+    );
+
+    expect(screen.getByText('Panel content')).toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+    // No wrapper element is added around the children.
+    expect(container.firstElementChild).toHaveTextContent('Panel content');
+    expect(container.childElementCount).toBe(1);
+  });
+});

--- a/src/components/New/ResizableContainer/ConditionalResizableContainer.stories.tsx
+++ b/src/components/New/ResizableContainer/ConditionalResizableContainer.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { ButtonAppearance, ButtonVariant } from '@/types/button';
+import { Button } from '../Button/Button';
+import {
+  ConditionalResizableContainer,
+  type ConditionalResizableContainerProps,
+} from './ConditionalResizableContainer';
+
+const meta = {
+  title: 'Components_2_0/ConditionalResizableContainer',
+  component: ConditionalResizableContainer,
+  tags: ['layout', 'resizable', 'container'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Renders its children inside a `ResizableContainer` only while `enabled`. When disabled the children are rendered on their own, with no wrapper element and no resize behaviour.',
+      },
+    },
+  },
+  argTypes: {
+    enabled: {
+      control: { type: 'boolean' },
+      description: 'Whether resizing is enabled',
+    },
+    children: { control: false },
+    onResize: { control: false },
+    onResizeStop: { control: false },
+  },
+  args: {
+    enabled: true,
+    minWidth: 150,
+    maxWidth: 500,
+    defaultWidth: 260,
+    children: (
+      <div className="flex flex-col gap-1 p-4">
+        <div className="dial-small-semi-text text-primary">Panel</div>
+        <div className="dial-small-paragraph-text text-secondary">
+          Resizable only while enabled.
+        </div>
+      </div>
+    ),
+  },
+} satisfies Meta<ConditionalResizableContainerProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Enabled: Story = {
+  render: (args) => (
+    <div className="flex h-[240px] bg-layer-base">
+      <ConditionalResizableContainer {...args} />
+      <div className="flex flex-1 items-center justify-center">
+        <p className="dial-small-text text-secondary">Main content area</p>
+      </div>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { enabled: false },
+  render: Enabled.render,
+};
+
+const ToggleStory = (args: ConditionalResizableContainerProps) => {
+  const [enabled, setEnabled] = useState(true);
+
+  return (
+    <div className="flex h-[240px] bg-layer-base">
+      <ConditionalResizableContainer {...args} enabled={enabled} />
+      <div className="flex flex-col items-start gap-2 p-4">
+        <Button
+          variant={ButtonVariant.Neutral}
+          appearance={ButtonAppearance.Outlined}
+          label={enabled ? 'Disable resizing' : 'Enable resizing'}
+          onClick={() => setEnabled((value) => !value)}
+        />
+        <p className="dial-small-text text-secondary">
+          Resizing: {enabled ? 'on' : 'off'}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const Toggleable: Story = {
+  render: ToggleStory,
+};

--- a/src/components/New/ResizableContainer/ConditionalResizableContainer.tsx
+++ b/src/components/New/ResizableContainer/ConditionalResizableContainer.tsx
@@ -1,0 +1,48 @@
+import type { FC } from 'react';
+
+import {
+  ResizableContainer,
+  type ResizableContainerProps,
+} from './ResizableContainer';
+
+export interface ConditionalResizableContainerProps extends ResizableContainerProps {
+  /** Whether resizing is enabled. Defaults to `true`. */
+  enabled?: boolean;
+}
+
+/**
+ * Renders its children inside a {@link ResizableContainer} only while `enabled`.
+ * aliases: OptionalResize|ConditionalPanel
+ * Design system 2.0
+ *
+ * When `enabled` is false the children are rendered on their own, with no
+ * wrapper element and no resize behaviour — useful for a panel that is only
+ * resizable while it is expanded. Every other prop is passed straight through;
+ * see {@link ResizableContainer} for controlled and uncontrolled sizing, sides
+ * and callbacks.
+ *
+ * @example
+ * ```tsx
+ * <ConditionalResizableContainer
+ *   enabled={isExpanded}
+ *   minWidth={180}
+ *   maxWidth={520}
+ *   defaultWidth={260}
+ * >
+ *   <Sidebar />
+ * </ConditionalResizableContainer>
+ * ```
+ *
+ * @param [enabled=true] - Whether resizing is enabled.
+ * @param children - Content to render inside the container.
+ * @see ResizableContainer
+ */
+export const ConditionalResizableContainer: FC<
+  ConditionalResizableContainerProps
+> = ({ enabled = true, children, ...rest }) => {
+  if (!enabled) {
+    return children;
+  }
+
+  return <ResizableContainer {...rest}>{children}</ResizableContainer>;
+};

--- a/src/components/New/ResizableContainer/ResizableContainer.spec.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.spec.tsx
@@ -1,0 +1,252 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ResizableContainerSide } from '@/types/resizable-container';
+import { ResizableContainer } from './ResizableContainer';
+
+const BOUNDS = { minWidth: 150, maxWidth: 500 };
+
+const focusHandle = async (name = 'Resize panel') => {
+  const handle = screen.getByRole('separator', { name });
+  handle.focus();
+  expect(handle).toHaveFocus();
+
+  return handle;
+};
+
+describe('Dial UI Kit :: ResizableContainer', () => {
+  test('renders children', () => {
+    render(
+      <ResizableContainer {...BOUNDS} defaultWidth={260}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(screen.getByText('Panel content')).toBeInTheDocument();
+  });
+
+  test('exposes the handle as a focusable separator carrying the bounds', () => {
+    render(
+      <ResizableContainer {...BOUNDS} defaultWidth={260}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    const handle = screen.getByRole('separator', { name: 'Resize panel' });
+
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+    expect(handle).toHaveAttribute('aria-valuenow', '260');
+    expect(handle).toHaveAttribute('aria-valuemin', '150');
+    expect(handle).toHaveAttribute('aria-valuemax', '500');
+    expect(handle).toHaveAttribute('tabindex', '0');
+  });
+
+  test('names the handle from ariaLabel', () => {
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        ariaLabel="Resize tree"
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(
+      screen.getByRole('separator', { name: 'Resize tree' }),
+    ).toBeInTheDocument();
+  });
+
+  test('uncontrolled: arrow keys resize the panel and report the new width', async () => {
+    const user = userEvent.setup();
+    const onResize = vi.fn();
+    const onResizeStop = vi.fn();
+    const { container } = render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        onResize={onResize}
+        onResizeStop={onResizeStop}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onResize).toHaveBeenLastCalledWith(276);
+    expect(onResizeStop).toHaveBeenLastCalledWith(276);
+    expect(screen.getByRole('separator')).toHaveAttribute(
+      'aria-valuenow',
+      '276',
+    );
+    expect(container.firstElementChild).toHaveStyle({ width: '276px' });
+
+    await user.keyboard('{ArrowLeft}{ArrowLeft}');
+
+    expect(onResizeStop).toHaveBeenLastCalledWith(244);
+    expect(container.firstElementChild).toHaveStyle({ width: '244px' });
+  });
+
+  test('uncontrolled: falls back to minWidth when defaultWidth is omitted', () => {
+    render(
+      <ResizableContainer {...BOUNDS}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(screen.getByRole('separator')).toHaveAttribute(
+      'aria-valuenow',
+      '150',
+    );
+  });
+
+  test('Home and End jump to the bounds and stop there', async () => {
+    const user = userEvent.setup();
+    const onResizeStop = vi.fn();
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        onResizeStop={onResizeStop}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+
+    await user.keyboard('{End}');
+    expect(onResizeStop).toHaveBeenLastCalledWith(500);
+
+    // Already at the maximum, so there is nothing to report.
+    onResizeStop.mockClear();
+    await user.keyboard('{ArrowRight}');
+    expect(onResizeStop).not.toHaveBeenCalled();
+
+    await user.keyboard('{Home}');
+    expect(onResizeStop).toHaveBeenLastCalledWith(150);
+
+    onResizeStop.mockClear();
+    await user.keyboard('{ArrowLeft}');
+    expect(onResizeStop).not.toHaveBeenCalled();
+  });
+
+  test('a left-side handle grows the panel with ArrowLeft', async () => {
+    const user = userEvent.setup();
+    const onResizeStop = vi.fn();
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        side={ResizableContainerSide.Left}
+        onResizeStop={onResizeStop}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onResizeStop).toHaveBeenLastCalledWith(276);
+
+    await user.keyboard('{ArrowRight}{ArrowRight}');
+    expect(onResizeStop).toHaveBeenLastCalledWith(244);
+  });
+
+  test('honours a custom keyboardStep', async () => {
+    const user = userEvent.setup();
+    const onResizeStop = vi.fn();
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        keyboardStep={50}
+        onResizeStop={onResizeStop}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onResizeStop).toHaveBeenLastCalledWith(310);
+  });
+
+  test('ignores keys that are not resize keys', async () => {
+    const user = userEvent.setup();
+    const onResizeStop = vi.fn();
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        onResizeStop={onResizeStop}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+    await user.keyboard('{Enter}{ArrowUp}a');
+
+    expect(onResizeStop).not.toHaveBeenCalled();
+  });
+
+  test('controlled: reports the next width without changing its own', async () => {
+    const user = userEvent.setup();
+    const onResizeStop = vi.fn();
+    render(
+      <ResizableContainer {...BOUNDS} width={300} onResizeStop={onResizeStop}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    await focusHandle();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onResizeStop).toHaveBeenCalledWith(316);
+    expect(screen.getByRole('separator')).toHaveAttribute(
+      'aria-valuenow',
+      '300',
+    );
+  });
+
+  test('controlled: follows the width prop', () => {
+    const { rerender } = render(
+      <ResizableContainer {...BOUNDS} width={300}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    rerender(
+      <ResizableContainer {...BOUNDS} width={420}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(screen.getByRole('separator')).toHaveAttribute(
+      'aria-valuenow',
+      '420',
+    );
+  });
+
+  test('renders a custom handler inside the separator', () => {
+    render(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        resizeHandler={<span>Grip</span>}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(screen.getByRole('separator')).toContainElement(
+      screen.getByText('Grip'),
+    );
+  });
+});

--- a/src/components/New/ResizableContainer/ResizableContainer.stories.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconGripVertical } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import { ResizableContainerSide } from '@/types/resizable-container';
+import {
+  ResizableContainer,
+  type ResizableContainerProps,
+} from './ResizableContainer';
+
+const PanelContent = (
+  <div className="flex flex-col gap-1 p-4">
+    <div className="dial-small-semi-text text-primary">Resizable panel</div>
+    <div className="dial-small-paragraph-text text-secondary">
+      Drag the edge, or focus it with the keyboard and use the arrow keys — Home
+      and End jump to the bounds.
+    </div>
+  </div>
+);
+
+const Layout = (args: ResizableContainerProps) => (
+  <div className="flex h-[280px] bg-layer-base">
+    <ResizableContainer {...args} />
+    <div className="flex flex-1 items-center justify-center">
+      <p className="dial-small-text text-secondary">Main content area</p>
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Components_2_0/ResizableContainer',
+  component: ResizableContainer,
+  tags: ['layout', 'resizable', 'container'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A panel the user can widen or narrow by dragging its edge, in controlled or uncontrolled mode, from either side. The handle is a focusable `separator`, so the panel is also resizable with the arrow keys.',
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: false,
+      description: 'Content rendered inside the container',
+    },
+    minWidth: {
+      control: { type: 'number' },
+      description: 'Minimum width in px',
+    },
+    maxWidth: {
+      control: { type: 'number' },
+      description: 'Maximum width in px',
+    },
+    width: {
+      control: { type: 'number' },
+      description: 'Controlled width. Omit for uncontrolled mode',
+    },
+    defaultWidth: {
+      control: { type: 'number' },
+      description: 'Initial width when uncontrolled',
+    },
+    side: {
+      control: { type: 'select' },
+      options: Object.values(ResizableContainerSide),
+      description: 'Edge carrying the resize handle',
+    },
+    keyboardStep: {
+      control: { type: 'number' },
+      description: 'Width change per arrow key press',
+    },
+    resizeHandlerClassName: {
+      control: { type: 'text' },
+      description: 'Additional CSS classes for the handle',
+    },
+    resizeHandler: {
+      control: false,
+      description: 'Custom node rendered inside the handle',
+    },
+    onResize: { control: false },
+    onResizeStop: { control: false },
+  },
+  args: {
+    minWidth: 150,
+    maxWidth: 500,
+    defaultWidth: 260,
+    side: ResizableContainerSide.Right,
+    children: PanelContent,
+  },
+  render: Layout,
+} satisfies Meta<ResizableContainerProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Uncontrolled: Story = {};
+
+const ControlledStory = (args: ResizableContainerProps) => {
+  const [width, setWidth] = useState(args.defaultWidth ?? args.minWidth);
+
+  return (
+    <div className="flex h-[280px] bg-layer-base">
+      <ResizableContainer {...args} width={width} onResizeStop={setWidth}>
+        <div className="flex flex-col gap-1 p-4">
+          <div className="dial-small-semi-text text-primary">
+            Controlled panel
+          </div>
+          <div className="dial-small-paragraph-text text-secondary">
+            Width is owned by the story: {width}px
+          </div>
+        </div>
+      </ResizableContainer>
+      <div className="flex flex-1 items-center justify-center">
+        <p className="dial-small-text text-secondary">Main content area</p>
+      </div>
+    </div>
+  );
+};
+
+export const Controlled: Story = {
+  render: ControlledStory,
+};
+
+export const ResizeFromLeft: Story = {
+  args: {
+    side: ResizableContainerSide.Left,
+  },
+  render: (args) => (
+    <div className="flex h-[280px] justify-end bg-layer-base">
+      <ResizableContainer {...args} />
+    </div>
+  ),
+};
+
+export const WithDividers: Story = {
+  args: {
+    className: 'divide-y divide-tertiary',
+    children: (
+      <>
+        <div className="p-4 dial-small-semi-text text-primary">Header</div>
+        <div className="flex-1 p-4 dial-small-text text-secondary">Body</div>
+        <div className="p-4 dial-small-text text-secondary">Footer</div>
+      </>
+    ),
+  },
+};
+
+export const CustomHandler: Story = {
+  args: {
+    resizeHandler: (
+      <IconGripVertical className="size-4 text-accent" aria-hidden="true" />
+    ),
+    resizeHandlerClassName: 'w-1 flex items-center justify-center',
+  },
+};

--- a/src/components/New/ResizableContainer/ResizableContainer.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.tsx
@@ -1,0 +1,235 @@
+import { Resizable, type ResizableProps } from 're-resizable';
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type ReactNode,
+} from 'react';
+
+import { ResizableContainerSide } from '@/types/resizable-container';
+import { mergeClasses } from '@/utils/merge-classes';
+
+import { ResizeHandle } from './components/ResizeHandle';
+
+/** Width change per arrow key press while the handle has keyboard focus. */
+const DEFAULT_KEYBOARD_STEP = 16;
+
+export interface ResizableContainerProps {
+  /** Content placed inside the container. */
+  children: ReactNode;
+  /** Minimum allowed width in px. */
+  minWidth: number;
+  /** Maximum allowed width in px. */
+  maxWidth: number;
+  /** Controlled width in px. When provided, the component becomes controlled. */
+  width?: number;
+  /** Initial width when uncontrolled. Defaults to `minWidth`. */
+  defaultWidth?: number;
+  /** Fired when a resize ends, and once per arrow key press. */
+  onResizeStop?: (width: number) => void;
+  /** Fired continuously while dragging, with the current width. */
+  onResize?: (width: number) => void;
+  /** Edge carrying the resize handle. Defaults to `ResizableContainerSide.Right`. */
+  side?: ResizableContainerSide;
+  /** Width change per arrow key press. Defaults to `16`. */
+  keyboardStep?: number;
+  /** Accessible name of the handle. Defaults to `'Resize panel'`. */
+  ariaLabel?: string;
+  /** Additional CSS classes for the inner content wrapper. */
+  className?: string;
+  /** Additional CSS classes for the resize handle. */
+  resizeHandlerClassName?: string;
+  /** Custom node rendered inside the handle. */
+  resizeHandler?: ReactNode;
+}
+
+/**
+ * A panel the user can widen or narrow by dragging its edge.
+ * aliases: ResizePanel|SizableContainer|Splitter
+ * Design system 2.0
+ *
+ * Works as a controlled component when `width` is provided, otherwise it keeps
+ * its own width from `defaultWidth`. The handle appears on hover and while
+ * dragging, and stays within `minWidth`–`maxWidth` in both modes.
+ *
+ * The handle is a focusable `separator`, so the panel resizes with the arrow
+ * keys — `Home` and `End` jump to the bounds — and each press reports through
+ * `onResize` and `onResizeStop`. Unlike the 1.0 container this one draws no
+ * dividers between its children; pass `divide-y divide-tertiary` through
+ * `className` if you want them.
+ *
+ * @example
+ * ```tsx
+ * <ResizableContainer minWidth={180} maxWidth={520} defaultWidth={260}>
+ *   <Sidebar />
+ * </ResizableContainer>
+ *
+ * <ResizableContainer
+ *   minWidth={180}
+ *   maxWidth={520}
+ *   width={sidebarWidth}
+ *   onResizeStop={setSidebarWidth}
+ * >
+ *   <Sidebar />
+ * </ResizableContainer>
+ * ```
+ *
+ * @param children - Content placed inside the container.
+ * @param minWidth - Minimum allowed width in px.
+ * @param maxWidth - Maximum allowed width in px.
+ * @param [width] - Controlled width. If omitted the container is uncontrolled.
+ * @param [defaultWidth] - Initial width when uncontrolled. Defaults to `minWidth`.
+ * @param [onResizeStop] - Fired when a resize ends, and once per arrow key press.
+ * @param [onResize] - Fired continuously while dragging.
+ * @param [side=ResizableContainerSide.Right] - Edge carrying the resize handle.
+ * @param [keyboardStep=16] - Width change per arrow key press.
+ * @param [ariaLabel='Resize panel'] - Accessible name of the handle.
+ * @param [className] - Additional CSS classes for the inner content wrapper.
+ * @param [resizeHandlerClassName] - Additional CSS classes for the resize handle.
+ * @param [resizeHandler] - Custom node rendered inside the handle.
+ */
+export const ResizableContainer: FC<ResizableContainerProps> = ({
+  children,
+  minWidth,
+  maxWidth,
+  width,
+  defaultWidth,
+  onResizeStop,
+  onResize,
+  side = ResizableContainerSide.Right,
+  keyboardStep = DEFAULT_KEYBOARD_STEP,
+  ariaLabel = 'Resize panel',
+  className,
+  resizeHandlerClassName,
+  resizeHandler,
+}) => {
+  const [isResizing, setIsResizing] = useState(false);
+  const [internalWidth, setInternalWidth] = useState(defaultWidth ?? minWidth);
+
+  const isControlled = width !== undefined;
+  const effectiveWidth = isControlled ? width : internalWidth;
+
+  const resizableRef = useRef<Resizable>(null);
+
+  const resizeStartHandler = useCallback(() => {
+    setIsResizing(true);
+  }, []);
+
+  const resizeStopHandler = useCallback(() => {
+    setIsResizing(false);
+
+    const rect = resizableRef.current?.resizable?.getBoundingClientRect();
+    const finalWidth = rect ? Math.round(rect.width) : minWidth;
+
+    if (!isControlled) {
+      setInternalWidth(finalWidth);
+    }
+
+    onResizeStop?.(finalWidth);
+  }, [onResizeStop, isControlled, minWidth]);
+
+  /**
+   * Keyboard resizing has no drag to end, so one press is both the move and the
+   * commit: it reports through `onResize` and `onResizeStop` at once.
+   */
+  const keyboardResizeHandler = useCallback(
+    (nextWidth: number) => {
+      const clamped = Math.min(maxWidth, Math.max(minWidth, nextWidth));
+
+      if (clamped === effectiveWidth) return;
+
+      if (!isControlled) {
+        setInternalWidth(clamped);
+        // `defaultSize` only seeds the first render — in uncontrolled mode
+        // re-resizable owns the rendered size, so the new width has to be
+        // pushed into it or the panel would not move.
+        resizableRef.current?.updateSize({ width: clamped, height: '100%' });
+      }
+
+      onResize?.(clamped);
+      onResizeStop?.(clamped);
+    },
+    [maxWidth, minWidth, effectiveWidth, isControlled, onResize, onResizeStop],
+  );
+
+  const resizeSettings: ResizableProps = useMemo(() => {
+    const isLeft = side === ResizableContainerSide.Left;
+
+    const handleComponent = (
+      <ResizeHandle
+        side={side}
+        isResizing={isResizing}
+        width={effectiveWidth}
+        minWidth={minWidth}
+        maxWidth={maxWidth}
+        step={keyboardStep}
+        ariaLabel={ariaLabel}
+        onWidthChange={keyboardResizeHandler}
+        customHandler={resizeHandler}
+        handlerClassName={resizeHandlerClassName}
+      />
+    );
+
+    return {
+      size: isControlled
+        ? { width: effectiveWidth, height: '100%' }
+        : undefined,
+      defaultSize: isControlled
+        ? undefined
+        : { width: effectiveWidth, height: '100%' },
+      minWidth,
+      maxWidth,
+      enable: {
+        left: isLeft,
+        right: !isLeft,
+      },
+      handleClasses: {
+        right: 'group',
+        left: 'group',
+      },
+      handleStyles: {
+        right: { right: '-8px', zIndex: 10 },
+        left: { left: 0, zIndex: 10 },
+      },
+      handleComponent: {
+        left: isLeft ? handleComponent : undefined,
+        right: !isLeft ? handleComponent : undefined,
+      },
+      onResizeStart: resizeStartHandler,
+      onResize: (_e, _dir, ref) => {
+        onResize?.(Math.round(ref.offsetWidth));
+      },
+      onResizeStop: resizeStopHandler,
+    };
+  }, [
+    side,
+    isControlled,
+    effectiveWidth,
+    minWidth,
+    maxWidth,
+    keyboardStep,
+    ariaLabel,
+    keyboardResizeHandler,
+    resizeHandler,
+    resizeHandlerClassName,
+    isResizing,
+    resizeStartHandler,
+    resizeStopHandler,
+    onResize,
+  ]);
+
+  return (
+    <Resizable ref={resizableRef} {...resizeSettings}>
+      <div
+        className={mergeClasses(
+          'group flex size-full flex-col bg-layer-raised transition-all motion-reduce:transition-none',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </Resizable>
+  );
+};

--- a/src/components/New/ResizableContainer/components/ResizeHandle.tsx
+++ b/src/components/New/ResizableContainer/components/ResizeHandle.tsx
@@ -1,0 +1,90 @@
+import type { FC, KeyboardEvent, ReactNode } from 'react';
+
+import { ResizableContainerSide } from '@/types/resizable-container';
+import { mergeClasses } from '@/utils/merge-classes';
+
+interface ResizeHandleProps {
+  side: ResizableContainerSide;
+  isResizing: boolean;
+  width: number;
+  minWidth: number;
+  maxWidth: number;
+  step: number;
+  ariaLabel: string;
+  onWidthChange: (nextWidth: number) => void;
+  customHandler?: ReactNode;
+  handlerClassName?: string;
+}
+
+/**
+ * The draggable edge of {@link ResizableContainer}. It is a focusable
+ * `separator` — the window-splitter pattern — so the panel can be resized with
+ * the arrow keys as well as the pointer.
+ */
+export const ResizeHandle: FC<ResizeHandleProps> = ({
+  side,
+  isResizing,
+  width,
+  minWidth,
+  maxWidth,
+  step,
+  ariaLabel,
+  onWidthChange,
+  customHandler,
+  handlerClassName,
+}) => {
+  const isLeft = side === ResizableContainerSide.Left;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    let next: number;
+
+    switch (e.key) {
+      // A left-side handle is the panel's left edge, so moving it left grows
+      // the panel; a right-side handle works the other way round.
+      case 'ArrowLeft':
+        next = width + (isLeft ? step : -step);
+        break;
+      case 'ArrowRight':
+        next = width + (isLeft ? -step : step);
+        break;
+      case 'Home':
+        next = minWidth;
+        break;
+      case 'End':
+        next = maxWidth;
+        break;
+      default:
+        return;
+    }
+
+    // Arrow keys would otherwise scroll the page while the handle has focus.
+    e.preventDefault();
+    onWidthChange(next);
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      aria-valuenow={width}
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className={mergeClasses(
+        'h-full w-0.5 cursor-col-resize bg-control-accent text-accent',
+        // Faded out rather than `invisible`: a `visibility: hidden` element
+        // cannot be focused, which would leave the handle keyboard-only in
+        // theory and unreachable in practice.
+        'opacity-0 transition-opacity motion-reduce:transition-none',
+        'group-hover:opacity-100 focus-visible:opacity-100',
+        'focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-focus',
+        isResizing && 'opacity-100',
+        handlerClassName,
+      )}
+    >
+      {customHandler}
+    </div>
+  );
+};

--- a/src/components/New/SegmentedControl/constants.ts
+++ b/src/components/New/SegmentedControl/constants.ts
@@ -10,7 +10,7 @@ export const NAVIGATION_KEYS = [
 
 /** The sunken track the segments sit in. */
 export const containerClassName =
-  'inline-flex w-fit items-center gap-1 rounded-full bg-layer-sunken p-1';
+  'inline-flex w-fit items-center gap-1 rounded-full border border-tertiary bg-layer-sunken p-[3px]';
 
 export const segmentClassName =
   'flex h-8 min-w-8 flex-1 shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-full px-4 dial-small-text transition-colors duration-200 outline-offset-0 focus-visible:outline focus-visible:outline-focus';

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,3 +411,9 @@ export type { TooltipContainerOptions } from './components/New/Tooltip/TooltipCo
 export { TooltipPlacement } from './types/tooltip.ts';
 export { EllipsisTooltip } from './components/New/EllipsisTooltip/EllipsisTooltip';
 export type { EllipsisTooltipProps } from './components/New/EllipsisTooltip/EllipsisTooltip';
+export { CollapsibleSidebar } from './components/New/CollapsibleSidebar/CollapsibleSidebar';
+export type { CollapsibleSidebarProps } from './components/New/CollapsibleSidebar/CollapsibleSidebar';
+export { ResizableContainer } from './components/New/ResizableContainer/ResizableContainer';
+export type { ResizableContainerProps } from './components/New/ResizableContainer/ResizableContainer';
+export { ConditionalResizableContainer } from './components/New/ResizableContainer/ConditionalResizableContainer';
+export type { ConditionalResizableContainerProps } from './components/New/ResizableContainer/ConditionalResizableContainer';

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -26,8 +26,13 @@
   @apply cursor-not-allowed;
 }
 
+/*
+ * `shadow-none` matters as much as the flat background: the resting shadow of
+ * the solid variants is blue-tinted (`--shadow-xs-sm-1`), so a disabled button
+ * that keeps it reads as a grey pill floating in a blue halo.
+ */
 .dial-kit-solid-button-disable {
-  @apply text-control-disable-primary bg-none bg-control-disable-primary border-transparent;
+  @apply text-control-disable-primary bg-none bg-control-disable-primary border-transparent shadow-none;
 }
 
 /*
@@ -75,12 +80,12 @@
   @apply shadow-sm dial-kit-base-button text-control-permanent bg-control-accent-gradient;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply shadow-md bg-control-accent-gradient-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply shadow-xs bg-control-accent-gradient-active;
   }
 }
@@ -90,12 +95,12 @@
   @apply border-accent-alpha;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-accent-alpha-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-accent-alpha-active;
   }
 }
@@ -104,12 +109,12 @@
   @apply dial-kit-base-button text-control-permanent bg-control-error;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-error-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-error-active;
   }
 }
@@ -118,12 +123,12 @@
   @apply dial-kit-base-button text-secondary bg-transparent;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-neutral-hover-muted;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-neutral-active;
   }
 }
@@ -134,12 +139,12 @@
   @apply border-default;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-neutral-hover-muted;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-neutral-active;
   }
 }
@@ -149,23 +154,42 @@
   @apply border-error;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-error-alpha-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-error-alpha-active;
   }
 }
 
+/*
+ * Both selectors per variant: a `Button` with an `href` renders an `<a>`, which
+ * never matches `:disabled` and carries `aria-disabled` instead — without the
+ * second half a disabled link keeps the enabled fill and shadow.
+ *
+ * The hover and active rules of every variant above are gated on
+ * `:not(:disabled):not([aria-disabled='true'])` rather than being overridden
+ * here: a disabled control must not react to the pointer at all, and leaving
+ * that to source order breaks the moment a rule moves. `:enabled` would not do
+ * — it never matches an `<a>`, so it would take the hover state away from
+ * enabled link buttons too.
+ */
 .dial-kit-primary-solid-button:disabled,
+.dial-kit-primary-solid-button[aria-disabled='true'],
 .dial-kit-neutral-solid-button:disabled,
+.dial-kit-neutral-solid-button[aria-disabled='true'],
 .dial-kit-danger-solid-button:disabled,
+.dial-kit-danger-solid-button[aria-disabled='true'],
 .dial-kit-static-solid-button:disabled,
+.dial-kit-static-solid-button[aria-disabled='true'],
 .dial-kit-neutral-outlined-button:disabled,
+.dial-kit-neutral-outlined-button[aria-disabled='true'],
 .dial-kit-danger-outlined-button:disabled,
-.dial-kit-fab-button:disabled {
+.dial-kit-danger-outlined-button[aria-disabled='true'],
+.dial-kit-fab-button:disabled,
+.dial-kit-fab-button[aria-disabled='true'] {
   @apply dial-kit-solid-button-disable;
 }
 
@@ -176,8 +200,8 @@
   &.dial-kit-base-icon-button {
     @apply text-secondary;
     @media (hover: hover) {
-      &:hover {
-        @apply enabled:text-accent;
+      &:hover:not(:disabled):not([aria-disabled='true']) {
+        @apply text-accent;
       }
     }
 
@@ -187,12 +211,12 @@
   }
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-accent-alpha-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-accent-alpha-active;
   }
 }
@@ -201,12 +225,12 @@
   @apply dial-kit-base-button text-error bg-transparent;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-error-alpha-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-error-alpha-active;
   }
 
@@ -218,7 +242,9 @@
 }
 
 .dial-kit-primary-ghost-button:disabled,
-.dial-kit-danger-ghost-button:disabled {
+.dial-kit-primary-ghost-button[aria-disabled='true'],
+.dial-kit-danger-ghost-button:disabled,
+.dial-kit-danger-ghost-button[aria-disabled='true'] {
   @apply text-control-disable-primary bg-transparent;
 }
 
@@ -228,16 +254,15 @@
   @apply dial-kit-base-button bg-transparent text-accent no-underline;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply text-control-accent-hover;
     }
   }
 
-  &:active {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply text-control-accent-active;
   }
 
-  /* Must stay last: same specificity as the hover/active rules above. */
   &:disabled,
   &[aria-disabled='true'] {
     @apply text-control-disable-primary;
@@ -249,12 +274,12 @@
   @apply bg-control-neutral shadow-sm text-primary;
 
   @media (hover: hover) {
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled):not([aria-disabled='true']) {
       @apply bg-control-neutral-hover-muted;
     }
   }
 
-  &:active:not(:disabled) {
+  &:active:not(:disabled):not([aria-disabled='true']) {
     @apply bg-control-neutral-active;
   }
 


### PR DESCRIPTION
Design review items 9 and 11, plus the 2.0 rebuild of the two panel components.

## SegmentedControl and buttons

- SegmentedControl: the track takes a `border-tertiary` rim; padding drops from 4px to 3px so the 1px border leaves it at the standard 40px height.
- Buttons: the disabled state now clears the blue-tinted resting shadow, and hover/active are gated on `:not(:disabled):not([aria-disabled='true'])` instead of relying on source order, so a disabled control no longer reacts to the pointer.
- The disabled styling covers `<a aria-disabled>` (a link button never matches `:disabled`) and the ghost variants, which were missing it.

## CollapsibleSidebar 2.0 and ResizableContainer 2.0

New components under `src/components/New/`. The 1.0 `Dial*` versions are untouched, and the MCP manifest links them as superseded.

- `CollapsibleSidebar` is an `<aside>` named by `ariaLabel`, and its toggle carries a real accessible name (`Collapse sidebar` / `Expand sidebar`, both overridable), `aria-expanded` and `aria-controls`. 1.0 shipped `aria-label="collapsible-sidebar"` on a bare `div` and `"sidebar-state"` on the button.
- Width is derived from the open state instead of being copied into state, so changing `width` on an open sidebar now takes effect. Content stays mounted behind the `hidden` attribute, so scroll position and form state survive a collapse while the content still leaves the accessibility tree.
- New props: `defaultOpened`, `collapsedWidth`, `footerClassName`, `collapseLabel` / `expandLabel`. `iconSize` / `iconStroke` are gone in favour of `DIAL_ICON_SIZE`, and `containerClassName` is now `className`.
- `ResizableContainer` exposes its handle as a focusable `separator` with `aria-valuenow/min/max`, so the panel resizes with the arrow keys as well as the pointer — `Home` / `End` jump to the bounds, step size via `keyboardStep`. 1.0 had no keyboard path at all.
- `defaultWidth` is optional now (falls back to `minWidth`), `className` and `ariaLabel` are new, and the forced `divide-y` between children is gone — pass it through `className` if you want it.
- `ConditionalResizableContainer` is ported too, so the family stays complete.
- Colours come from the 2.0 keeper sets only: `bg-layer-raised`, `bg-control-accent`, `text-accent`, `outline-focus`, `border-tertiary`, `text-primary`. No `*ColorsToRemove` token is referenced.
- The resize handle joins the README target-size exception table: it has to sit exactly on the panel boundary, so a 44px pointer strip would swallow content on both sides. The keyboard path is the compensating affordance.

## Verification

- `npm run lint` clean; `npm run test` green — 173 files / 2352 tests, 28 of them new.
- `npm run typecheck` reports no errors in the changed files (the 56 pre-existing errors in `use-trigger-view-create-folder.spec.tsx` are untouched by this PR).
- `npm run build:css` compiles every new utility; `npm run build:manifest` files both components as generation 2.0 and links `DialCollapsibleSidebar` → `CollapsibleSidebar`, `DialResizableContainer` → `ResizableContainer`.

Issues: none — design review follow-up plus 2.0 component work, no ticket.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no ticket for this one

**New Component Checklist:**

- [ ] component name starts with Dial — intentionally not: 2.0 components drop the prefix (`Accordion`, `Button`, `Tag`, …)
- [x] custom css classes has dial- prefix — no new classes; the toggle reuses `dial-kit-primary-ghost-button`
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports — `@/` for shared modules, relative for sibling 2.0 components, as in `IconButton` / `Tooltip`
- [x] stories are added
- [x] tests are added
