### PR TITLE
fix: fix recreating upload input element (Issue #7627)

### DIFF
--- a/src/components/FileManager/FileManager.spec.tsx
+++ b/src/components/FileManager/FileManager.spec.tsx
@@ -1619,4 +1619,102 @@ describe('Dial UI Kit :: FileManager', () => {
       expect(onNewFolderDepthExceeded).not.toHaveBeenCalled();
     });
   });
+
+  describe('upload input survives StrictMode effect re-invocation', () => {
+    const UPLOAD_PATH = 'files/bucket/uploads/2026-08';
+
+    const writableTree = (): DialFile[] => [
+      {
+        id: 'files/bucket',
+        name: 'All files',
+        path: 'files/bucket',
+        folderId: '',
+        parentPath: null,
+        nodeType: DialFileNodeType.FOLDER,
+        permissions: [DialFilePermission.READ, DialFilePermission.WRITE],
+        items: [],
+      },
+    ];
+
+    const getUploadInputs = (): HTMLInputElement[] =>
+      Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="file"]'),
+      ).filter((input) => input.accept !== '.zip,application/zip');
+
+    const getUploadInput = (): HTMLInputElement => {
+      const inputs = getUploadInputs();
+      expect(inputs.length).toBeGreaterThan(0);
+      return inputs[inputs.length - 1];
+    };
+
+    const pickFiles = (input: HTMLInputElement, files: File[]): void => {
+      Object.defineProperty(input, 'files', {
+        value: Object.assign(
+          { length: files.length, item: (i: number) => files[i] ?? null },
+          files,
+        ),
+        writable: false,
+        configurable: true,
+      });
+      fireEvent.change(input);
+    };
+
+    test('the element the picker was opened against is still the live one', async () => {
+      const onUploadFiles = vi.fn();
+      const clickSpy = vi
+        .spyOn(HTMLInputElement.prototype, 'click')
+        .mockImplementation(() => undefined);
+
+      render(
+        <React.StrictMode>
+          <div style={{ height: 640, width: 1100 }}>
+            <DialFileManager
+              items={writableTree()}
+              path={UPLOAD_PATH}
+              onUploadFiles={onUploadFiles}
+              uploadEnabled
+              autoSelectUploadedItems
+              initialUploadFilesOpen
+            />
+          </div>
+        </React.StrictMode>,
+      );
+
+      await waitFor(() => {
+        expect(clickSpy).toHaveBeenCalled();
+      });
+
+      const clickedInput = clickSpy.mock.instances[0] as HTMLInputElement;
+      expect(document.body.contains(clickedInput)).toBe(true);
+      expect(getUploadInputs()).toContain(clickedInput);
+
+      pickFiles(clickedInput, [
+        new File(['content'], 'picked.txt', { type: 'text/plain' }),
+      ]);
+
+      await waitFor(() => {
+        expect(onUploadFiles).toHaveBeenCalledTimes(1);
+      });
+      expect(onUploadFiles.mock.calls[0][1]).toBe(UPLOAD_PATH);
+
+      clickSpy.mockRestore();
+    });
+
+    test('the input is removed from the document on unmount', () => {
+      const { unmount } = renderWithinSizedShell(
+        <DialFileManager
+          items={writableTree()}
+          path={UPLOAD_PATH}
+          onUploadFiles={vi.fn()}
+          uploadEnabled
+        />,
+      );
+
+      expect(getUploadInputs()).toHaveLength(1);
+
+      unmount();
+
+      expect(getUploadInputs()).toHaveLength(0);
+    });
+  });
 });

--- a/src/components/FileManager/FileManagerProvider.tsx
+++ b/src/components/FileManager/FileManagerProvider.tsx
@@ -417,6 +417,8 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
     clearError: clearUploadError,
     openFileDialog: openFileDialogBase,
     fileInputRef,
+    fileInputAccept,
+    handleFileInputChange,
     openArchiveDialog,
 
     uploadConflictingFiles,
@@ -1062,6 +1064,15 @@ export const FileManagerProvider: FC<FileManagerProviderProps> = ({
 
   return (
     <FileManagerContext.Provider value={value}>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        hidden
+        accept={fileInputAccept}
+        onChange={handleFileInputChange}
+        data-qa="file-manager-upload-input"
+      />
       {children}
     </FileManagerContext.Provider>
   );

--- a/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
+++ b/src/components/FileManager/hooks/__tests__/use-file-upload.spec.ts
@@ -5,7 +5,7 @@ import type { DialFileAcceptType } from '@/models/file-manager';
 import type { DialFile } from '@/models/file';
 import { DialFileNodeType } from '@/models/file';
 import { DialFilePermission } from '@/models/file';
-import type { DragEvent } from 'react';
+import type { ChangeEvent, DragEvent } from 'react';
 
 const writableFolder: DialFile = {
   id: 'folder',
@@ -1372,7 +1372,7 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
     });
   });
 
