### PR TITLE
feat(2.0): add Grid, DateCellRenderer and NoDataContent

### DIFF
--- a/src/components/Grid/comparators/base-column-comparator.ts
+++ b/src/components/Grid/comparators/base-column-comparator.ts
@@ -1,53 +1,8 @@
-import type { ColDef, IRowNode } from 'ag-grid-community';
-
-const collator = new Intl.Collator(undefined, {
-  sensitivity: 'base',
-  numeric: true,
-});
-
-export const baseColumnComparator = (
-  a: string | number | undefined,
-  b: string | number | undefined,
-  _nodeA?: IRowNode,
-  _nodeB?: IRowNode,
-  isInverted?: boolean,
-): number => {
-  if (typeof a === 'string' && typeof b === 'string' && a && b) {
-    const result = collator.compare(a, b);
-
-    return result === 0 ? 0 : result > 0 ? 1 : -1;
-  }
-
-  if (a === b) {
-    return 0;
-  }
-
-  if (!a) {
-    return !isInverted ? 1 : -1;
-  }
-
-  if (!b) {
-    return !isInverted ? -1 : 1;
-  }
-
-  return a > b ? 1 : -1;
-};
-
-export const omitUndefined = <T extends object>(value: T | undefined): T => {
-  if (!value) {
-    return {} as T;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).filter(([, v]) => v !== undefined),
-  ) as T;
-};
-
-export const checkColDefsChanges = (cols: ColDef[], initialCols: ColDef[]) => {
-  return cols.some((col, index) => {
-    if (col.field !== initialCols[index].field) {
-      return true;
-    }
-    return col.hide !== initialCols[index].hide;
-  });
-};
+// The comparators moved to `@/utils/grid-comparators` so the 2.0 Grid can use
+// them without importing out of the 1.0 component folder. Re-exported here so
+// existing 1.0 imports keep working.
+export {
+  baseColumnComparator,
+  checkColDefsChanges,
+  omitUndefined,
+} from '@/utils/grid-comparators';

--- a/src/components/Grid/renderers/utils.ts
+++ b/src/components/Grid/renderers/utils.ts
@@ -1,29 +1,4 @@
-import type { DateValue } from './DateCellRenderer';
-
-export function convertToDate(input?: DateValue | null): Date | null {
-  if (!input) return null;
-
-  if (input instanceof Date) {
-    return isFinite(input.getTime()) ? input : null;
-  }
-
-  if (typeof input === 'number') {
-    const date = new Date(input);
-    return isFinite(date.getTime()) ? date : null;
-  }
-
-  if (typeof input === 'string') {
-    const trimmed = input.trim();
-
-    // Treat pure integer strings as epoch milliseconds (supports negatives).
-    if (/^-?\d+$/.test(trimmed)) {
-      const asNum = Number(trimmed);
-      return convertToDate(asNum);
-    }
-
-    const d = new Date(trimmed);
-    return isFinite(d.getTime()) ? d : null;
-  }
-
-  return null;
-}
+// `convertToDate` moved to `@/utils/grid-date` so the 2.0 date cell can use it
+// without importing out of the 1.0 component folder. Re-exported here so
+// existing 1.0 imports keep working.
+export { convertToDate } from '@/utils/grid-date';

--- a/src/components/New/Grid/Grid.spec.tsx
+++ b/src/components/New/Grid/Grid.spec.tsx
@@ -1,0 +1,374 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ColDef, type GridApi } from 'ag-grid-community';
+import { describe, expect, test, vi } from 'vitest';
+
+import { GridSelectionMode } from '@/models/selection-mode';
+import { Grid } from './Grid';
+
+interface TestRow {
+  id: string;
+  name: string;
+  age: number;
+}
+
+const testRows: TestRow[] = [
+  { id: '1', name: 'Alice', age: 30 },
+  { id: '2', name: 'Bob', age: 25 },
+  { id: '3', name: 'Charlie', age: 35 },
+];
+
+const testColumns: ColDef<TestRow>[] = [
+  { field: 'name', headerName: 'Name', width: 150 },
+  { field: 'age', headerName: 'Age', width: 100 },
+];
+
+const mixedCaseRows: TestRow[] = [
+  { id: '1', name: 'appdata', age: 1 },
+  { id: '2', name: 'Banana', age: 2 },
+  { id: '3', name: 'code app', age: 3 },
+  { id: '4', name: 'Zebra', age: 4 },
+];
+
+const getSortedNames = (api: GridApi<TestRow>): string[] => {
+  const names: string[] = [];
+  api.forEachNodeAfterFilterAndSort((node) => {
+    if (node.data) {
+      names.push(node.data.name);
+    }
+  });
+  return names;
+};
+
+describe('Dial UI Kit :: Grid', () => {
+  test('renders the rows', async () => {
+    render(<Grid<TestRow> columnDefs={testColumns} rowData={testRows} />);
+
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  test('names the grid region', async () => {
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={testRows}
+        ariaLabel="Products"
+      />,
+    );
+
+    await screen.findByText('Alice');
+
+    expect(
+      screen.getByRole('region', { name: 'Products' }),
+    ).toBeInTheDocument();
+  });
+
+  test('applies a custom class to the grid container', async () => {
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={testRows}
+        className="my-custom-grid-class"
+      />,
+    );
+
+    await screen.findByText('Alice');
+
+    expect(screen.getByRole('region')).toHaveClass('my-custom-grid-class');
+  });
+
+  test('sorts names case-insensitively', async () => {
+    let api: GridApi<TestRow> | undefined;
+
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={mixedCaseRows}
+        onGridApiChange={(gridApi) => {
+          api = gridApi;
+        }}
+      />,
+    );
+
+    await screen.findByText('appdata');
+
+    api!.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+
+    expect(getSortedNames(api!)).toEqual([
+      'appdata',
+      'Banana',
+      'code app',
+      'Zebra',
+    ]);
+  });
+
+  test('keeps case-insensitive sorting when a defaultColDef is supplied', async () => {
+    let api: GridApi<TestRow> | undefined;
+
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={mixedCaseRows}
+        additionalGridOptions={{ defaultColDef: { floatingFilter: false } }}
+        onGridApiChange={(gridApi) => {
+          api = gridApi;
+        }}
+      />,
+    );
+
+    await screen.findByText('appdata');
+
+    api!.applyColumnState({ state: [{ colId: 'name', sort: 'asc' }] });
+
+    expect(getSortedNames(api!)).toEqual([
+      'appdata',
+      'Banana',
+      'code app',
+      'Zebra',
+    ]);
+  });
+
+  test('honours a sort declared on a column, which 1.0 stripped', async () => {
+    let api: GridApi<TestRow> | undefined;
+
+    render(
+      <Grid<TestRow>
+        columnDefs={[{ ...testColumns[0], sort: 'desc' }, testColumns[1]]}
+        rowData={mixedCaseRows}
+        onGridApiChange={(gridApi) => {
+          api = gridApi;
+        }}
+      />,
+    );
+
+    await screen.findByText('appdata');
+
+    expect(getSortedNames(api!)).toEqual([
+      'Zebra',
+      'code app',
+      'Banana',
+      'appdata',
+    ]);
+  });
+
+  test('calls onGridReady from additionalGridOptions', async () => {
+    const onGridReady = vi.fn();
+
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={testRows}
+        additionalGridOptions={{ onGridReady }}
+      />,
+    );
+
+    await screen.findByText('Alice');
+
+    expect(onGridReady).toHaveBeenCalledTimes(1);
+    expect(onGridReady.mock.calls[0][0]).toBeDefined();
+  });
+
+  test('announces the empty state when there are no rows', async () => {
+    render(
+      <Grid<TestRow>
+        columnDefs={testColumns}
+        rowData={[]}
+        emptyStateTitle="No results found"
+        emptyStateDescription="Try another search."
+      />,
+    );
+
+    const emptyState = await screen.findByRole('status');
+
+    expect(emptyState).toHaveTextContent('No results found');
+    expect(emptyState).toHaveTextContent('Try another search.');
+  });
+
+  describe('selection', () => {
+    test('renders no selection control without a selectionMode', async () => {
+      render(<Grid<TestRow> columnDefs={testColumns} rowData={testRows} />);
+
+      await screen.findByText('Alice');
+
+      expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+      expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    });
+
+    test('renders one 2.0 checkbox per row plus the select-all, and no ag-Grid input', async () => {
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+        />,
+      );
+
+      await screen.findByText('Alice');
+
+      await waitFor(() =>
+        expect(screen.getAllByRole('checkbox')).toHaveLength(
+          testRows.length + 1,
+        ),
+      );
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all rows' }),
+      ).toBeInTheDocument();
+      // ag-Grid's own inputs are switched off, so nothing renders them.
+      expect(document.querySelector('.ag-checkbox-input')).toBeNull();
+    });
+
+    test('names each row control through selectRowLabel', async () => {
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+        />,
+      );
+
+      expect(
+        await screen.findByRole('checkbox', { name: 'Select Alice' }),
+      ).toBeInTheDocument();
+    });
+
+    test('reports the row selected by its checkbox', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+
+      await user.click(
+        await screen.findByRole('checkbox', { name: 'Select Bob' }),
+      );
+
+      await waitFor(() =>
+        expect(onSelectionChange).toHaveBeenCalledWith(new Set(['2']), [
+          testRows[1],
+        ]),
+      );
+      expect(
+        screen.getByRole('checkbox', { name: 'Select Bob' }),
+      ).toBeChecked();
+    });
+
+    test('select-all takes every row, and goes mixed when one is dropped', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+        />,
+      );
+
+      const selectAll = await screen.findByRole('checkbox', {
+        name: 'Select all rows',
+      });
+
+      await user.click(selectAll);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('checkbox', { name: 'Select Alice' }),
+        ).toBeChecked(),
+      );
+      expect(selectAll).toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'Select Alice' }));
+
+      await waitFor(() =>
+        expect(selectAll).toHaveAttribute('aria-checked', 'mixed'),
+      );
+    });
+
+    test('disables the control of a disabled row and leaves it out of select-all', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+          disabledRowIds={new Set(['3'])}
+        />,
+      );
+
+      const disabled = await screen.findByRole('checkbox', {
+        name: 'Select Charlie',
+      });
+      expect(disabled).toBeDisabled();
+
+      const selectAll = screen.getByRole('checkbox', {
+        name: 'Select all rows',
+      });
+      await user.click(selectAll);
+
+      await waitFor(() => expect(selectAll).toBeChecked());
+      expect(disabled).not.toBeChecked();
+    });
+
+    test('single mode renders radios and keeps one selected at a time', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.SINGLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+
+      const alice = await screen.findByRole('radio', { name: 'Select Alice' });
+      await user.click(alice);
+      await waitFor(() => expect(alice).toBeChecked());
+
+      const bob = screen.getByRole('radio', { name: 'Select Bob' });
+      await user.click(bob);
+
+      await waitFor(() => expect(bob).toBeChecked());
+      expect(alice).not.toBeChecked();
+      // Single mode never has a select-all control.
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('controlled: reflects selectedRowIds', async () => {
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          selectionMode={GridSelectionMode.MULTIPLE}
+          selectRowLabel={(row) => `Select ${row.name}`}
+          selectedRowIds={new Set(['1', '2'])}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('checkbox', { name: 'Select Alice' }),
+        ).toBeChecked(),
+      );
+      expect(
+        screen.getByRole('checkbox', { name: 'Select Bob' }),
+      ).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'Select Charlie' }),
+      ).not.toBeChecked();
+    });
+  });
+});

