### PR TITLE
fix(2.0): give the resize handle back its chevron

### DIFF
--- a/src/components/New/ResizableContainer/ResizableContainer.spec.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.spec.tsx
@@ -234,7 +234,37 @@ describe('Dial UI Kit :: ResizableContainer', () => {
     );
   });
 
-  test('renders a custom handler inside the separator', () => {
+  test('marks the handle with a chevron pointing away from the panel', () => {
+    const { rerender } = render(
+      <ResizableContainer {...BOUNDS} defaultWidth={260}>
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(
+      screen
+        .getByRole('separator')
+        .querySelector('svg.tabler-icon-chevron-right'),
+    ).not.toBeNull();
+
+    rerender(
+      <ResizableContainer
+        {...BOUNDS}
+        defaultWidth={260}
+        side={ResizableContainerSide.Left}
+      >
+        <div>Panel content</div>
+      </ResizableContainer>,
+    );
+
+    expect(
+      screen
+        .getByRole('separator')
+        .querySelector('svg.tabler-icon-chevron-left'),
+    ).not.toBeNull();
+  });
+
+  test('renders a custom handler in place of the chevron', () => {
     render(
       <ResizableContainer
         {...BOUNDS}
@@ -245,8 +275,9 @@ describe('Dial UI Kit :: ResizableContainer', () => {
       </ResizableContainer>,
     );
 
-    expect(screen.getByRole('separator')).toContainElement(
-      screen.getByText('Grip'),
-    );
+    const handle = screen.getByRole('separator');
+
+    expect(handle).toContainElement(screen.getByText('Grip'));
+    expect(handle.querySelector('svg.tabler-icon-chevron-right')).toBeNull();
   });
 });

--- a/src/components/New/ResizableContainer/ResizableContainer.stories.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.stories.tsx
@@ -77,7 +77,8 @@ const meta = {
     },
     resizeHandler: {
       control: false,
-      description: 'Custom node rendered inside the handle',
+      description:
+        'Custom node rendered inside the handle, in place of the default chevron',
     },
     onResize: { control: false },
     onResizeStop: { control: false },

--- a/src/components/New/ResizableContainer/ResizableContainer.tsx
+++ b/src/components/New/ResizableContainer/ResizableContainer.tsx
@@ -41,7 +41,7 @@ export interface ResizableContainerProps {
   className?: string;
   /** Additional CSS classes for the resize handle. */
   resizeHandlerClassName?: string;
-  /** Custom node rendered inside the handle. */
+  /** Custom node rendered inside the handle, in place of the default chevron. */
   resizeHandler?: ReactNode;
 }
 
@@ -51,8 +51,9 @@ export interface ResizableContainerProps {
  * Design system 2.0
  *
  * Works as a controlled component when `width` is provided, otherwise it keeps
- * its own width from `defaultWidth`. The handle appears on hover and while
- * dragging, and stays within `minWidth`–`maxWidth` in both modes.
+ * its own width from `defaultWidth`. The handle — an accent line with a chevron
+ * pointing away from the panel — appears on hover and while dragging, and stays
+ * within `minWidth`–`maxWidth` in both modes.
  *
  * The handle is a focusable `separator`, so the panel resizes with the arrow
  * keys — `Home` and `End` jump to the bounds — and each press reports through
@@ -88,7 +89,7 @@ export interface ResizableContainerProps {
  * @param [ariaLabel='Resize panel'] - Accessible name of the handle.
  * @param [className] - Additional CSS classes for the inner content wrapper.
  * @param [resizeHandlerClassName] - Additional CSS classes for the resize handle.
- * @param [resizeHandler] - Custom node rendered inside the handle.
+ * @param [resizeHandler] - Custom node rendered inside the handle, replacing the default chevron.
  */
 export const ResizableContainer: FC<ResizableContainerProps> = ({
   children,

--- a/src/components/New/ResizableContainer/components/ResizeHandle.tsx
+++ b/src/components/New/ResizableContainer/components/ResizeHandle.tsx
@@ -1,5 +1,8 @@
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import type { FC, KeyboardEvent, ReactNode } from 'react';
 
+import { DIAL_KIT_ICON_STROKE } from '@/components/New/constants/icon';
+import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { ResizableContainerSide } from '@/types/resizable-container';
 import { mergeClasses } from '@/utils/merge-classes';
 
@@ -34,6 +37,7 @@ export const ResizeHandle: FC<ResizeHandleProps> = ({
   handlerClassName,
 }) => {
   const isLeft = side === ResizableContainerSide.Left;
+  const Chevron = isLeft ? IconChevronLeft : IconChevronRight;
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     let next: number;
@@ -73,7 +77,7 @@ export const ResizeHandle: FC<ResizeHandleProps> = ({
       tabIndex={0}
       onKeyDown={handleKeyDown}
       className={mergeClasses(
-        'h-full w-0.5 cursor-col-resize bg-control-accent text-accent',
+        'relative h-full w-0.5 cursor-col-resize bg-control-accent text-accent',
         // Faded out rather than `invisible`: a `visibility: hidden` element
         // cannot be focused, which would leave the handle keyboard-only in
         // theory and unreachable in practice.
@@ -84,7 +88,22 @@ export const ResizeHandle: FC<ResizeHandleProps> = ({
         handlerClassName,
       )}
     >
-      {customHandler}
+      {customHandler ?? (
+        // The chevron sits beside the line rather than on it — the line is 2px
+        // wide, so anything drawn inside it would be clipped to a sliver. It
+        // points away from the panel, and takes no pointer events of its own:
+        // the drag zone is the strip re-resizable puts around the line, and an
+        // icon hanging outside that strip must not look draggable.
+        <Chevron
+          size={DIAL_ICON_SIZE.MD}
+          stroke={DIAL_KIT_ICON_STROKE}
+          aria-hidden="true"
+          className={mergeClasses(
+            'pointer-events-none absolute top-1/2 -translate-y-1/2',
+            isLeft ? 'right-full' : 'left-full',
+          )}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What

The 2.0 `ResizableContainer`'s handle drew only the 2px accent line. The chevron the 1.0 handle rendered through `ResizeIcon` was never carried over to `New/ResizableContainer/components/ResizeHandle.tsx`, so a panel edge lost the arrow marking it as draggable — visible in `ai-dial-react-file-manager`, which moved onto the 2.0 container in its 0.14.0-dev.12 bump.

The handle renders the chevron again:

- `IconChevronRight` for a right-side handle, `IconChevronLeft` for a left one, so it points away from the panel, as in 1.0.
- `DIAL_ICON_SIZE.MD` at `DIAL_KIT_ICON_STROKE`, `aria-hidden` — matching the 2.0 `CollapsibleSidebar` toggle.
- Positioned beside the line, not inside it: the line is `w-0.5`, so anything drawn within it would be clipped to a sliver. It inherits the handle's `text-accent`, fades in with the line on hover and focus, and takes `pointer-events-none` — the drag zone stays the strip re-resizable puts around the line, and an icon hanging outside that strip must not look draggable.
- `resizeHandler` now replaces the chevron rather than being the handle's only content.

Docs on `ResizableContainer` and the `resizeHandler` argType describe it.

## Testing

- Two new specs in `ResizableContainer.spec.tsx`: the chevron and its direction per `side`, and that a custom `resizeHandler` takes its place.
- `vitest run src/components/New/ResizableContainer` — 15/15 green; eslint and prettier clean.
- Checked in Storybook from both sides: the hovered edge shows the accent line with the chevron centred on it, pointing outward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)