-  describe('hidden file input lifecycle', () => {
+  describe('file input wiring', () => {
     const getHiddenFileInputs = () =>
       Array.from(
         document.body.querySelectorAll<HTMLInputElement>('input[type="file"]'),
@@ -1385,46 +1385,28 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
         { initialProps: { allowedFileTypes: types } },
       );
 
-    it('appends exactly one hidden file input on mount', () => {
+    it('does not append any element to the document', () => {
       renderUseFileUpload();
 
-      expect(getHiddenFileInputs()).toHaveLength(1);
-    });
-
-    it('removes the hidden file input on unmount', () => {
-      const { unmount } = renderUseFileUpload();
-
-      const input = getHiddenFileInputs()[0];
-      expect(input).toBeDefined();
-      expect(document.body.contains(input)).toBe(true);
-
-      unmount();
-
-      expect(document.body.contains(input)).toBe(false);
       expect(getHiddenFileInputs()).toHaveLength(0);
     });
 
-    it('does not create duplicate inputs when dependencies change', () => {
-      const { rerender } = renderWithTypes(['application/pdf']);
+    it('derives the accept string from allowedFileTypes', () => {
+      const { rerender, result } = renderWithTypes(['application/pdf']);
 
-      expect(getHiddenFileInputs()).toHaveLength(1);
-
-      rerender({ allowedFileTypes: ['image/*'] });
-      rerender({ allowedFileTypes: ['text/plain', '.pdf'] });
-
-      expect(getHiddenFileInputs()).toHaveLength(1);
-    });
-
-    it("updates the input's accept attribute when allowedFileTypes changes", () => {
-      const { rerender } = renderWithTypes(['application/pdf']);
-
-      expect(getHiddenFileInputs()[0]?.accept).toBe('application/pdf');
+      expect(result.current.fileInputAccept).toBe('application/pdf');
 
       rerender({ allowedFileTypes: ['image/*', 'text/plain'] });
-      expect(getHiddenFileInputs()[0]?.accept).toBe('image/*,text/plain');
+      expect(result.current.fileInputAccept).toBe('image/*,text/plain');
+    });
 
-      rerender({ allowedFileTypes: [] });
-      expect(getHiddenFileInputs()[0]?.hasAttribute('accept')).toBe(false);
+    it('leaves accept undefined when there is no restriction', () => {
+      const { rerender, result } = renderWithTypes([]);
+
+      expect(result.current.fileInputAccept).toBeUndefined();
+
+      rerender({ allowedFileTypes: undefined });
+      expect(result.current.fileInputAccept).toBeUndefined();
     });
 
     it('surfaces an error and resets input value when the upload throws', async () => {
@@ -1433,8 +1415,8 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       });
       const { result } = renderUseFileUpload({ onUploadFiles });
 
-      const input = getHiddenFileInputs()[0];
-      expect(input).toBeDefined();
+      const input = document.createElement('input');
+      input.type = 'file';
 
       const file = createMockFile('file1.txt', 1024);
       Object.defineProperty(input, 'files', {
@@ -1443,8 +1425,9 @@ describe('Dial UI Kit :: FileManager :: useFileUpload', () => {
       });
 
       await act(async () => {
-        input.dispatchEvent(new Event('change'));
-        await Promise.resolve();
+        await result.current.handleFileInputChange({
+          currentTarget: input,
+        } as unknown as ChangeEvent<HTMLInputElement>);
       });
 
       await waitFor(() => {

--- a/src/components/FileManager/hooks/use-file-upload.tsx
+++ b/src/components/FileManager/hooks/use-file-upload.tsx
@@ -1,4 +1,5 @@
 import {
+  type ChangeEvent,
   type DragEvent,
   useCallback,
   useEffect,
@@ -500,11 +501,9 @@ export const useFileUpload = ({
     ],
   );
 
-  const handleChangeRef = useRef<() => void | Promise<void>>(() => {});
-
-  useEffect(() => {
-    handleChangeRef.current = async () => {
-      const input = fileInputRef.current;
+  const handleFileInputChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const input = event.currentTarget;
       if (!input) return;
 
       if (!uploadEnabled || !hasWriteAccess) {
@@ -542,45 +541,20 @@ export const useFileUpload = ({
       } finally {
         input.value = '';
       }
-    };
-  }, [
-    uploadEnabled,
-    hasWriteAccess,
-    filterAcceptedFiles,
-    handleUpload,
-    validationMessages,
-  ]);
+    },
+    [
+      uploadEnabled,
+      hasWriteAccess,
+      filterAcceptedFiles,
+      handleUpload,
+      validationMessages,
+    ],
+  );
 
-  useEffect(() => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.multiple = true;
-    input.style.display = 'none';
-    document.body.appendChild(input);
-    fileInputRef.current = input;
-
-    const listener = () => handleChangeRef.current?.();
-    input.addEventListener('change', listener);
-
-    return () => {
-      input.removeEventListener('change', listener);
-      if (fileInputRef.current === input) {
-        document.body.removeChild(input);
-        fileInputRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    const input = fileInputRef.current;
-    if (!input) return;
-
-    if (allowedFileTypes && allowedFileTypes.length > 0) {
-      input.accept = allowedFileTypes.join(',');
-    } else {
-      input.removeAttribute('accept');
-    }
-  }, [allowedFileTypes]);
+  const fileInputAccept = useMemo(
+    () => (allowedFileTypes?.length ? allowedFileTypes.join(',') : undefined),
+    [allowedFileTypes],
+  );
 
   const openFileDialog = useCallback(
     (destinationFolder: string, existingFiles: DialFile[]) => {
@@ -682,6 +656,8 @@ export const useFileUpload = ({
     openFileDialog,
     openArchiveDialog,
     fileInputRef,
+    fileInputAccept,
+    handleFileInputChange,
 
     uploadConflictingFiles: conflictingFiles,
     uploadConflictResolutionOpen: conflictResolutionOpen,


### PR DESCRIPTION
**Description and UI changes:**

- fix recreating upload input element which caused uploading files not reaching handler if input dependencies change

Issues:

- Issue https://github.com/epam/ai-dial-chat/issues/7627

**Checklist:**

- [x] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [x] stories are added
- [x] tests are added