### PR TITLE
fix: share one ResizeObserver and frame across EllipsisTooltip instances

### DIFF
--- a/src/components/EllipsisTooltip/EllipsisTooltip.tsx
+++ b/src/components/EllipsisTooltip/EllipsisTooltip.tsx
@@ -6,6 +6,10 @@ import { DialTooltipContent } from '@/components/Tooltip/TooltipContent';
 import type { DialTooltipContainerOptions } from '@/components/Tooltip/TooltipContext';
 import { DialTooltipTrigger } from '@/components/Tooltip/TooltipTrigger';
 import { tooltipContentBaseClassName } from './constants';
+import {
+  observeElementSize,
+  scheduleMeasure,
+} from '@/utils/element-size-observer';
 import { mergeClasses } from '@/utils/merge-classes';
 
 export interface DialEllipsisTooltipProps extends DialTooltipContainerOptions {
@@ -56,41 +60,38 @@ export const DialEllipsisTooltip: FC<DialEllipsisTooltipProps> = ({
   const ref = useRef<HTMLElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
   const [nodeTextSnapshot, setNodeTextSnapshot] = useState<string>('');
-  const rafRef = useRef<number | null>(null);
 
-  const computeTruncation = () => {
+  const computeTruncation = useCallback(() => {
     const el = ref.current as HTMLElement | null;
     if (!el) return;
 
     setNodeTextSnapshot(el.textContent ?? '');
-    const client = el.clientWidth;
-    const scroll = el.scrollWidth;
-    const rectW = Math.ceil(el.getBoundingClientRect().width);
-    setIsTruncated(scroll > client || scroll > rectW);
-  };
-
-  const scheduleCompute = useCallback(() => {
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    rafRef.current = requestAnimationFrame(computeTruncation);
+    // `scrollWidth` against `clientWidth` is the whole check: both are layout
+    // widths of the same box, so a wider scroll width is exactly what
+    // `text-overflow` clips.
+    setIsTruncated(el.scrollWidth > el.clientWidth);
   }, []);
+
+  // Reading layout inside an event handler forces a synchronous reflow, so the
+  // measurement is deferred to the next frame — shared with every other pending
+  // measurement, which keeps a screen full of these to one reflow per frame.
+  const scheduleCompute = useCallback(
+    () => scheduleMeasure(computeTruncation),
+    [computeTruncation],
+  );
+
+  // Observing is tied to the element, not to the text: a new string must not
+  // cost an unobserve and a re-observe. The shared observer means the whole
+  // page allocates one `ResizeObserver` and one resize listener in total.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    return observeElementSize(el, computeTruncation);
+  }, [computeTruncation]);
 
   useEffect(() => {
     scheduleCompute();
-
-    const onResize = () => scheduleCompute();
-    window.addEventListener('resize', onResize);
-
-    let ro: ResizeObserver | null = null;
-    if ('ResizeObserver' in window && ref.current) {
-      ro = new ResizeObserver(() => scheduleCompute());
-      ro.observe(ref.current);
-    }
-
-    return () => {
-      window.removeEventListener('resize', onResize);
-      if (ro) ro.disconnect();
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    };
   }, [text, scheduleCompute]);
 
   const fullText = useMemo(

--- a/src/components/New/EllipsisTooltip/use-truncation.ts
+++ b/src/components/New/EllipsisTooltip/use-truncation.ts
@@ -6,6 +6,11 @@ import {
   useState,
 } from 'react';
 
+import {
+  observeElementSize,
+  scheduleMeasure,
+} from '@/utils/element-size-observer';
+
 /**
  * Reports whether an element's text is being cut off by `text-overflow`, so a
  * tooltip can carry the full string only when there is something to reveal.
@@ -15,6 +20,11 @@ import {
  * window resize, and — since a parent can resize without the window doing so —
  * whenever the element's own box changes size.
  *
+ * All of that goes through the shared observer in
+ * `@/utils/element-size-observer`, so a screen full of truncating labels costs
+ * one `ResizeObserver`, one resize listener and one animation frame in total
+ * rather than a set per label.
+ *
  * @param text - The rendered content; a change to it re-measures
  * @returns `ref` to attach to the truncating element, whether it `isTruncated`,
  * its `textContent` (the full string even when `text` is a node), and
@@ -22,52 +32,49 @@ import {
  */
 export const useTruncation = <T extends HTMLElement>(text: ReactNode) => {
   const ref = useRef<T | null>(null);
-  const frameRef = useRef<number | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
   const [textContent, setTextContent] = useState('');
+
+  // A string `text` is already the full string, so the DOM read that recovers
+  // it from a node is skipped for what is by far the common case. It lives in a
+  // ref because `measure` has to stay referentially stable: the shared observer
+  // keys its callbacks by element.
+  const isTextNodeRef = useRef(false);
 
   const measure = useCallback(() => {
     const element = ref.current;
 
     if (!element) return;
 
-    setTextContent(element.textContent ?? '');
+    if (isTextNodeRef.current) {
+      setTextContent(element.textContent ?? '');
+    }
 
-    // `scrollWidth` is rounded, so a sub-pixel box can report one pixel more
-    // than `clientWidth` while nothing is actually clipped. Comparing against
-    // the ceiled rendered width as well keeps that from reading as truncation.
-    const renderedWidth = Math.ceil(element.getBoundingClientRect().width);
-
-    setIsTruncated(
-      element.scrollWidth > element.clientWidth ||
-        element.scrollWidth > renderedWidth,
-    );
+    // `scrollWidth` against `clientWidth` is the whole check: both are layout
+    // widths of the same box, so a wider scroll width is exactly what
+    // `text-overflow` clips.
+    setIsTruncated(element.scrollWidth > element.clientWidth);
   }, []);
 
   // Reading layout inside an event handler forces a synchronous reflow, so the
-  // measurement is deferred to the next frame.
-  const remeasure = useCallback(() => {
-    if (frameRef.current) cancelAnimationFrame(frameRef.current);
-    frameRef.current = requestAnimationFrame(measure);
+  // measurement is deferred to the next frame — shared with every other
+  // pending measurement, which keeps the batch to a single reflow.
+  const remeasure = useCallback(() => scheduleMeasure(measure), [measure]);
+
+  // Observing is tied to the element, not to the text: a new string must not
+  // cost an unobserve and a re-observe.
+  useEffect(() => {
+    const element = ref.current;
+
+    if (!element) return;
+
+    return observeElementSize(element, measure);
   }, [measure]);
 
   useEffect(() => {
+    isTextNodeRef.current = typeof text !== 'string';
+
     remeasure();
-
-    window.addEventListener('resize', remeasure);
-
-    let observer: ResizeObserver | null = null;
-
-    if ('ResizeObserver' in window && ref.current) {
-      observer = new ResizeObserver(remeasure);
-      observer.observe(ref.current);
-    }
-
-    return () => {
-      window.removeEventListener('resize', remeasure);
-      observer?.disconnect();
-      if (frameRef.current) cancelAnimationFrame(frameRef.current);
-    };
   }, [text, remeasure]);
 
   return { ref, isTruncated, textContent, remeasure };

--- a/src/utils/__tests__/element-size-observer.spec.ts
+++ b/src/utils/__tests__/element-size-observer.spec.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+type Module = typeof import('../element-size-observer');
+
+let observeElementSize: Module['observeElementSize'];
+let scheduleMeasure: Module['scheduleMeasure'];
+
+let constructedObservers = 0;
+let observedElements: Element[] = [];
+let unobservedElements: Element[] = [];
+let disconnectCount = 0;
+let notifyResize: ResizeObserverCallback | null = null;
+
+class ResizeObserverStub implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    constructedObservers += 1;
+    notifyResize = callback;
+  }
+
+  observe(element: Element) {
+    observedElements.push(element);
+  }
+
+  unobserve(element: Element) {
+    unobservedElements.push(element);
+  }
+
+  disconnect() {
+    disconnectCount += 1;
+  }
+}
+
+let frames: FrameRequestCallback[] = [];
+
+/** Runs whatever the module queued, the way the browser would on the next frame. */
+const runFrame = () => {
+  const queued = frames;
+  frames = [];
+  queued.forEach((callback) => callback(0));
+};
+
+const resizeEntryFor = (target: Element) =>
+  ({ target }) as unknown as ResizeObserverEntry;
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+/**
+ * Observes through the module under test and remembers the unsubscribe, so a
+ * test never leaves the previous module copy's resize listener attached to the
+ * shared `window`.
+ */
+let unsubscribes: (() => void)[] = [];
+
+const observe = (element: Element, callback: () => void) => {
+  const unsubscribe = observeElementSize(element, callback);
+  unsubscribes.push(unsubscribe);
+
+  return unsubscribe;
+};
+
+beforeEach(async () => {
+  constructedObservers = 0;
+  observedElements = [];
+  unobservedElements = [];
+  disconnectCount = 0;
+  notifyResize = null;
+  frames = [];
+  unsubscribes = [];
+
+  globalThis.ResizeObserver =
+    ResizeObserverStub as unknown as typeof ResizeObserver;
+
+  vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(
+    (callback) => {
+      frames.push(callback);
+
+      return frames.length;
+    },
+  );
+  vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+
+  // The module keeps its observer, its listener and its frame in module scope,
+  // so every test needs a fresh copy of it.
+  vi.resetModules();
+  ({ observeElementSize, scheduleMeasure } =
+    await import('../element-size-observer'));
+});
+
+afterEach(() => {
+  unsubscribes.forEach((unsubscribe) => unsubscribe());
+  unsubscribes = [];
+
+  vi.restoreAllMocks();
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+describe('Dial UI Kit :: observeElementSize', () => {
+  test('Should allocate one ResizeObserver and one resize listener for many elements', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const elements = [
+      document.createElement('span'),
+      document.createElement('span'),
+      document.createElement('span'),
+    ];
+
+    elements.forEach((element) => observe(element, vi.fn()));
+
+    expect(constructedObservers).toBe(1);
+    expect(observedElements).toEqual(elements);
+    expect(
+      addEventListener.mock.calls.filter(([type]) => type === 'resize'),
+    ).toHaveLength(1);
+  });
+
+  test('Should measure every observed element in a single frame on window resize', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    observe(document.createElement('span'), first);
+    observe(document.createElement('span'), second);
+    // The initial observe schedules nothing on its own.
+    expect(frames).toHaveLength(0);
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(frames).toHaveLength(1);
+
+    runFrame();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should measure only the element the observer reported', () => {
+    const measured = document.createElement('span');
+    const onMeasured = vi.fn();
+    const untouched = vi.fn();
+
+    observe(measured, onMeasured);
+    observe(document.createElement('span'), untouched);
+
+    notifyResize?.([resizeEntryFor(measured)], {} as ResizeObserver);
+    runFrame();
+
+    expect(onMeasured).toHaveBeenCalledTimes(1);
+    expect(untouched).not.toHaveBeenCalled();
+  });
+
+  test('Should stop measuring an element once it is unobserved', () => {
+    const element = document.createElement('span');
+    const measure = vi.fn();
+    const other = vi.fn();
+
+    const unobserve = observe(element, measure);
+    observe(document.createElement('span'), other);
+
+    unobserve();
+    window.dispatchEvent(new Event('resize'));
+    runFrame();
+
+    expect(unobservedElements).toEqual([element]);
+    expect(measure).not.toHaveBeenCalled();
+    expect(other).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should drop a measurement already queued for an unobserved element', () => {
+    const measure = vi.fn();
+
+    const unobserve = observe(document.createElement('span'), measure);
+
+    scheduleMeasure(measure);
+    unobserve();
+    runFrame();
+
+    expect(measure).not.toHaveBeenCalled();
+  });
+
+  test('Should tear the shared listener and observer down with the last element', () => {
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    const first = observe(document.createElement('span'), vi.fn());
+    const second = observe(document.createElement('span'), vi.fn());
+
+    first();
+
+    expect(disconnectCount).toBe(0);
+
+    second();
+
+    expect(disconnectCount).toBe(1);
+    expect(
+      removeEventListener.mock.calls.filter(([type]) => type === 'resize'),
+    ).toHaveLength(1);
+  });
+
+  test('Should build a new observer after a full teardown', () => {
+    observe(document.createElement('span'), vi.fn())();
+    observe(document.createElement('span'), vi.fn());
+
+    expect(constructedObservers).toBe(2);
+  });
+});
+
+describe('Dial UI Kit :: scheduleMeasure', () => {
+  test('Should run a callback queued repeatedly only once per frame', () => {
+    const measure = vi.fn();
+
+    scheduleMeasure(measure);
+    scheduleMeasure(measure);
+    scheduleMeasure(measure);
+
+    expect(frames).toHaveLength(1);
+
+    runFrame();
+
+    expect(measure).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should coalesce callbacks from different elements into one frame', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    scheduleMeasure(first);
+    scheduleMeasure(second);
+
+    expect(frames).toHaveLength(1);
+
+    runFrame();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should defer a callback queued from inside a frame to the next one', () => {
+    const followUp = vi.fn();
+    const measure = vi.fn(() => scheduleMeasure(followUp));
+
+    scheduleMeasure(measure);
+    runFrame();
+
+    expect(followUp).not.toHaveBeenCalled();
+
+    runFrame();
+
+    expect(followUp).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should schedule a fresh frame after the previous one has run', () => {
+    const measure = vi.fn();
+
+    scheduleMeasure(measure);
+    runFrame();
+    scheduleMeasure(measure);
+
+    expect(frames).toHaveLength(1);
+
+    runFrame();
+
+    expect(measure).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/element-size-observer.ts
+++ b/src/utils/element-size-observer.ts
@@ -1,0 +1,112 @@
+type SizeCallback = () => void;
+
+/**
+ * One `ResizeObserver`, one `window.resize` listener and one animation frame
+ * shared by every element being watched, instead of a set per component.
+ *
+ * A screen rendering hundreds of truncating labels used to allocate hundreds of
+ * observers, hundreds of resize listeners and hundreds of animation frames —
+ * and, because each frame read layout on its own, the browser could be forced
+ * into a reflow once per label. Routing every watcher through this module keeps
+ * the cost flat: one observer, and one frame in which all pending measurements
+ * run back to back, so the layout is recalculated once for the whole batch.
+ */
+const callbacks = new Map<Element, SizeCallback>();
+const pending = new Set<SizeCallback>();
+
+let observer: ResizeObserver | null = null;
+let frame: number | null = null;
+
+const flush = () => {
+  frame = null;
+
+  // Snapshot first: a callback is free to schedule itself again, and that
+  // belongs in the next frame rather than in this one's loop.
+  const batch = Array.from(pending);
+  pending.clear();
+
+  batch.forEach((callback) => callback());
+};
+
+/**
+ * Queues a measurement for the next animation frame, coalescing it with every
+ * other measurement queued for that frame.
+ *
+ * Passing the same callback twice before the frame runs schedules it once.
+ *
+ * @param callback - Reads layout and stores the result; must be referentially stable
+ */
+export const scheduleMeasure = (callback: SizeCallback) => {
+  pending.add(callback);
+
+  if (frame === null) {
+    frame = requestAnimationFrame(flush);
+  }
+};
+
+const handleWindowResize = () => {
+  callbacks.forEach(scheduleMeasure);
+};
+
+const handleResizeEntries = (entries: ResizeObserverEntry[]) => {
+  entries.forEach((entry) => {
+    const callback = callbacks.get(entry.target);
+
+    if (callback) {
+      scheduleMeasure(callback);
+    }
+  });
+};
+
+const teardown = () => {
+  window.removeEventListener('resize', handleWindowResize);
+  observer?.disconnect();
+  observer = null;
+  pending.clear();
+
+  if (frame !== null) {
+    cancelAnimationFrame(frame);
+    frame = null;
+  }
+};
+
+/**
+ * Watches an element's box for size changes and calls back — batched through
+ * {@link scheduleMeasure} — whenever it may need re-measuring.
+ *
+ * A parent can resize without the window doing so, which is what the
+ * `ResizeObserver` covers; the `window.resize` listener stays for environments
+ * that have no `ResizeObserver`.
+ *
+ * One callback per element: observing the same element again replaces it.
+ *
+ * @param element - The element to watch
+ * @param callback - Runs when the element may have changed size; must be referentially stable
+ * @returns Unsubscribes the element, tearing the shared observer down once nothing is left to watch
+ */
+export const observeElementSize = (
+  element: Element,
+  callback: SizeCallback,
+) => {
+  if (callbacks.size === 0) {
+    window.addEventListener('resize', handleWindowResize);
+  }
+
+  callbacks.set(element, callback);
+
+  if (!observer && typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(handleResizeEntries);
+  }
+
+  observer?.observe(element);
+
+  return () => {
+    callbacks.delete(element);
+    observer?.unobserve(element);
+    pending.delete(callback);
+
+    if (callbacks.size === 0) {
+      teardown();
+    }
+  };
+};


### PR DESCRIPTION
Closes #525

## Problem

Every `DialEllipsisTooltip` instance set up its own truncation detection: its own `ResizeObserver`, its own `window.resize` listener and its own `requestAnimationFrame`, reading layout alone inside that frame. A screen that renders a grid, a menu or a select full of truncating labels therefore allocated hundreds of observers and hundreds of listeners, and could be forced into a reflow once per label.

`EllipsisTooltip` is used by `Grid`, `Select`, `MenuItem`, `Tab`, `Tag`, `Breadcrumb`, `Checkbox`, `FileName`, `FolderName` and the FileManager columns — many instances at once is the normal case, not the edge case.

## Change

A shared observer in `src/utils/element-size-observer.ts`:

- one `ResizeObserver` for the whole page, with a `Map<Element, callback>` registry;
- one `window.resize` listener;
- one animation frame in which every pending measurement runs back to back, so the browser recalculates layout once per frame instead of once per label;
- full teardown once the last element unsubscribes.

Both components now route through it — the 1.0 `DialEllipsisTooltip` and the 2.0 `useTruncation`. Observing is tied to the element rather than to the text, so a new string no longer costs an unobserve and a re-observe.

Two per-instance DOM reads go with it:

- **`getBoundingClientRect()` dropped.** The check was `scrollWidth > clientWidth || scrollWidth > ceil(rect.width)`. For an untransformed element `ceil(rect.width) >= clientWidth` always holds (rect is the border box, `clientWidth` the padding box), so the second term is subsumed by the first and could never change the result — a forced layout read for nothing. The comment above it described an `&&` (guarding against sub-pixel rounding) that the `||` never implemented; turning it into an `&&` is a behaviour change and is deliberately **not** part of this PR.
- **`textContent` is only read when `text` is a node.** A string `text` is already the full string, so the common case skips a DOM read and a `setState`.

**No public API change.**

## Verification

- `npm run test` — 178 files / 2422 tests green
- `npm run lint`, prettier — clean
- `npm run typecheck` — 56 errors, identical to the count on `development` (all pre-existing, in `FileManager/hooks/__tests__`)
- New `src/utils/__tests__/element-size-observer.spec.ts` — 11 tests covering the sharing itself: one observer and one listener for N elements, measurements coalesced into a single frame, per-element dispatch, unsubscribe and teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