--- a/src/components/New/Grid/Grid.spec.tsx
+++ b/src/components/New/Grid/Grid.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { GridSelectionMode } from '@/models/selection-mode';
 import { Grid } from './Grid';
+import { DateCellRenderer } from './renderers/DateCellRenderer';
 
 interface TestRow {
   id: string;
@@ -183,6 +184,52 @@ describe('Dial UI Kit :: Grid', () => {
 
     expect(emptyState).toHaveTextContent('No results found');
     expect(emptyState).toHaveTextContent('Try another search.');
+  });
+
+  describe('cell alignment', () => {
+    const dateColumns: ColDef<TestRow>[] = [
+      testColumns[0],
+      {
+        field: 'age',
+        headerName: 'Updated',
+        cellRenderer: DateCellRenderer,
+        valueGetter: () => '2026-07-20T00:00:00Z',
+        cellRendererParams: {
+          options: { dateStyle: 'medium', timeZone: 'UTC' },
+        },
+      },
+    ];
+
+    test('gives a default cell and a custom renderer the same text box', async () => {
+      render(<Grid<TestRow> columnDefs={dateColumns} rowData={testRows} />);
+
+      const plainCell = await screen.findByText('Alice');
+      const customCell = screen.getAllByText('Jul 20, 2026')[0].closest('span');
+
+      // jsdom performs no layout, so the assertion is on what decides the
+      // alignment: a text box stretched to the row height puts its line at the
+      // top, while one of its natural height is centred by the cell.
+      expect(plainCell).not.toHaveClass('h-full');
+      expect(customCell).not.toHaveClass('h-full');
+      expect(plainCell).toHaveClass('dial-small-text');
+      expect(customCell).toHaveClass('dial-small-text');
+    });
+
+    test('centres the content of a cell wrapped in a context menu', async () => {
+      render(
+        <Grid<TestRow>
+          columnDefs={testColumns}
+          rowData={testRows}
+          getContextMenuItems={() => [{ key: 'edit', label: 'Edit' }]}
+        />,
+      );
+
+      const trigger = (await screen.findByText('Alice')).closest(
+        '[aria-haspopup="menu"]',
+      );
+
+      expect(trigger).toHaveClass('items-center');
+    });
   });
 
   describe('selection', () => {

--- a/src/components/New/Grid/Grid.stories.tsx
+++ b/src/components/New/Grid/Grid.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ColDef } from 'ag-grid-community';
+import { IconInbox } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+
+import { GridSelectionMode } from '@/models/selection-mode';
+import { Grid, type GridProps } from './Grid';
+import { DateCellRenderer } from './renderers/DateCellRenderer';
+
+interface Product extends Record<string, unknown> {
+  id: string;
+  name: string;
+  owner: string;
+  price: number;
+  updatedAt: string;
+}
+
+const products: Product[] = [
+  {
+    id: '1',
+    name: 'Analytics workspace',
+    owner: 'Ada Lovelace',
+    price: 1200,
+    updatedAt: '2026-07-20T09:30:00Z',
+  },
+  {
+    id: '2',
+    name: 'Billing add-on',
+    owner: 'Grace Hopper',
+    price: 340,
+    updatedAt: '2026-07-18T14:05:00Z',
+  },
+  {
+    id: '3',
+    name: 'Content pipeline',
+    owner: 'Alan Turing',
+    price: 780,
+    updatedAt: '2026-06-30T08:00:00Z',
+  },
+  {
+    id: '4',
+    name: 'Data catalogue',
+    owner: 'Katherine Johnson',
+    price: 2100,
+    updatedAt: '2026-05-11T17:45:00Z',
+  },
+];
+
+const columns: ColDef<Product>[] = [
+  { field: 'name', headerName: 'Name', flex: 2 },
+  { field: 'owner', headerName: 'Owner', flex: 1 },
+  { field: 'price', headerName: 'Price', width: 120 },
+  {
+    field: 'updatedAt',
+    headerName: 'Updated',
+    width: 200,
+    cellRenderer: DateCellRenderer,
+    cellRendererParams: { options: { dateStyle: 'medium', timeZone: 'UTC' } },
+  },
+];
+
+const Layout = (args: GridProps<Product>) => (
+  <div className="h-[420px] bg-layer-base p-4">
+    <Grid<Product> {...args} />
+  </div>
+);
+
+const meta = {
+  title: 'Components_2_0/Grid',
+  component: Grid as FC<GridProps<Product>>,
+  tags: ['grid', 'table', 'data'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A data grid built on ag-Grid, wired to the 2.0 tokens and controls. The selection column renders the 2.0 Checkbox and Radio instead of ag-Grid inputs, and stays faded out until the row is hovered, something is selected, or the keyboard reaches it.',
+      },
+    },
+  },
+  argTypes: {
+    columnDefs: { control: false, description: 'ag-Grid column definitions' },
+    rowData: { control: false, description: 'Rows to display' },
+    selectionMode: {
+      control: { type: 'select' },
+      options: [undefined, ...Object.values(GridSelectionMode)],
+      description: 'Renders a selection column of checkboxes or radios',
+    },
+    loading: { control: { type: 'boolean' } },
+    alternateOddRowColors: { control: { type: 'boolean' } },
+    wrapperBorder: { control: { type: 'boolean' } },
+    withoutHeaderBorders: { control: { type: 'boolean' } },
+    getContextMenuItems: { control: false },
+    onSelectionChange: { control: false },
+    onGridApiChange: { control: false },
+    getRowId: { control: false },
+    selectRowLabel: { control: false },
+  },
+  args: {
+    columnDefs: columns,
+    rowData: products,
+  },
+  render: Layout,
+} satisfies Meta<GridProps<Product>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const MultipleSelection: Story = {
+  args: {
+    selectionMode: GridSelectionMode.MULTIPLE,
+    selectRowLabel: (row) => `Select ${row.name}`,
+  },
+};
+
+export const SingleSelection: Story = {
+  args: {
+    selectionMode: GridSelectionMode.SINGLE,
+    selectRowLabel: (row) => `Select ${row.name}`,
+  },
+};
+
+export const DisabledRows: Story = {
+  args: {
+    selectionMode: GridSelectionMode.MULTIPLE,
+    selectRowLabel: (row) => `Select ${row.name}`,
+    disabledRowIds: new Set(['2', '4']),
+  },
+};
+
+export const WithContextMenu: Story = {
+  args: {
+    getContextMenuItems: (row) => [
+      { key: 'edit', label: `Edit ${row.name}` },
+      { key: 'duplicate', label: 'Duplicate' },
+      { key: 'delete', label: 'Delete', danger: true },
+    ],
+  },
+};
+
+export const AlternatingRows: Story = {
+  args: {
+    alternateOddRowColors: true,
+  },
+};
+
+export const WithoutHeaderBorders: Story = {
+  args: {
+    withoutHeaderBorders: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    rowData: [],
+    emptyStateTitle: 'No products yet',
+    emptyStateDescription: 'Create one to see it listed here.',
+    emptyStateIcon: <IconInbox size={100} stroke={0.5} aria-hidden="true" />,
+  },
+};
+
+const ControlledStory = (args: GridProps<Product>) => {
+  const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(
+    new Set(['1']),
+  );
+
+  return (
+    <div className="flex h-[420px] flex-col gap-2 bg-layer-base p-4">
+      <p className="dial-small-text text-secondary">
+        Selected:{' '}
+        {selectedRowIds.size ? [...selectedRowIds].join(', ') : 'none'}
+      </p>
+      <div className="min-h-0 flex-1">
+        <Grid<Product>
+          {...args}
+          selectedRowIds={selectedRowIds}
+          onSelectionChange={(ids) => setSelectedRowIds(ids)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const ControlledSelection: Story = {
+  args: {
+    selectionMode: GridSelectionMode.MULTIPLE,
+    selectRowLabel: (row) => `Select ${row.name}`,
+  },
+  render: ControlledStory,
+};

--- a/src/components/New/Grid/Grid.tsx
+++ b/src/components/New/Grid/Grid.tsx
@@ -1,0 +1,603 @@
+import {
+  AllCommunityModule,
+  type ColDef,
+  colorSchemeLight,
+  type GridApi,
+  type GridOptions,
+  type GridReadyEvent,
+  type GridSizeChangedEvent,
+  type ICellRendererParams,
+  ModuleRegistry,
+  type RowSelectionOptions,
+  type SelectionChangedEvent,
+  setupAgTestIds,
+  themeBalham,
+} from 'ag-grid-community';
+import { AgGridReact } from 'ag-grid-react';
+import { IconZoomCancel } from '@tabler/icons-react';
+import {
+  type FC,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useIsMobileScreen } from '@/hooks/use-is-mobile-screen';
+import { useIsTabletScreen } from '@/hooks/use-is-tablet-screen';
+import type { DropdownItem } from '@/models/dropdown';
+import { GridSelectionMode } from '@/models/selection-mode';
+import { DropdownTrigger } from '@/types/dropdown';
+import { debounceFn } from '@/utils/debounce';
+import { baseColumnComparator, omitUndefined } from '@/utils/grid-comparators';
+import { mergeClasses } from '@/utils/merge-classes';
+
+import { Dropdown } from '../Dropdown/Dropdown';
+import { EllipsisTooltip } from '../EllipsisTooltip/EllipsisTooltip';
+import { NoDataContent } from '../NoDataContent/NoDataContent';
+import { SelectionCell } from './components/SelectionCell';
+import { SelectionHeader } from './components/SelectionHeader';
+import {
+  GRID_HEADER_SELECT_CLASS,
+  GRID_ROOT_CLASS,
+  GRID_ROW_SELECT_CLASS,
+  GRID_SELECTION_VISIBLE_CLASS,
+  GRID_THEME_PARAMS,
+  GRID_WITH_SELECTION_CLASS,
+  GRID_WITHOUT_HEADER_BORDERS_CLASS,
+  ROW_HEIGHT,
+  SelectionEventSourceType,
+} from './constants';
+import { SELECTION_COL_DEF } from './renderers/constants';
+
+setupAgTestIds({ testIdAttribute: 'dataQA' });
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+/** Column id of the selection column this component prepends itself. */
+export const GRID_SELECTION_COLUMN_ID = 'dial-kit-grid-selection';
+
+/** Narrowest a data column may become while the grid distributes width. */
+const DEFAULT_MIN_COLUMN_WIDTH = 150;
+
+/** Selection changes are coalesced: ag-Grid fires one event per row. */
+const SELECTION_DEBOUNCE_MS = 100;
+
+export interface GridProps<T extends object = Record<string, unknown>> {
+  /** Column definitions, in ag-Grid `ColDef` format. */
+  columnDefs?: ColDef<T>[];
+  /** Rows to display. */
+  rowData?: T[];
+  /** Extra ag-Grid options, merged over the defaults. */
+  additionalGridOptions?: GridOptions<T>;
+  /** Items of the row context menu. Omit it to render no context menu at all. */
+  getContextMenuItems?: (row: T) => DropdownItem[];
+  /** Additional CSS classes for the grid container. */
+  className?: string;
+  /** Accessible name of the grid region. Defaults to `'Data grid'`. */
+  ariaLabel?: string;
+  /** Whether custom cell renderers are wrapped with context-menu support. */
+  wrapCustomCellRenderers?: boolean | ((col: ColDef<T>) => boolean);
+  /** Rows that cannot be selected. Ids must match what `getRowId` returns. */
+  disabledRowIds?: Set<string>;
+  /** Controlled selection: ids of the selected rows. */
+  selectedRowIds?: Set<string>;
+  /** Fired when the grid API becomes available. */
+  onGridApiChange?: (api: GridApi<T>) => void;
+  /** Fired when the selection changes, with the selected ids and rows. */
+  onSelectionChange?: (selectedRowIds: Set<string>, selectedRows: T[]) => void;
+  /** Extracts the unique id of a row. Defaults to its `id` field. */
+  getRowId?: (row: T) => string;
+  /** Tints odd rows. Defaults to `false`. */
+  alternateOddRowColors?: boolean;
+  /** Placeholder of the column filter inputs. */
+  filterPlaceholder?: string;
+  /** Illustration of the empty state. */
+  emptyStateIcon?: ReactNode;
+  /** Headline of the empty state. */
+  emptyStateTitle?: string;
+  /** Secondary line of the empty state. */
+  emptyStateDescription?: string;
+  /** Shows the loading overlay. Defaults to `false`. */
+  loading?: boolean;
+  /** Draws a border around the grid. Defaults to `true`. */
+  wrapperBorder?: boolean;
+  /** Hides the vertical borders between header cells. Defaults to `false`. */
+  withoutHeaderBorders?: boolean;
+  /** Renders a selection column of checkboxes or radios. */
+  selectionMode?: GridSelectionMode;
+  /** Keeps the context menu on a row that cannot be selected. */
+  allowDisabledContextMenu?: boolean;
+  /** Accessible name of a row's selection control. Defaults to `'Select row'`. */
+  selectRowLabel?: (row: T) => string;
+  /** Accessible name of the select-all control. Defaults to `'Select all rows'`. */
+  selectAllLabel?: string;
+}
+
+/**
+ * A data grid built on ag-Grid, wired to the 2.0 tokens and controls.
+ * aliases: DataTable|TableGrid|DataGrid
+ * Design system 2.0
+ *
+ * Comes preconfigured with case-insensitive sorting, floating column filters,
+ * columns sized to the available width, a row context menu, truncation
+ * tooltips, and an empty state.
+ *
+ * The selection column renders the 2.0 `Checkbox` and `Radio` instead of
+ * ag-Grid's own inputs, so selection looks and behaves like every other control
+ * in the kit and the select-all reaches the `mixed` state when the selection is
+ * partial. The column stays faded out until the row is hovered, something is
+ * selected, or the keyboard reaches it.
+ *
+ * Selection works controlled or uncontrolled: pass `selectedRowIds` to own it,
+ * or read `onSelectionChange` and let the grid keep its own. A `sort` declared
+ * on a column is honoured — 1.0 stripped it on startup.
+ *
+ * @example
+ * ```tsx
+ * interface Product { id: string; name: string; price: number }
+ *
+ * const columns: ColDef<Product>[] = [
+ *   { field: 'name', headerName: 'Product', flex: 1 },
+ *   { field: 'price', headerName: 'Price', width: 120 },
+ * ];
+ *
+ * <Grid<Product> columnDefs={columns} rowData={products} />
+ *
+ * // With selection and a context menu
+ * <Grid<Product>
+ *   columnDefs={columns}
+ *   rowData={products}
+ *   selectionMode={GridSelectionMode.MULTIPLE}
+ *   selectedRowIds={selectedIds}
+ *   onSelectionChange={(ids) => setSelectedIds(ids)}
+ *   selectRowLabel={(row) => `Select ${row.name}`}
+ *   getContextMenuItems={(row) => [{ key: 'edit', label: 'Edit' }]}
+ * />
+ * ```
+ *
+ * @param [columnDefs] - Column definitions, in ag-Grid `ColDef` format.
+ * @param [rowData] - Rows to display.
+ * @param [additionalGridOptions] - Extra ag-Grid options, merged over the defaults.
+ * @param [getContextMenuItems] - Items of the row context menu. Omit for no menu.
+ * @param [className] - Additional CSS classes for the grid container.
+ * @param [ariaLabel='Data grid'] - Accessible name of the grid region.
+ * @param [wrapCustomCellRenderers=true] - Whether custom renderers get context-menu support.
+ * @param [disabledRowIds] - Rows that cannot be selected.
+ * @param [selectedRowIds] - Controlled selection: ids of the selected rows.
+ * @param [onGridApiChange] - Fired when the grid API becomes available.
+ * @param [onSelectionChange] - Fired when the selection changes.
+ * @param [getRowId] - Extracts the unique id of a row. Defaults to its `id` field.
+ * @param [alternateOddRowColors=false] - Tints odd rows.
+ * @param [filterPlaceholder='Enter value'] - Placeholder of the column filter inputs.
+ * @param [emptyStateIcon] - Illustration of the empty state.
+ * @param [emptyStateTitle='No results found'] - Headline of the empty state.
+ * @param [emptyStateDescription] - Secondary line of the empty state.
+ * @param [loading=false] - Shows the loading overlay.
+ * @param [wrapperBorder=true] - Draws a border around the grid.
+ * @param [withoutHeaderBorders=false] - Hides the vertical borders between header cells.
+ * @param [selectionMode] - Renders a selection column of checkboxes or radios.
+ * @param [allowDisabledContextMenu=false] - Keeps the context menu on a non-selectable row.
+ * @param [selectRowLabel] - Accessible name of a row's selection control.
+ * @param [selectAllLabel='Select all rows'] - Accessible name of the select-all control.
+ */
+export const Grid = <T extends object>({
+  columnDefs,
+  rowData,
+  additionalGridOptions,
+  getContextMenuItems,
+  className,
+  ariaLabel = 'Data grid',
+  wrapCustomCellRenderers = true,
+  disabledRowIds,
+  selectedRowIds,
+  onSelectionChange,
+  onGridApiChange,
+  getRowId,
+  alternateOddRowColors = false,
+  filterPlaceholder = 'Enter value',
+  emptyStateIcon,
+  emptyStateTitle = 'No results found',
+  emptyStateDescription = "Sorry, we couldn't find any results for your search.",
+  loading = false,
+  wrapperBorder = true,
+  withoutHeaderBorders = false,
+  allowDisabledContextMenu = false,
+  selectionMode,
+  selectRowLabel,
+  selectAllLabel = 'Select all rows',
+}: GridProps<T>) => {
+  const [gridApi, setGridApi] = useState<GridApi<T> | undefined>();
+  const isMobileScreen = useIsMobileScreen();
+  const isTabletScreen = useIsTabletScreen();
+  const selectedNodesRef = useRef<Set<string>>(new Set());
+  const lastSelectionSourceRef = useRef<SelectionEventSourceType | undefined>(
+    undefined,
+  );
+  // One radio group per grid instance: two single-select grids on a page would
+  // otherwise share a group and steal each other's selection.
+  const radioGroupName = `dial-kit-grid-selection-${useId()}`;
+
+  /**
+   * The callback props are read through a box rather than closed over, so the
+   * column definitions keep their identity across renders. ag-Grid rebuilds
+   * every cell when a definition changes, and a rebuild mid-interaction
+   * detaches the very input the user is clicking — which is what made the 1.0
+   * grid drop clicks whenever an inline `getRowId` was passed.
+   */
+  const callbacksRef = useRef({
+    getRowId,
+    getContextMenuItems,
+    onSelectionChange,
+    selectRowLabel,
+    wrapCustomCellRenderers,
+  });
+  callbacksRef.current = {
+    getRowId,
+    getContextMenuItems,
+    onSelectionChange,
+    selectRowLabel,
+    wrapCustomCellRenderers,
+  };
+
+  const resolveRowId = useCallback((row: T) => {
+    const custom = callbacksRef.current.getRowId;
+
+    if (custom) return custom(row);
+
+    return String((row as Record<string, unknown>).id ?? JSON.stringify(row));
+  }, []);
+
+  const hasContextMenu = !!getContextMenuItems;
+  const wrapsRenderers = !!wrapCustomCellRenderers;
+
+  const theme = useMemo(
+    () =>
+      themeBalham.withPart(colorSchemeLight).withParams({
+        ...GRID_THEME_PARAMS,
+        oddRowBackgroundColor: alternateOddRowColors
+          ? GRID_THEME_PARAMS.oddRowBackgroundColor
+          : GRID_THEME_PARAMS.backgroundColor,
+        wrapperBorder,
+      }),
+    [alternateOddRowColors, wrapperBorder],
+  );
+
+  const onGridSizeChanged = useCallback((e: GridSizeChangedEvent) => {
+    e.api.sizeColumnsToFit();
+  }, []);
+
+  /**
+   * There is no hover state to reveal the selection column on a touch screen,
+   * and hiding it once rows are selected would take the user's own selection
+   * off screen — so it stays pinned in both cases.
+   */
+  const isSelectionPinnedVisible =
+    isMobileScreen || isTabletScreen || (selectedRowIds?.size ?? 0) > 0;
+
+  const isRowDisabled = useCallback(
+    (row: T | undefined | null) =>
+      !!row && !!disabledRowIds?.has(resolveRowId(row)),
+    [disabledRowIds, resolveRowId],
+  );
+
+  const withContextMenu = useCallback(
+    (
+      p: ICellRendererParams<T, unknown>,
+      content: ReactNode,
+      disabled: boolean,
+    ) => {
+      if (!hasContextMenu) {
+        return content;
+      }
+
+      return (
+        <Dropdown
+          trigger={[DropdownTrigger.ContextMenu]}
+          items={
+            p.data
+              ? (callbacksRef.current.getContextMenuItems?.(p.data) ?? [])
+              : []
+          }
+          anchorToMouse
+          matchReferenceWidth
+          className={mergeClasses(
+            'size-full',
+            disabled && 'cursor-not-allowed opacity-75',
+          )}
+          disabled={disabled && !allowDisabledContextMenu}
+        >
+          <span className="block min-w-0 max-w-full flex-1">{content}</span>
+        </Dropdown>
+      );
+    },
+    [hasContextMenu, allowDisabledContextMenu],
+  );
+
+  const renderDataCell = useCallback(
+    (p: ICellRendererParams<T, unknown>) => {
+      if (!p.data) return null;
+
+      const disabled = isRowDisabled(p.data);
+
+      return withContextMenu(
+        p,
+        <EllipsisTooltip
+          text={p.value == null ? '' : String(p.value)}
+          className="h-full max-w-full"
+          hideTooltip={disabled}
+        />,
+        disabled,
+      );
+    },
+    [isRowDisabled, withContextMenu],
+  );
+
+  const isUserSelectionEvent = useCallback(
+    (source?: SelectionEventSourceType) =>
+      source === SelectionEventSourceType.API ||
+      source === SelectionEventSourceType.ROW_DATA_CHANGED,
+    [],
+  );
+
+  /**
+   * Stable on purpose: ag-Grid keeps the handler it was given at start-up, so a
+   * handler rebuilt on every render would leave it holding a stale closure —
+   * in 1.0 that closure captured `gridApi` before it existed and returned early
+   * forever, which swallowed every selection change.
+   */
+  const onSelectionChanged = useMemo(
+    () =>
+      debounceFn((event: SelectionChangedEvent) => {
+        const selectedNodes = event.selectedNodes ?? [];
+        const selectedRows = selectedNodes.map((node) => node.data as T);
+        const selectedIds = new Set(selectedRows.map(resolveRowId));
+
+        selectedNodesRef.current = selectedIds;
+        lastSelectionSourceRef.current =
+          event.source as SelectionEventSourceType;
+
+        if (isUserSelectionEvent(event.source as SelectionEventSourceType)) {
+          return;
+        }
+
+        callbacksRef.current.onSelectionChange?.(selectedIds, selectedRows);
+      }, SELECTION_DEBOUNCE_MS),
+    [isUserSelectionEvent, resolveRowId],
+  );
+
+  const selectionColumn = useMemo<ColDef<T> | undefined>(() => {
+    if (!selectionMode) return undefined;
+
+    return {
+      ...SELECTION_COL_DEF,
+      colId: GRID_SELECTION_COLUMN_ID,
+      headerName: '',
+      headerClass: GRID_HEADER_SELECT_CLASS,
+      cellClass: GRID_ROW_SELECT_CLASS,
+      headerComponent:
+        selectionMode === GridSelectionMode.MULTIPLE
+          ? SelectionHeader
+          : undefined,
+      headerComponentParams: { label: selectAllLabel },
+      cellRenderer: (p: ICellRendererParams<T, unknown>) => {
+        if (!p.data) return null;
+
+        const rowId = resolveRowId(p.data);
+
+        return (
+          <SelectionCell
+            params={p}
+            mode={selectionMode}
+            rowId={rowId}
+            radioName={radioGroupName}
+            label={
+              callbacksRef.current.selectRowLabel?.(p.data) ?? 'Select row'
+            }
+            disabled={disabledRowIds?.has(rowId)}
+          />
+        );
+      },
+    } as ColDef<T>;
+  }, [
+    selectionMode,
+    selectAllLabel,
+    resolveRowId,
+    disabledRowIds,
+    radioGroupName,
+  ]);
+
+  const wrapRendererIfNeeded = useCallback(
+    (col: ColDef<T>): ColDef<T> => {
+      if (!col.cellRenderer) {
+        return { ...col, cellRenderer: renderDataCell };
+      }
+
+      const wrapSetting = callbacksRef.current.wrapCustomCellRenderers;
+      const shouldWrap =
+        typeof wrapSetting === 'function' ? wrapSetting(col) : !!wrapSetting;
+
+      if (!shouldWrap) {
+        return col;
+      }
+
+      const userRenderer = col.cellRenderer;
+
+      const Wrapped: FC<ICellRendererParams<T, unknown>> = (p) => {
+        const disabled = isRowDisabled(p.data);
+        const Renderer =
+          typeof userRenderer === 'function' ? userRenderer : undefined;
+        const content = Renderer ? <Renderer {...p} /> : renderDataCell(p);
+
+        return withContextMenu(p, content, disabled);
+      };
+
+      return { ...col, cellRenderer: Wrapped };
+    },
+    [isRowDisabled, renderDataCell, withContextMenu],
+  );
+
+  const computedColumnDefs = useMemo<ColDef<T>[]>(() => {
+    const columns = wrapsRenderers
+      ? (columnDefs ?? []).map(wrapRendererIfNeeded)
+      : (columnDefs ?? []);
+
+    return selectionColumn ? [selectionColumn, ...columns] : columns;
+  }, [columnDefs, wrapsRenderers, wrapRendererIfNeeded, selectionColumn]);
+
+  const { defaultColDef: consumerDefaultColDef, ...restAdditionalGridOptions } =
+    additionalGridOptions ?? {};
+
+  const defaultColDef: ColDef<T> = useMemo(
+    () => ({
+      minWidth: DEFAULT_MIN_COLUMN_WIDTH,
+      resizable: true,
+      sortable: true,
+      floatingFilter: true,
+      filter: 'agTextColumnFilter',
+      filterParams: {
+        filterPlaceholder,
+        buttons: ['reset'],
+      },
+      comparator: baseColumnComparator,
+      ...omitUndefined(consumerDefaultColDef),
+    }),
+    [filterPlaceholder, consumerDefaultColDef],
+  );
+
+  const onGridReady = (e: GridReadyEvent) => {
+    e.api.sizeColumnsToFit();
+
+    setGridApi(e.api as GridApi<T>);
+    additionalGridOptions?.onGridReady?.(e);
+    onGridApiChange?.(e.api as GridApi<T>);
+  };
+
+  useEffect(() => {
+    if (gridApi && rowData) {
+      gridApi.setGridOption('rowData', rowData);
+    }
+  }, [gridApi, rowData]);
+
+  const emptyStateRenderer = useCallback(
+    () => (
+      <NoDataContent
+        live
+        title={emptyStateTitle}
+        description={emptyStateDescription}
+        icon={
+          emptyStateIcon ?? (
+            <IconZoomCancel size={100} stroke={0.5} aria-hidden="true" />
+          )
+        }
+      />
+    ),
+    [emptyStateTitle, emptyStateDescription, emptyStateIcon],
+  );
+
+  const rowSelection = useMemo<RowSelectionOptions | undefined>(() => {
+    if (!selectionMode) return undefined;
+
+    return {
+      mode:
+        selectionMode === GridSelectionMode.SINGLE ? 'singleRow' : 'multiRow',
+      // The controls live in this component's own selection column, so
+      // ag-Grid's inputs are switched off and only its behaviour is used.
+      checkboxes: false,
+      headerCheckbox: false,
+      isRowSelectable: (node) => !isRowDisabled(node.data as T | undefined),
+    };
+  }, [isRowDisabled, selectionMode]);
+
+  useEffect(() => {
+    if (gridApi && rowData && selectedNodesRef.current.size) {
+      selectedNodesRef.current.forEach((id) => {
+        const node = gridApi.getRowNode(id);
+        if (node && !node.isSelected()) {
+          node.setSelected(true, false, SelectionEventSourceType.API);
+        }
+      });
+    }
+  }, [gridApi, rowData]);
+
+  useEffect(() => {
+    if (gridApi && selectedRowIds) {
+      gridApi.deselectAll('all', SelectionEventSourceType.API);
+      selectedRowIds.forEach((id) => {
+        const node = gridApi.getRowNode(id);
+        if (node && !node.isSelected()) {
+          node.setSelected(true, false, SelectionEventSourceType.API);
+        }
+      });
+    }
+  }, [gridApi, selectedRowIds]);
+
+  const agGridGetRowId = useCallback(
+    (params: { data?: T }) => (params.data ? resolveRowId(params.data) : ''),
+    [resolveRowId],
+  );
+
+  useEffect(() => {
+    const isCustomSelection = isUserSelectionEvent(
+      lastSelectionSourceRef.current,
+    );
+
+    if (gridApi && selectedRowIds?.size && isCustomSelection) {
+      const firstSelectedId = Array.from(selectedRowIds)[0];
+
+      if (firstSelectedId) {
+        const node = gridApi.getRowNode(firstSelectedId);
+
+        if (node) {
+          gridApi.ensureNodeVisible(node);
+        }
+      }
+    }
+  }, [gridApi, isUserSelectionEvent, selectedRowIds]);
+
+  return (
+    <div
+      className={mergeClasses(
+        GRID_ROOT_CLASS,
+        'size-full',
+        selectionMode && GRID_WITH_SELECTION_CLASS,
+        selectionMode &&
+          isSelectionPinnedVisible &&
+          GRID_SELECTION_VISIBLE_CLASS,
+        withoutHeaderBorders && GRID_WITHOUT_HEADER_BORDERS_CLASS,
+        className,
+      )}
+      role="region"
+      aria-label={ariaLabel}
+      aria-busy={loading}
+    >
+      {/* ag-Grid renders its own `role="grid"` inside, so this wrapper stays a
+          plain scroll container rather than claiming a table role of its own. */}
+      <div className="h-full overflow-x-auto">
+        <AgGridReact<T>
+          rowModelType="clientSide"
+          headerHeight={ROW_HEIGHT}
+          rowHeight={ROW_HEIGHT}
+          cellSelection={false}
+          theme={theme}
+          autoSizeStrategy={{ type: 'fitGridWidth' }}
+          columnDefs={computedColumnDefs}
+          defaultColDef={defaultColDef}
+          onGridSizeChanged={onGridSizeChanged}
+          onGridReady={onGridReady}
+          loading={loading}
+          suppressCellFocus
+          suppressDragLeaveHidesColumns
+          noRowsOverlayComponent={emptyStateRenderer}
+          rowData={rowData}
+          rowSelection={rowSelection}
+          onSelectionChanged={onSelectionChanged}
+          getRowId={agGridGetRowId}
+          {...restAdditionalGridOptions}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/New/Grid/Grid.tsx
+++ b/src/components/New/Grid/Grid.tsx
@@ -326,7 +326,10 @@ export const Grid = <T extends object>({
         p,
         <EllipsisTooltip
           text={p.value == null ? '' : String(p.value)}
-          className="h-full max-w-full"
+          // No `h-full`: a full-height text box puts its line at the top of the
+          // row, while a cell renderer of its own natural height is centred by
+          // `.ag-cell`. Mixing the two left the columns visibly out of line.
+          className="max-w-full dial-small-text text-primary"
           hideTooltip={disabled}
         />,
         disabled,

--- a/src/components/New/Grid/components/SelectionCell.tsx
+++ b/src/components/New/Grid/components/SelectionCell.tsx
@@ -1,0 +1,80 @@
+import type { ICellRendererParams, IRowNode } from 'ag-grid-community';
+import { useEffect, useState } from 'react';
+
+import { GridSelectionMode } from '@/models/selection-mode';
+import { Checkbox } from '../../Checkbox/Checkbox';
+import { Radio } from '../../Radio/Radio';
+import { SelectionEventSourceType } from '../constants';
+
+export interface SelectionCellProps<T> {
+  params: ICellRendererParams<T>;
+  mode: GridSelectionMode;
+  /** Accessible name of the control; a row-specific name is far more useful. */
+  label: string;
+  /** Shared radio group name, so single mode behaves as one group. */
+  radioName: string;
+  rowId: string;
+  disabled?: boolean;
+}
+
+/**
+ * The 2.0 {@link Checkbox} or {@link Radio} rendered in the selection column,
+ * in place of ag-Grid's own checkbox.
+ *
+ * The row node is the source of truth: the control subscribes to its
+ * `rowSelected` event, so a selection made anywhere — another cell, the header,
+ * or the `selectedRowIds` prop — is reflected here without refreshing the cell.
+ */
+export const SelectionCell = <T,>({
+  params,
+  mode,
+  label,
+  radioName,
+  rowId,
+  disabled,
+}: SelectionCellProps<T>) => {
+  const node = params.node as IRowNode<T>;
+  const [isSelected, setIsSelected] = useState(() => !!node.isSelected());
+
+  useEffect(() => {
+    const sync = () => setIsSelected(!!node.isSelected());
+
+    sync();
+    node.addEventListener('rowSelected', sync);
+
+    return () => node.removeEventListener('rowSelected', sync);
+  }, [node]);
+
+  const select = (next: boolean) => {
+    if (disabled) return;
+
+    node.setSelected(
+      next,
+      // Single mode clears the rest of the selection, as a radio group does.
+      mode === GridSelectionMode.SINGLE,
+      SelectionEventSourceType.CHECKBOX_SELECTED,
+    );
+  };
+
+  if (mode === GridSelectionMode.SINGLE) {
+    return (
+      <Radio
+        name={radioName}
+        value={rowId}
+        isSelected={isSelected}
+        disabled={disabled}
+        aria-label={label}
+        onChange={() => select(true)}
+      />
+    );
+  }
+
+  return (
+    <Checkbox
+      isSelected={isSelected}
+      disabled={disabled}
+      aria-label={label}
+      onChange={select}
+    />
+  );
+};

--- a/src/components/New/Grid/components/SelectionHeader.tsx
+++ b/src/components/New/Grid/components/SelectionHeader.tsx
@@ -1,0 +1,85 @@
+import type { GridApi, IHeaderParams } from 'ag-grid-community';
+import { useCallback, useEffect, useState } from 'react';
+
+import { Checkbox } from '../../Checkbox/Checkbox';
+import { SelectionEventSourceType } from '../constants';
+
+/**
+ * Counts the rows the header speaks for. Filtered-out rows are left out, so the
+ * checkbox describes what is on screen — and `selectAll('filtered')` below
+ * selects exactly the rows it was counting.
+ */
+const countSelection = (api: GridApi) => {
+  let selected = 0;
+  let selectable = 0;
+
+  api.forEachNodeAfterFilter((node) => {
+    if (node.selectable === false) return;
+
+    selectable++;
+    if (node.isSelected()) selected++;
+  });
+
+  return { selected, selectable };
+};
+
+export interface SelectionHeaderProps<T> extends IHeaderParams<T> {
+  /** Accessible name of the select-all control. */
+  label: string;
+}
+
+/**
+ * Select-all {@link Checkbox} for the selection column, in place of ag-Grid's
+ * own header checkbox.
+ *
+ * It derives its state from the grid rather than from a prop: partly selected
+ * rows put it in the `mixed` state, and disabled rows are excluded from the
+ * count so a grid whose selectable rows are all selected still reads as full.
+ */
+export const SelectionHeader = <T,>({
+  api,
+  label,
+}: SelectionHeaderProps<T>) => {
+  const [{ selected, selectable }, setCounts] = useState(() =>
+    countSelection(api),
+  );
+
+  useEffect(() => {
+    const sync = () => setCounts(countSelection(api));
+
+    sync();
+    api.addEventListener('selectionChanged', sync);
+    // Rows arriving, leaving or being filtered all change what the header
+    // speaks for, so the count is refreshed on model updates too.
+    api.addEventListener('modelUpdated', sync);
+
+    return () => {
+      if (api.isDestroyed()) return;
+
+      api.removeEventListener('selectionChanged', sync);
+      api.removeEventListener('modelUpdated', sync);
+    };
+  }, [api]);
+
+  const onChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        api.selectAll('filtered', SelectionEventSourceType.CHECKBOX_SELECTED);
+        return;
+      }
+
+      api.deselectAll('filtered', SelectionEventSourceType.CHECKBOX_SELECTED);
+    },
+    [api],
+  );
+
+  return (
+    <Checkbox
+      isSelected={selectable > 0 && selected === selectable}
+      isIndeterminate={selected > 0 && selected < selectable}
+      disabled={selectable === 0}
+      aria-label={label}
+      onChange={onChange}
+    />
+  );
+};

--- a/src/components/New/Grid/constants.ts
+++ b/src/components/New/Grid/constants.ts
@@ -1,0 +1,71 @@
+/** Root class of the 2.0 grid; every rule in `styles/grid.scss` sits under it. */
+export const GRID_ROOT_CLASS = 'dial-kit-grid';
+
+/** Present only while a selection column is rendered. Drives its reveal. */
+export const GRID_WITH_SELECTION_CLASS = 'dial-kit-grid-with-selection';
+
+export const GRID_WITHOUT_HEADER_BORDERS_CLASS =
+  'dial-kit-grid-without-header-borders';
+
+/** Cell of the selection column: faded out until the row is hovered. */
+export const GRID_ROW_SELECT_CLASS = 'dial-kit-grid-row-select';
+
+/** Header of the selection column: faded out until the header is hovered. */
+export const GRID_HEADER_SELECT_CLASS = 'dial-kit-grid-header-select';
+
+/**
+ * Pins the whole selection column visible — on touch, or once something is
+ * selected. It sits on the container rather than on the column definition:
+ * ag-Grid rebuilds every cell when a column definition changes, which would
+ * pull the DOM out from under the click that caused the selection.
+ */
+export const GRID_SELECTION_VISIBLE_CLASS = 'dial-kit-grid-selection-visible';
+
+/** Right-aligns a column. Applied by the consumer through `cellClass`. */
+export const GRID_ALIGN_RIGHT_CLASS = 'dial-kit-grid-align-right';
+
+/** Height of both a body row and the header row. */
+export const ROW_HEIGHT = 40;
+
+/**
+ * ag-Grid theme parameters, resolved from the 2.0 colour tokens with the same
+ * literal fallbacks the Tailwind config carries, so a consumer that defines no
+ * CSS variables still gets the intended palette.
+ *
+ * Hover sits one step up the accent-alpha ramp from the selected tint, so a
+ * hovered selected row still reads as hovered — the same relationship the 2.0
+ * dropdown and select rows use.
+ */
+export const GRID_THEME_PARAMS = {
+  accentColor: 'var(--bg-control-accent, #1D4ED8)',
+  backgroundColor: 'var(--bg-layer-raised, #FCFCFC)',
+  oddRowBackgroundColor: 'var(--bg-layer-sunken, #EEF1F7)',
+  selectedRowBackgroundColor: 'var(--bg-control-accent-alpha, #2764D90F)',
+  rowHoverColor: 'var(--bg-control-accent-alpha-hover, #2764D924)',
+  borderColor: 'var(--stroke-tertiary, #E0E6F0)',
+  rowBorder: '1px solid var(--stroke-tertiary, #E0E6F0)',
+  chromeBackgroundColor: 'var(--bg-layer-base, #F5F7FA)',
+  foregroundColor: 'var(--text-primary, #161B2D)',
+  headerTextColor: 'var(--text-secondary, #57647A)',
+  // 1.0 asked the browser for dark native widgets while painting a light
+  // theme; the scheme now matches the palette it is used with.
+  browserColorScheme: 'light',
+  headerFontSize: 14,
+  headerFontWeight: 600,
+  fontSize: 14,
+  fontFamily: 'var(--theme-font, var(--font-inter))',
+  spacing: 4,
+  borderRadius: 4,
+  wrapperBorderRadius: 8,
+};
+
+/**
+ * Sources reported with a selection change. `checkboxSelected` marks the ones
+ * the user made in the selection column, the other two mark selections the
+ * component applied itself while syncing to `selectedRowIds` or new row data.
+ */
+export enum SelectionEventSourceType {
+  API = 'api',
+  ROW_DATA_CHANGED = 'rowDataChanged',
+  CHECKBOX_SELECTED = 'checkboxSelected',
+}

--- a/src/components/New/Grid/renderers/DateCellRenderer.spec.tsx
+++ b/src/components/New/Grid/renderers/DateCellRenderer.spec.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { DateCellRenderer } from './DateCellRenderer';
+
+describe('Dial UI Kit :: DateCellRenderer', () => {
+  test('renders an ISO string inside a machine-readable <time>', () => {
+    render(
+      <DateCellRenderer
+        value="2025-07-20T00:00:00Z"
+        locale="en-US"
+        options={{ timeZone: 'UTC' }}
+      />,
+    );
+
+    const timeElement = screen.getByText('7/20/2025').closest('time');
+
+    expect(timeElement).toBeInTheDocument();
+    expect(timeElement).toHaveAttribute('dateTime', '2025-07-20T00:00:00.000Z');
+  });
+
+  test('reads a numeric value as epoch milliseconds', () => {
+    render(
+      <DateCellRenderer
+        value={1752969600000}
+        locale="en-US"
+        options={{ timeZone: 'UTC' }}
+      />,
+    );
+
+    expect(screen.getByText('7/20/2025')).toBeInTheDocument();
+  });
+
+  test('reads an integer string as epoch milliseconds too', () => {
+    render(
+      <DateCellRenderer
+        value="1752969600000"
+        locale="en-US"
+        options={{ timeZone: 'UTC' }}
+      />,
+    );
+
+    expect(screen.getByText('7/20/2025')).toBeInTheDocument();
+  });
+
+  test('falls back to the placeholder on an unusable value', () => {
+    render(<DateCellRenderer value="not-a-date" emptyPlaceholder="—" />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(document.querySelector('time')).toBeNull();
+  });
+
+  test('renders nothing readable when there is no value and no placeholder', () => {
+    const { container } = render(<DateCellRenderer value={null} />);
+
+    expect(container).toHaveTextContent('');
+    expect(document.querySelector('time')).toBeNull();
+  });
+
+  test('formats with the locale it is given', () => {
+    render(
+      <DateCellRenderer
+        value="2025-07-20T00:00:00Z"
+        locale="de-DE"
+        options={{ timeZone: 'UTC', dateStyle: 'short' }}
+      />,
+    );
+
+    expect(screen.getByText('20.07.25')).toBeInTheDocument();
+  });
+});

--- a/src/components/New/Grid/renderers/DateCellRenderer.stories.tsx
+++ b/src/components/New/Grid/renderers/DateCellRenderer.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import {
+  DateCellRenderer,
+  type DateCellRendererProps,
+} from './DateCellRenderer';
+
+const meta = {
+  title: 'Components_2_0/Grid/DateCellRenderer',
+  component: DateCellRenderer,
+  tags: ['grid', 'cell', 'date'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Date cell for the 2.0 Grid, usable as an ag-Grid `cellRenderer` or on its own. A valid date is rendered inside a `<time datetime>`, and the full string is only offered in a tooltip when the column is too narrow to show it.',
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: 'text' },
+      description: 'ISO string, epoch milliseconds, or a Date',
+    },
+    locale: { control: { type: 'text' } },
+    options: { control: false, description: 'Intl.DateTimeFormat options' },
+    emptyPlaceholder: { control: { type: 'text' } },
+  },
+  args: {
+    value: '2026-07-20T09:30:00Z',
+    locale: 'en-US',
+    options: { timeZone: 'UTC' },
+  },
+  render: (args) => (
+    <div className="w-[280px] rounded-lg bg-layer-raised p-3">
+      <DateCellRenderer {...args} />
+    </div>
+  ),
+} satisfies Meta<DateCellRendererProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const EpochMilliseconds: Story = {
+  args: {
+    value: 1752969600000,
+  },
+};
+
+export const OtherLocale: Story = {
+  args: {
+    locale: 'de-DE',
+    options: { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' },
+  },
+};
+
+export const Truncated: Story = {
+  args: {
+    options: { timeZone: 'UTC', dateStyle: 'full', timeStyle: 'long' },
+  },
+  render: (args) => (
+    <div className="w-[140px] rounded-lg bg-layer-raised p-3">
+      <DateCellRenderer {...args} />
+    </div>
+  ),
+};
+
+export const NoValue: Story = {
+  args: {
+    value: null,
+    emptyPlaceholder: '—',
+  },
+};

--- a/src/components/New/Grid/renderers/DateCellRenderer.tsx
+++ b/src/components/New/Grid/renderers/DateCellRenderer.tsx
@@ -1,0 +1,84 @@
+import type { ICellRendererParams } from 'ag-grid-community';
+import { useMemo, type FC } from 'react';
+
+import { convertToDate, type DateValue } from '@/utils/grid-date';
+import { mergeClasses } from '@/utils/merge-classes';
+import { EllipsisTooltip } from '../../EllipsisTooltip/EllipsisTooltip';
+import { DEFAULT_DATE_FORMAT_OPTIONS, DEFAULT_LOCALE } from './constants';
+
+export type { DateValue };
+
+export interface DateCellRendererProps extends Partial<
+  ICellRendererParams<Record<string, unknown>, DateValue>
+> {
+  /** The date to render. A pure integer string is read as epoch milliseconds. */
+  value?: DateValue | null;
+  /** Locale used for formatting. Defaults to `'en-US'`. */
+  locale?: string;
+  /** `Intl.DateTimeFormat` options. */
+  options?: Intl.DateTimeFormatOptions;
+  /** Rendered when the value carries no usable date. */
+  emptyPlaceholder?: string;
+  /** Additional CSS classes for the cell. */
+  className?: string;
+  /** Suppresses the truncation tooltip. */
+  hideTooltip?: boolean;
+}
+
+/**
+ * Date cell for the 2.0 {@link Grid}, usable as an ag-Grid `cellRenderer`.
+ * aliases: DateCell|TimestampCell
+ * Design system 2.0
+ *
+ * Formats the value with `Intl.DateTimeFormat` and wraps it in a
+ * {@link EllipsisTooltip}, so the full string is only offered when the column is
+ * too narrow to show it. A valid date is rendered inside a `<time datetime>`,
+ * which gives assistive tech and crawlers the machine-readable value next to
+ * the localised one.
+ *
+ * @example
+ * ```tsx
+ * // As a column renderer
+ * { field: 'createdAt', cellRenderer: DateCellRenderer,
+ *   cellRendererParams: { options: { timeZone: 'UTC' } } }
+ *
+ * // Directly
+ * <DateCellRenderer value="2025-07-20T00:00:00Z" options={{ timeZone: 'UTC' }} />
+ * <DateCellRenderer value={1752969600000} /> // epoch milliseconds
+ * ```
+ *
+ * @param [value] - The date to render.
+ * @param [locale='en-US'] - Locale used for formatting.
+ * @param [options] - `Intl.DateTimeFormat` options, e.g. `timeZone`.
+ * @param [emptyPlaceholder] - Rendered when the value carries no usable date.
+ * @param [className] - Additional CSS classes for the cell.
+ * @param [hideTooltip=false] - Suppresses the truncation tooltip.
+ */
+export const DateCellRenderer: FC<DateCellRendererProps> = ({
+  value,
+  locale = DEFAULT_LOCALE,
+  options = DEFAULT_DATE_FORMAT_OPTIONS,
+  emptyPlaceholder,
+  className,
+  hideTooltip = false,
+}) => {
+  const date = convertToDate(value);
+
+  const content = useMemo(() => {
+    if (!date) return emptyPlaceholder;
+
+    return new Intl.DateTimeFormat(locale, options).format(date);
+  }, [date, emptyPlaceholder, locale, options]);
+
+  const iso = date ? date.toISOString() : undefined;
+
+  return (
+    <EllipsisTooltip
+      text={
+        iso ? <time dateTime={iso}>{content}</time> : <span>{content}</span>
+      }
+      className={mergeClasses('dial-small-text text-primary', className)}
+      hideTooltip={hideTooltip}
+    />
+  );
+};

--- a/src/components/New/Grid/renderers/constants.ts
+++ b/src/components/New/Grid/renderers/constants.ts
@@ -1,0 +1,30 @@
+import type { ColDef } from 'ag-grid-community';
+
+export const DEFAULT_LOCALE = 'en-US';
+
+export const DEFAULT_DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'numeric',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+};
+
+/** Just wide enough for a 20px control plus the grid's own cell padding. */
+const SELECTION_COLUMN_WIDTH = 40;
+
+/** Fixed, unsortable and unfilterable: the column holds a control, not data. */
+export const SELECTION_COL_DEF: ColDef = {
+  minWidth: SELECTION_COLUMN_WIDTH,
+  width: SELECTION_COLUMN_WIDTH,
+  maxWidth: SELECTION_COLUMN_WIDTH,
+  resizable: false,
+  sortable: false,
+  filter: false,
+  floatingFilter: false,
+  suppressMovable: true,
+  suppressHeaderMenuButton: true,
+  suppressAutoSize: true,
+  suppressSizeToFit: true,
+};

--- a/src/components/New/NoDataContent/NoDataContent.spec.tsx
+++ b/src/components/New/NoDataContent/NoDataContent.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { NoDataContent } from './NoDataContent';
+
+describe('Dial UI Kit :: NoDataContent', () => {
+  test('renders the title and description', () => {
+    render(<NoDataContent title="No results" description="Try again" />);
+
+    expect(screen.getByText('No results')).toBeInTheDocument();
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+  });
+
+  test('omits the description when none is given', () => {
+    render(<NoDataContent title="No results" />);
+
+    expect(screen.getByText('No results')).toBeInTheDocument();
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+  });
+
+  test('hides the default icon from assistive tech', () => {
+    const { container } = render(<NoDataContent title="No results" />);
+
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('renders a custom icon instead of the default one', () => {
+    render(<NoDataContent title="No results" icon={<span>Icon</span>} />);
+
+    expect(screen.getByText('Icon')).toBeInTheDocument();
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  test('is silent by default and announced with live', () => {
+    const { rerender } = render(<NoDataContent title="No results" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    rerender(<NoDataContent title="No results" live />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('No results');
+  });
+
+  test('merges custom classes into the container and the text', () => {
+    const { container } = render(
+      <NoDataContent
+        title="No results"
+        description="Try again"
+        className="my-container"
+        titleClassName="my-title"
+        descriptionClassName="my-description"
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveClass('my-container');
+    expect(screen.getByText('No results')).toHaveClass('my-title');
+    expect(screen.getByText('Try again')).toHaveClass('my-description');
+  });
+});

--- a/src/components/New/NoDataContent/NoDataContent.stories.tsx
+++ b/src/components/New/NoDataContent/NoDataContent.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconInbox, IconZoomCancel } from '@tabler/icons-react';
+
+import { NoDataContent, type NoDataContentProps } from './NoDataContent';
+
+const meta = {
+  title: 'Components_2_0/NoDataContent',
+  component: NoDataContent,
+  tags: ['empty', 'state', 'placeholder'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Message shown in place of a list, table or grid that has nothing to show. The icon is decorative and hidden from assistive tech; pass `live` where the content replaces a list the user has just filtered, so the message is announced.',
+      },
+    },
+  },
+  argTypes: {
+    title: { control: { type: 'text' }, description: 'Headline' },
+    description: {
+      control: { type: 'text' },
+      description: 'Secondary line under the title',
+    },
+    icon: { control: false, description: 'Illustration above the title' },
+    live: {
+      control: { type: 'boolean' },
+      description: 'Announce the empty state to assistive tech',
+    },
+  },
+  args: {
+    title: 'No results found',
+    description: "Sorry, we couldn't find any results for your search.",
+  },
+  render: (args) => (
+    <div className="h-[280px] rounded-xl bg-layer-base">
+      <NoDataContent {...args} />
+    </div>
+  ),
+} satisfies Meta<NoDataContentProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TitleOnly: Story = {
+  args: {
+    title: 'Nothing here yet',
+    description: undefined,
+  },
+};
+
+export const CustomIcon: Story = {
+  args: {
+    title: 'No results found',
+    icon: <IconZoomCancel size={60} stroke={0.5} aria-hidden="true" />,
+  },
+};
+
+export const Announced: Story = {
+  args: {
+    title: 'No matching rows',
+    description: 'Adjust the filters to see more.',
+    icon: <IconInbox size={60} stroke={0.5} aria-hidden="true" />,
+    live: true,
+  },
+};

--- a/src/components/New/NoDataContent/NoDataContent.tsx
+++ b/src/components/New/NoDataContent/NoDataContent.tsx
@@ -1,0 +1,102 @@
+import { IconClipboardX } from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
+
+import { mergeClasses } from '@/utils/merge-classes';
+
+/** Footprint of the default icon, large enough to carry an empty state. */
+const DEFAULT_ICON_SIZE = 60;
+
+export interface NoDataContentProps {
+  /** Headline of the empty state. */
+  title: ReactNode;
+  /** Optional secondary line under the title. */
+  description?: ReactNode;
+  /** Illustration above the title. Defaults to a struck-through clipboard. */
+  icon?: ReactNode;
+  /**
+   * Announces the empty state to assistive tech as it appears. Turn it on where
+   * the content replaces a list the user has just filtered or searched.
+   */
+  live?: boolean;
+  /** Additional CSS classes for the container. */
+  className?: string;
+  /** Additional CSS classes for the title. */
+  titleClassName?: string;
+  /** Additional CSS classes for the description. */
+  descriptionClassName?: string;
+}
+
+/**
+ * Message shown in place of a list, table or grid that has nothing to show.
+ * aliases: EmptyState|NoResults|ZeroState
+ * Design system 2.0
+ *
+ * Fills its container and centres an illustration, a headline and an optional
+ * secondary line. The icon is decorative, so it is hidden from assistive tech
+ * and the text carries the message on its own.
+ *
+ * @example
+ * ```tsx
+ * <NoDataContent
+ *   title="No results found"
+ *   description="Try a different search term."
+ * />
+ *
+ * <NoDataContent title="Nothing here yet" icon={<IconInbox size={60} />} live />
+ * ```
+ *
+ * @param title - Headline of the empty state.
+ * @param [description] - Optional secondary line under the title.
+ * @param [icon] - Illustration above the title. Defaults to a struck-through clipboard.
+ * @param [live=false] - Announce the empty state to assistive tech as it appears.
+ * @param [className] - Additional CSS classes for the container.
+ * @param [titleClassName] - Additional CSS classes for the title.
+ * @param [descriptionClassName] - Additional CSS classes for the description.
+ */
+export const NoDataContent: FC<NoDataContentProps> = ({
+  title,
+  description,
+  icon,
+  live = false,
+  className,
+  titleClassName,
+  descriptionClassName,
+}) => {
+  return (
+    <div
+      // `status` announces the message once it appears, which is what a grid
+      // emptied by a filter needs; a decorative empty state stays silent.
+      role={live ? 'status' : undefined}
+      className={mergeClasses(
+        'flex size-full flex-col items-center justify-center gap-2 text-tertiary',
+        className,
+      )}
+    >
+      {icon ?? (
+        <IconClipboardX
+          size={DEFAULT_ICON_SIZE}
+          stroke={0.5}
+          aria-hidden="true"
+        />
+      )}
+      <span
+        className={mergeClasses(
+          'dial-body-semi-text text-primary',
+          titleClassName,
+        )}
+      >
+        {title}
+      </span>
+      {description && (
+        <span
+          className={mergeClasses(
+            'dial-small-text text-secondary',
+            descriptionClassName,
+          )}
+        >
+          {description}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -417,3 +417,27 @@ export { ResizableContainer } from './components/New/ResizableContainer/Resizabl
 export type { ResizableContainerProps } from './components/New/ResizableContainer/ResizableContainer';
 export { ConditionalResizableContainer } from './components/New/ResizableContainer/ConditionalResizableContainer';
 export type { ConditionalResizableContainerProps } from './components/New/ResizableContainer/ConditionalResizableContainer';
+export { NoDataContent } from './components/New/NoDataContent/NoDataContent';
+export type { NoDataContentProps } from './components/New/NoDataContent/NoDataContent';
+export { Grid, GRID_SELECTION_COLUMN_ID } from './components/New/Grid/Grid';
+export type { GridProps } from './components/New/Grid/Grid';
+export { DateCellRenderer } from './components/New/Grid/renderers/DateCellRenderer';
+export type {
+  DateCellRendererProps,
+  DateValue,
+} from './components/New/Grid/renderers/DateCellRenderer';
+export {
+  DEFAULT_DATE_FORMAT_OPTIONS,
+  DEFAULT_LOCALE as DEFAULT_DATE_LOCALE,
+} from './components/New/Grid/renderers/constants';
+export {
+  GRID_ALIGN_RIGHT_CLASS,
+  GRID_ROOT_CLASS,
+  GRID_THEME_PARAMS,
+  ROW_HEIGHT as GRID_ROW_HEIGHT,
+} from './components/New/Grid/constants';
+export { convertToDate } from './utils/grid-date';
+export {
+  baseColumnComparator,
+  checkColDefsChanges,
+} from './utils/grid-comparators';

--- a/src/styles/grid.scss
+++ b/src/styles/grid.scss
@@ -1,0 +1,94 @@
+/**
+ * 2.0 data grid. Every rule is scoped under `.dial-kit-grid`, so it neither
+ * reaches the 1.0 grid nor leans on `ag-grid.scss`, which retires with 1.0 —
+ * the structural rules the grid needs are restated here rather than inherited.
+ *
+ * Imported after `ag-grid.scss`: both files are unlayered and these selectors
+ * are no more specific, so source order is what makes them win.
+ */
+.dial-kit-grid {
+  .ag-root-wrapper {
+    @apply overflow-x-auto;
+
+    .ag-root-wrapper-body {
+      @apply h-auto;
+    }
+  }
+
+  .ag-cell {
+    @apply flex items-center;
+
+    &.ag-cell-focus {
+      @apply border-0;
+    }
+  }
+
+  .ag-header {
+    .ag-column-last::after {
+      @apply border-0;
+    }
+
+    .ag-header-viewport,
+    .ag-pinned-left-header {
+      .ag-floating-filter input {
+        @apply m-0 px-2 py-0;
+        height: 24px !important;
+      }
+    }
+  }
+
+  .ag-layout-auto-height {
+    .ag-center-cols-container,
+    .ag-center-cols-viewport {
+      @apply min-h-0;
+    }
+  }
+
+  .dial-kit-grid-align-right {
+    @apply justify-end;
+
+    .ag-header-cell-label {
+      @apply justify-end;
+    }
+  }
+}
+
+/**
+ * The selection column stays out of the way until it is needed: hovering the
+ * row, selecting anything, or reaching the checkbox with the keyboard brings it
+ * back. `focus-within` is what keeps it operable — a faded-out checkbox is
+ * still in the tab order, and focus has to be visible when it lands there.
+ */
+.dial-kit-grid-with-selection {
+  .ag-row .dial-kit-grid-row-select,
+  .ag-header-row .dial-kit-grid-header-select {
+    @apply opacity-0 transition-opacity motion-reduce:transition-none;
+  }
+
+  .ag-row-hover .dial-kit-grid-row-select,
+  .ag-row-selected .dial-kit-grid-row-select,
+  .ag-row .dial-kit-grid-row-select:focus-within,
+  .ag-header-cell:hover.dial-kit-grid-header-select,
+  .ag-header-row .dial-kit-grid-header-select:focus-within {
+    @apply opacity-100;
+  }
+}
+
+/**
+ * Pinned visible: a touch screen has no hover to reveal the column with, and
+ * hiding a selection the user has just made would take it off screen. Both
+ * classes are matched together so this outweighs the fade above, which is one
+ * selector deeper.
+ */
+.dial-kit-grid-with-selection.dial-kit-grid-selection-visible {
+  .ag-row .dial-kit-grid-row-select,
+  .ag-header-row .dial-kit-grid-header-select {
+    @apply opacity-100;
+  }
+}
+
+.dial-kit-grid-without-header-borders {
+  .ag-header .ag-header-cell::after {
+    @apply border-r-0;
+  }
+}

--- a/src/styles/tailwind-entry.scss
+++ b/src/styles/tailwind-entry.scss
@@ -6,6 +6,7 @@
 @import './scroll.scss';
 @import './popup.scss';
 @import './ag-grid.scss';
+@import './grid.scss';
 @import './steps.scss';
 @import './pagination.scss';
 @import './markdown-editor.scss';

--- a/src/utils/grid-comparators.ts
+++ b/src/utils/grid-comparators.ts
@@ -1,0 +1,53 @@
+import type { ColDef, IRowNode } from 'ag-grid-community';
+
+const collator = new Intl.Collator(undefined, {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+export const baseColumnComparator = (
+  a: string | number | undefined,
+  b: string | number | undefined,
+  _nodeA?: IRowNode,
+  _nodeB?: IRowNode,
+  isInverted?: boolean,
+): number => {
+  if (typeof a === 'string' && typeof b === 'string' && a && b) {
+    const result = collator.compare(a, b);
+
+    return result === 0 ? 0 : result > 0 ? 1 : -1;
+  }
+
+  if (a === b) {
+    return 0;
+  }
+
+  if (!a) {
+    return !isInverted ? 1 : -1;
+  }
+
+  if (!b) {
+    return !isInverted ? -1 : 1;
+  }
+
+  return a > b ? 1 : -1;
+};
+
+export const omitUndefined = <T extends object>(value: T | undefined): T => {
+  if (!value) {
+    return {} as T;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([, v]) => v !== undefined),
+  ) as T;
+};
+
+export const checkColDefsChanges = (cols: ColDef[], initialCols: ColDef[]) => {
+  return cols.some((col, index) => {
+    if (col.field !== initialCols[index].field) {
+      return true;
+    }
+    return col.hide !== initialCols[index].hide;
+  });
+};

--- a/src/utils/grid-date.ts
+++ b/src/utils/grid-date.ts
@@ -1,0 +1,33 @@
+export type DateValue = string | number | Date;
+
+/**
+ * Normalises the value a date cell can receive into a `Date`, or `null` when it
+ * carries no usable date. A pure integer string is read as epoch milliseconds,
+ * so a serialised timestamp behaves like the number it came from.
+ */
+export const convertToDate = (input?: DateValue | null): Date | null => {
+  if (!input) return null;
+
+  if (input instanceof Date) {
+    return isFinite(input.getTime()) ? input : null;
+  }
+
+  if (typeof input === 'number') {
+    const date = new Date(input);
+    return isFinite(date.getTime()) ? date : null;
+  }
+
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+
+    // Treat pure integer strings as epoch milliseconds (supports negatives).
+    if (/^-?\d+$/.test(trimmed)) {
+      return convertToDate(Number(trimmed));
+    }
+
+    const date = new Date(trimmed);
+    return isFinite(date.getTime()) ? date : null;
+  }
+
+  return null;
+};


### PR DESCRIPTION
Moves the data grid to the 2.0 design system. The 1.0 `DialGrid`, `DialDateCellRenderer` and `DialNoDataContent` stay untouched, and the MCP manifest links each pair automatically.

New public components: `Grid`, `DateCellRenderer`, `NoDataContent`.

## Selection column

It renders the 2.0 `Checkbox` and `Radio` instead of ag-Grid's own inputs, which retires the mask-SVG styling hack in `ag-grid.scss` and the deprecated `controls-accent` token it needed. Row controls take their state from the row node's `rowSelected` event, so a selection made anywhere — another cell, the header, or the `selectedRowIds` prop — is reflected without refreshing the cell. The select-all derives checked and `mixed` from the grid itself, leaving out rows that cannot be selected, and acts on the filtered rows so it describes what is on screen.

Each control has a real accessible name through `selectRowLabel` / `selectAllLabel`. 1.0 patched `aria-description="checkbox-container"` onto ag-Grid's inputs from a `document.querySelector`, which named nothing.

## Bugs found while porting

All fixed in 2.0 and deliberately left alone in 1.0:

- **Selection clicks were dropped.** An inline `getRowId` rebuilt every column definition on every render, and ag-Grid rebuilds every cell when a definition changes — the rebuild detached the very input being clicked. Callback props are now read through a box so the definitions keep their identity, and the reveal-on-hover state moved from the column definition onto the container.
- **`onSelectionChange` never fired.** The handler closed over the `gridApi` state that only exists after start-up, and ag-Grid keeps the handler it was given at start-up, so the early return fired forever. The 2.0 handler is stable and reads the api off the event.
- **A `sort` declared on a column was stripped** on startup.
- **A wrapper claimed `role="table"`** around ag-Grid's own `role="grid"`, with an `aria-describedby` pointing at no element at all. Both are gone; the labelled `region` stays.
- **The theme object was rebuilt on every render**, and `browserColorScheme: 'dark'` was set while painting the light palette.

## Also

- A cell is only wrapped in a context-menu `Dropdown` when `getContextMenuItems` is passed — 1.0 wrapped every cell in a menu with no items.
- `NoDataContent` 2.0 announces the empty state through `role="status"`, so a grid emptied by a filter is not silent, and it drops the `aria-label`s 1.0 put on its own text nodes.
- `DateCellRenderer` keeps the `<time datetime>` output and the truncation tooltip, now on the 2.0 `EllipsisTooltip`.
- The comparators and `convertToDate` moved to `src/utils`, so 2.0 does not import out of the 1.0 component folder. The 1.0 modules re-export them, and their public exports are unchanged.
- `styles/grid.scss` is scoped under `.dial-kit-grid` and restates the structural rules it needs, so it neither reaches the 1.0 grid nor depends on `ag-grid.scss`, which retires with 1.0.

## Colours

Every token comes from the 2.0 keeper sets — checked against the `*ColorsToRemove` sets in `tailwind.config.js`. The grid theme maps `--bg-layer-3` → `--bg-layer-raised`, `--bg-layer-2` → `--bg-layer-sunken`, `--bg-accent-primary` → `--bg-control-accent`, `--controls-bg-accent-primary-alpha-active` → `--bg-control-accent-alpha` (hover one step up the ramp, as the 2.0 dropdown rows do), `--bg-layer-4` → `--stroke-tertiary`, and `--bg-layer-1` → `--bg-layer-base`.

## Verification

- `npm run lint` clean; `npm run test` green — 176 files / 2380 tests, 28 of them new for this work. Coverage 86.1% statements / 80.7% branches, above the 70% thresholds.
- `npm run typecheck` reports no errors in the changed files (the 56 pre-existing errors in `use-trigger-view-create-folder.spec.tsx` are untouched by this PR).
- `npm run build:css` compiles the `.dial-kit-grid*` rules; `npm run build:manifest` files all three new components as generation 2.0 and links them from `DialGrid`, `DialDateCellRenderer` and `DialNoDataContent`.

Issues: none — 2.0 component work, no ticket.

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` — no ticket for this one

**New Component Checklist:**

- [ ] component name starts with Dial — intentionally not: 2.0 components drop the prefix (`Accordion`, `Button`, `Tag`, …)
- [x] custom css classes has dial- prefix — the new rules are `dial-kit-grid*`
- [x] component export added to index.ts
- [x] jsdoc is added for component
- [x] absolute paths are used for imports — `@/` for shared modules, relative for sibling 2.0 components, as in `IconButton` / `Tooltip`
- [x] stories are added
- [x] tests are added
