### PR TITLE
feat: carry a host token scope into portalled overlays

### DIFF
--- a/src/components/New/Calendar/Calendar.tsx
+++ b/src/components/New/Calendar/Calendar.tsx
@@ -27,6 +27,7 @@ import { DIAL_KIT_ICON_STROKE } from '@/components/New/constants/icon';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { CalendarMode } from '@/types/calendar';
 import { ElementSize } from '@/types/size';
+import { useThemeScope } from '@/components/New/ThemeScope/ThemeScope';
 import { mergeClasses } from '@/utils/merge-classes';
 import {
   DEFAULT_CALENDAR_LOCALE,
@@ -106,6 +107,7 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
   labelledBy,
   panelLabel,
 }) => {
+  const themeScope = useThemeScope();
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
@@ -160,7 +162,11 @@ const CalendarPopoverField: FC<CalendarPopoverFieldProps> = ({
               ref={refs.setFloating}
               style={floatingStyles}
               aria-label={panelLabel}
-              className={mergeClasses(calendarPopoverClassName, panelClassName)}
+              className={mergeClasses(
+                calendarPopoverClassName,
+                themeScope,
+                panelClassName,
+              )}
               {...getFloatingProps()}
             >
               {panel(() => setIsOpen(false))}

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -50,6 +50,7 @@ import { type DropdownItem } from '@/models/dropdown';
 import { CloseButton } from '@/components/New/CloseButton/CloseButton';
 import { CheckboxBox } from '@/components/New/Checkbox/CheckboxBox';
 
+import { useThemeScope } from '@/components/New/ThemeScope/ThemeScope';
 import { mergeClasses } from '@/utils/merge-classes';
 import { DropdownSubMenuItem } from './DropdownSubMenuItem';
 
@@ -200,6 +201,7 @@ export const Dropdown: FC<DropdownProps> = ({
   matchReferenceWidth = true,
   maxDropdownHeight,
 }) => {
+  const themeScope = useThemeScope();
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
   const isControlled = open !== undefined;
   const isOpen = isControlled ? !!open : uncontrolledOpen;
@@ -601,6 +603,7 @@ export const Dropdown: FC<DropdownProps> = ({
                 dropdownListBaseClassName,
                 !matchReferenceWidth && 'w-max',
                 'overflow-auto',
+                themeScope,
                 listClassName,
               )}
               {...getFloatingProps({ onKeyDown: handleFloatingKeyDown })}

--- a/src/components/New/Popup/Popup.tsx
+++ b/src/components/New/Popup/Popup.tsx
@@ -18,6 +18,7 @@ import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { ButtonVariant } from '@/types/button';
 import { PopupSize } from '@/types/popup';
 import { ElementSize } from '@/types/size';
+import { useThemeScope } from '@/components/New/ThemeScope/ThemeScope';
 import { mergeClasses } from '@/utils/merge-classes';
 import { IconChevronLeft } from '@tabler/icons-react';
 import {
@@ -168,6 +169,7 @@ export const Popup: FC<PopupProps> = ({
   closeOnOutsideClick = true,
   preventKeyboardOnOpen = false,
 }) => {
+  const themeScope = useThemeScope();
   const focusGuardRef = useRef<HTMLDivElement>(null);
   // Generated rather than fixed: two popups mounted at once would otherwise
   // share one heading id, and each dialog would be named by the first title.
@@ -258,7 +260,11 @@ export const Popup: FC<PopupProps> = ({
   return (
     <FloatingPortal id={portalId}>
       <FloatingOverlay
-        className={mergeClasses(popupOverlayBaseClassName, overlayClassName)}
+        className={mergeClasses(
+          popupOverlayBaseClassName,
+          themeScope,
+          overlayClassName,
+        )}
       >
         <FloatingFocusManager
           context={context}

--- a/src/components/New/ThemeScope/ThemeScope.spec.tsx
+++ b/src/components/New/ThemeScope/ThemeScope.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { Dropdown } from '@/components/New/Dropdown/Dropdown';
+import { ThemeScope, useThemeScope } from './ThemeScope';
+
+const ScopeProbe = () => <span data-testid="probe">{useThemeScope()}</span>;
+
+describe('Dial UI Kit :: ThemeScope', () => {
+  test('generates no box, so it does not disturb the surrounding layout', () => {
+    const { container } = render(
+      <ThemeScope className="panel-theme">
+        <span>content</span>
+      </ThemeScope>,
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveClass('contents');
+    expect(wrapper).toHaveClass('panel-theme');
+  });
+
+  test('reports no scope outside any ThemeScope', () => {
+    render(<ScopeProbe />);
+
+    expect(screen.getByTestId('probe')).toBeEmptyDOMElement();
+  });
+
+  test('nests outer scopes before inner ones, matching the cascade', () => {
+    render(
+      <ThemeScope className="outer-theme">
+        <ThemeScope className="inner-theme">
+          <ScopeProbe />
+        </ThemeScope>
+      </ThemeScope>,
+    );
+
+    expect(screen.getByTestId('probe')).toHaveTextContent(
+      'outer-theme inner-theme',
+    );
+  });
+
+  test('carries the scope onto an overlay the subtree opens in a portal', () => {
+    render(
+      <ThemeScope className="panel-theme">
+        <Dropdown
+          defaultOpen
+          items={[{ key: 'rename', label: 'Rename' }]}
+          listClassName="dropdown-list"
+        >
+          <button type="button">Actions</button>
+        </Dropdown>
+      </ThemeScope>,
+    );
+
+    // The overlay is portalled to the end of <body>, outside the scope's
+    // subtree, so the class is the only thing carrying the tokens to it.
+    const list = document.querySelector('.dropdown-list');
+    expect(list).not.toBeNull();
+    expect(list).toHaveClass('panel-theme');
+    expect(list?.closest('.contents')).toBeNull();
+  });
+
+  test('leaves overlays opened outside a scope unclassed', () => {
+    render(
+      <Dropdown
+        defaultOpen
+        items={[{ key: 'rename', label: 'Rename' }]}
+        listClassName="dropdown-list"
+      >
+        <button type="button">Actions</button>
+      </Dropdown>,
+    );
+
+    expect(document.querySelector('.dropdown-list')).not.toHaveClass(
+      'panel-theme',
+    );
+  });
+});

--- a/src/components/New/ThemeScope/ThemeScope.stories.tsx
+++ b/src/components/New/ThemeScope/ThemeScope.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Dropdown } from '@/components/New/Dropdown/Dropdown';
+import { ThemeScope, type ThemeScopeProps } from './ThemeScope';
+
+/**
+ * A host-owned scope, the kind a consumer defines in its own stylesheet. Only
+ * the tokens the panel actually paints with need redefining.
+ */
+const scopeStyles = `
+  .sb-dark-panel {
+    --bg-layer-raised: #201e1e;
+    --bg-control-accent-alpha: #483f38;
+    --bg-control-accent-alpha-hover: #564b43;
+    --stroke-tertiary: #3b3b38;
+    --text-primary: #f4f4f4;
+    --text-secondary: #a29f9f;
+  }
+`;
+
+const Panel = ({ label }: { label: string }) => (
+  <div className="dial-surface flex w-[260px] flex-col gap-3 rounded border border-tertiary p-4">
+    <div className="dial-small-semi-text">{label}</div>
+    <div className="dial-small-paragraph-text text-secondary">
+      The panel repaints from the scope&apos;s tokens.
+    </div>
+    <Dropdown
+      defaultOpen
+      items={[
+        { key: 'rename', label: 'Rename' },
+        { key: 'duplicate', label: 'Duplicate' },
+      ]}
+      listClassName="w-[180px]"
+    >
+      <button type="button" className="dial-small-text text-start">
+        Open the row actions
+      </button>
+    </Dropdown>
+  </div>
+);
+
+const meta = {
+  title: 'Components_2_0/ThemeScope',
+  component: ThemeScope,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Marks a subtree as living under a host-defined token scope, so overlays this subtree opens in a portal are painted with the same tokens. Redefining tokens on a panel root re-themes everything the panel renders — until a `Dropdown`, `Popup`, `Tooltip` or `Calendar` escapes into a portal at the end of `<body>`, where the scope no longer reaches it. The wrapper is `display: contents`, so it generates no box and leaves the surrounding layout untouched.',
+      },
+    },
+  },
+  argTypes: {
+    className: {
+      control: { type: 'text' },
+      description: 'Class name redefining the design tokens for this subtree',
+    },
+    children: {
+      control: false,
+      description: 'The subtree painted with those tokens',
+    },
+  },
+} satisfies Meta<ThemeScopeProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The panel and its portalled dropdown both read the scope's tokens. Compare
+ * with `WithoutScope`, where the same dropdown stays on the app palette.
+ */
+export const Default: Story = {
+  args: {
+    className: 'sb-dark-panel',
+    children: <Panel label="Inside a ThemeScope" />,
+  },
+  render: (args) => (
+    <>
+      <style>{scopeStyles}</style>
+      <ThemeScope {...args} />
+    </>
+  ),
+};
+
+/**
+ * The same markup with the class applied directly instead of through a
+ * `ThemeScope`: the panel repaints, but the dropdown — portalled out of the
+ * subtree — does not.
+ */
+export const WithoutScope: Story = {
+  args: {
+    className: 'sb-dark-panel',
+    children: <Panel label="Class applied directly" />,
+  },
+  render: (args) => (
+    <>
+      <style>{scopeStyles}</style>
+      <div className={args.className}>{args.children}</div>
+    </>
+  ),
+};

--- a/src/components/New/ThemeScope/ThemeScope.tsx
+++ b/src/components/New/ThemeScope/ThemeScope.tsx
@@ -1,0 +1,75 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type FC,
+  type ReactNode,
+} from 'react';
+
+import { mergeClasses } from '@/utils/merge-classes';
+
+/**
+ * Class names of the theme scopes wrapping the current subtree, outermost
+ * first. Empty outside any `ThemeScope`.
+ */
+const ThemeScopeContext = createContext<string>('');
+
+export interface ThemeScopeProps {
+  /**
+   * Class name that redefines the design tokens for this subtree — typically a
+   * host-owned rule setting `--bg-*` / `--text-*` / `--stroke-*` custom
+   * properties. Multiple space-separated classes are allowed.
+   */
+  className: string;
+  children: ReactNode;
+}
+
+/**
+ * Marks a subtree as living under a host-defined token scope, so overlays this
+ * subtree opens in a portal are painted with the same tokens.
+ * Design system 2.0
+ *
+ * Redefining design tokens on a panel root re-themes everything the panel
+ * renders — until a `Dropdown`, `Popup`, `Tooltip` or `Calendar` escapes into a
+ * `FloatingPortal` at the end of `<body>`, where the scope's custom properties
+ * no longer reach it. Wrapping the panel in a `ThemeScope` re-applies the same
+ * class to those portalled overlays, so an overlay opened from a dark panel
+ * stays dark while the rest of the app keeps its own palette.
+ *
+ * The wrapper itself is `display: contents`, so it generates no box and leaves
+ * the surrounding flex or grid layout untouched — custom properties inherit
+ * through it all the same. Scopes nest: an inner scope's overlays carry the
+ * outer classes first, matching the cascade they would see in place.
+ *
+ * @example
+ * ```tsx
+ * // .side-panel-theme redefines --bg-*, --text-* and --stroke-* tokens.
+ * <ThemeScope className="side-panel-theme">
+ *   <ConversationPanel {...props} />
+ * </ThemeScope>
+ * ```
+ *
+ * @param className - Class name redefining the design tokens for this subtree
+ * @param children - The subtree painted with those tokens
+ */
+export const ThemeScope: FC<ThemeScopeProps> = ({ className, children }) => {
+  const inherited = useContext(ThemeScopeContext);
+  const scope = useMemo(
+    () => [inherited, className].filter(Boolean).join(' '),
+    [inherited, className],
+  );
+
+  return (
+    <ThemeScopeContext.Provider value={scope}>
+      <div className={mergeClasses('contents', className)}>{children}</div>
+    </ThemeScopeContext.Provider>
+  );
+};
+
+/**
+ * Class names of the enclosing `ThemeScope`s, outermost first, or `''` when the
+ * caller sits outside any scope. Components rendering into a `FloatingPortal`
+ * merge this onto their floating root so the tokens follow them out of the
+ * subtree.
+ */
+export const useThemeScope = (): string => useContext(ThemeScopeContext);

--- a/src/components/New/Tooltip/TooltipContent.tsx
+++ b/src/components/New/Tooltip/TooltipContent.tsx
@@ -6,6 +6,7 @@ import {
 import classNames from 'classnames';
 import { type CSSProperties, type FC, type HTMLProps, useRef } from 'react';
 
+import { useThemeScope } from '@/components/New/ThemeScope/ThemeScope';
 import { useIsMobileScreen } from '@/hooks/use-is-mobile-screen';
 import { arrowClassName, tooltipClassName } from './constants';
 import { useTooltipContext } from './TooltipContext';
@@ -33,6 +34,7 @@ export const TooltipContent: FC<TooltipContentProps> = ({
 }) => {
   const context = useTooltipContext();
   const isMobile = useIsMobileScreen();
+  const themeScope = useThemeScope();
   const propRef = useRef(null);
   const ref = useMergeRefs([context.refs.setFloating, propRef]);
 
@@ -53,6 +55,7 @@ export const TooltipContent: FC<TooltipContentProps> = ({
         {...context.getFloatingProps(props)}
         className={classNames(
           tooltipClassName,
+          themeScope,
           context.getFloatingProps(props).className as string,
         )}
       >

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,6 +357,11 @@ export { ConfirmationPopup } from './components/New/ConfirmationPopup/Confirmati
 export type { ConfirmationPopupProps } from './components/New/ConfirmationPopup/ConfirmationPopup';
 export { Dropdown } from './components/New/Dropdown/Dropdown';
 export type { DropdownProps } from './components/New/Dropdown/Dropdown';
+export {
+  ThemeScope,
+  useThemeScope,
+} from './components/New/ThemeScope/ThemeScope';
+export type { ThemeScopeProps } from './components/New/ThemeScope/ThemeScope';
 export type { TextareaProps } from './components/New/Textarea/Textarea';
 export type { CaptionTextProps } from './components/New/CaptionText/CaptionText';
 export {

--- a/src/styles/surface.scss
+++ b/src/styles/surface.scss
@@ -1,0 +1,16 @@
+@layer base {
+  /*
+   * A panel that owns its palette.
+   *
+   * Redefining the design tokens on a subtree root is not enough on its own for
+   * content carrying no color utility: such content inherits the color computed
+   * on an ancestor — usually `<body>` — which resolved against the tokens in
+   * effect there. This re-resolves both the surface and the inherited text
+   * color against the tokens in effect here, so a re-themed panel does not have
+   * to name a text color on every node inside it.
+   */
+  .dial-surface {
+    background-color: var(--bg-layer-raised, #fcfcfc);
+    color: var(--text-primary, #161b2d);
+  }
+}

--- a/src/styles/tailwind-entry.scss
+++ b/src/styles/tailwind-entry.scss
@@ -12,6 +12,7 @@
 @import './markdown-editor.scss';
 @import './tabs.scss';
 @import './slider.scss';
+@import './surface.scss';
 
 @layer ui {
   @tailwind base;

--- a/src/utils/sub-menu-floating.tsx
+++ b/src/utils/sub-menu-floating.tsx
@@ -15,6 +15,8 @@ import {
 import classNames from 'classnames';
 import { useState, type ReactNode } from 'react';
 
+import { useThemeScope } from '@/components/New/ThemeScope/ThemeScope';
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -113,27 +115,32 @@ export const SubMenuPanel = ({
   surfaceClassName,
   className,
   children,
-}: SubMenuPanelProps) => (
-  <FloatingPortal>
-    <FloatingFocusManager
-      context={context}
-      modal={false}
-      initialFocus={-1}
-      returnFocus
-    >
-      <div
-        ref={refs.setFloating}
-        style={floatingStyles}
-        role={role}
-        className={classNames(
-          'z-[53] overflow-auto text-primary focus-visible:outline-none',
-          surfaceClassName ?? subMenuSurfaceClassName,
-          className,
-        )}
-        {...getFloatingProps()}
+}: SubMenuPanelProps) => {
+  const themeScope = useThemeScope();
+
+  return (
+    <FloatingPortal>
+      <FloatingFocusManager
+        context={context}
+        modal={false}
+        initialFocus={-1}
+        returnFocus
       >
-        {children}
-      </div>
-    </FloatingFocusManager>
-  </FloatingPortal>
-);
+        <div
+          ref={refs.setFloating}
+          style={floatingStyles}
+          role={role}
+          className={classNames(
+            'z-[53] overflow-auto text-primary focus-visible:outline-none',
+            surfaceClassName ?? subMenuSurfaceClassName,
+            themeScope,
+            className,
+          )}
+          {...getFloatingProps()}
+        >
+          {children}
+        </div>
+      </FloatingFocusManager>
+    </FloatingPortal>
+  );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,7 +75,9 @@ const borderColors = {
   'accent-alpha': 'var(--stroke-accent-alpha, #2764D933)', // blue-500 alpha-20
   'gradient-1': 'var(--stroke-gradient-1, #5976E9)', // blue-300
   'gradient-2': 'var(--stroke-gradient-2, #885DF2)', // Violet-300
-  focus: 'var(--stroke-focus-black, #161B2D)', // grey-1000
+  // `--stroke-focus` is the token name the design system settled on;
+  // `--stroke-focus-black` stays as a fallback for consumers still setting it.
+  focus: 'var(--stroke-focus, var(--stroke-focus-black, #161B2D))', // grey-1000
   'accent-focus': 'var(--stroke-accent-focus, #6785FB)', // blue-200
   'error-alpha': 'var(--stroke-error-alpha, #AE2F2F73)', // red-800 alpha-45
   'control-disable-primary': 'var(--stroke-control-disable-primary, #848E9C)', // grey-600


### PR DESCRIPTION
## Problem

Redefining the design tokens on a subtree root re-themes everything that subtree renders — until a `Dropdown`, `Popup`, `Tooltip`, `Calendar` or submenu escapes into a `FloatingPortal` at the end of `<body>`, where the scope's custom properties no longer reach it.

Concretely: a consumer painting one side panel on a dark surface gets a light dropdown floating over it, and nothing outside the component can fix it — `listClassName` is hardcoded or unexposed in the panel libraries that wrap us.

## What this adds

**`ThemeScope` + `useThemeScope`** — the host's scope class travels through context, and the five portal sites merge it onto their floating root, so an overlay is painted with the tokens in effect where it was opened:

```tsx
<ThemeScope className="side-panel-theme">
  <ConversationPanel {...props} />
</ThemeScope>
```

The wrapper is `display: contents`, so it generates no box and leaves the surrounding flex or grid layout untouched — custom properties inherit through it all the same. Scopes nest, outermost class first, matching the cascade the overlay would see in place.

Portal sites covered: `New/Dropdown`, `New/Popup`, `New/Calendar`, `New/Tooltip/TooltipContent`, and the shared `SubMenuPanel` in `utils/sub-menu-floating.tsx` — the last one covers submenus in both `Dropdown` and `Select`.

**`.dial-surface`** — redefining `--text-primary` is not enough for content carrying no color utility of its own: it inherits the color computed on `<body>`, which resolved against the tokens in effect *there*. The utility re-resolves both the surface and the inherited text color against the tokens in effect *here*, so a re-themed panel does not have to name a text color on every node inside it.

**Focus token alias** — `focus` now reads `var(--stroke-focus, var(--stroke-focus-black, #161B2D))`. The design system settled on `--stroke-focus`, several consumers already set it, and the fallback keeps `--stroke-focus-black` working.

## Compatibility

Everything is additive — no renamed or removed props, no changed behaviour for existing usage, no altered token names. Not a breaking change, so no migration guide. Outside a `ThemeScope` every overlay renders exactly as before (covered by a test).

`CHANGELOG.md` is deliberately untouched: it has unrelated in-flight edits on another branch. Happy to add an entry here if you would rather it land with the change.

## Verification

- `tsc --noEmit` — no new errors. The 56 pre-existing ones live in `FileManager/hooks/__tests__/use-trigger-view-create-folder.spec.tsx`, untouched here.
- ESLint clean on every changed file.
- 179 tests pass across `ThemeScope`, `Dropdown`, `Popup`, `Calendar`, `Tooltip` and `Select` — 5 of them new, including one asserting the class reaches the portalled overlay and one asserting overlays outside a scope stay unclassed.
- CSS build emits `.dial-surface{background-color:var(--bg-layer-raised,#fcfcfc);color:var(--text-primary,#161b2d)}` and `outline-focus{outline-color:var(--stroke-focus,var(--stroke-focus-black,#161b2d))}`.
- Storybook: `Components_2_0/ThemeScope` has a with-scope and a without-scope story, so the difference is visible side by side.

## Note for consumers

The mechanism rests on a React context, so it needs a single `@epam/ai-dial-ui-kit` instance in the dependency graph. Some panel libraries currently list the kit under `dependencies` rather than `peerDependencies`; if versions drift, npm installs a second copy and the context silently stops arriving — with the same light-dropdown symptom. Worth moving the kit to peer dependencies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
