### PR TITLE
feat: make control corner radius themable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ The library uses CSS custom properties for comprehensive theming. Override these
 
 Full list of variables is available [here](tailwind.config.js)
 
+Corner radii of the 2.0 controls are themable the same way. Each defaults to the
+fully rounded pill the buttons ship with, so setting nothing keeps the stock
+look:
+
+```css
+:root {
+  --radius-control: 12px; /* Button at standard and large size */
+  --radius-control-small: 8px; /* Button at ElementSize.Small */
+  --radius-control-icon: 9999px; /* IconButton, ToggleIconButton — any size */
+}
+```
+
+Labelled and icon-only buttons read separate variables on purpose: a design that
+wants squarer action buttons usually still wants its icon buttons round.
+
 ## ♿ Accessibility
 
 ### Naming icon-only controls

--- a/src/components/New/Button/Button.tsx
+++ b/src/components/New/Button/Button.tsx
@@ -105,6 +105,9 @@ export const Button: FC<ButtonProps> = ({
       ? 'dial-tiny-semi-text'
       : 'dial-small-paragraph-semi-text',
     size === ElementSize.Small ? 'h-[24px] gap-1' : 'h-[40px] gap-2',
+    // Corner radius is themable per size — see the radius tokens in
+    // `buttons.scss`; the standard radius comes from `dial-kit-base-button`.
+    size === ElementSize.Small && 'dial-kit-base-button-small',
     appearance !== ButtonAppearance.Link &&
       (size === ElementSize.Small ? 'px-2' : 'px-4'),
     // A link-appearance button sits inline in text, where WCAG 2.5.5 exempts

--- a/src/components/New/Button/__tests__/Button.spec.tsx
+++ b/src/components/New/Button/__tests__/Button.spec.tsx
@@ -93,7 +93,20 @@ describe('Dial UI Kit :: DialButton', () => {
   test('Should apply small size classes', () => {
     render(<Button label="Small button" size={ElementSize.Small} />);
     const button = screen.getByRole('button', { name: 'Small button' });
-    expect(button).toHaveClass('h-[24px]', 'px-2', 'dial-tiny-semi-text');
+    expect(button).toHaveClass(
+      'h-[24px]',
+      'px-2',
+      'dial-tiny-semi-text',
+      'dial-kit-base-button-small',
+    );
+  });
+
+  test('Should take the corner radius from the base class at standard size', () => {
+    render(<Button label="Standard button" />);
+
+    expect(screen.getByRole('button')).not.toHaveClass(
+      'dial-kit-base-button-small',
+    );
   });
 
   test('Should not apply height/padding classes for link appearance', () => {

--- a/src/components/New/IconButton/IconButton.spec.tsx
+++ b/src/components/New/IconButton/IconButton.spec.tsx
@@ -87,4 +87,22 @@ describe('Dial UI Kit :: DialIconButton', () => {
       'dial-kit-enhanced-target',
     );
   });
+
+  /*
+   * The icon-only class is what keeps an icon button on its own corner-radius
+   * token (`--radius-control-icon`) instead of the labelled button's, so it has
+   * to stay on the element at every size.
+   */
+  test.each([ElementSize.Small, ElementSize.Standard, ElementSize.Large])(
+    'Should mark itself as an icon-only button at %s size',
+    (size) => {
+      render(
+        <IconButton icon={<div>icon</div>} aria-label="Delete" size={size} />,
+      );
+
+      expect(screen.getByRole('button')).toHaveClass(
+        'dial-kit-base-icon-button',
+      );
+    },
+  );
 });

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -8,9 +8,29 @@
 
 .dial-kit-base-button {
   @apply flex flex-row items-center justify-center;
-  @apply rounded-full border border-solid border-transparent;
+  @apply rounded-control border border-solid border-transparent;
   @apply disabled:cursor-not-allowed outline-offset-0;
   @apply focus-visible:outline focus-visible:outline-focus;
+}
+
+/*
+ * Per-size and icon-only corner radii. Both selectors are compound on purpose:
+ * every variant class inlines `.dial-kit-base-button` with `@apply`, so a
+ * single-class rule here would carry the same specificity as
+ * `.dial-kit-primary-solid-button` and lose or win purely on source order.
+ *
+ * `Button` adds `.dial-kit-base-button-small` at `ElementSize.Small`;
+ * `IconButton` and `ToggleIconButton` always carry
+ * `.dial-kit-base-icon-button`, and an icon-only control stays on its own token
+ * so a host can square the labelled buttons while leaving round icon buttons
+ * round. All three tokens default to the same pill.
+ */
+.dial-kit-base-button.dial-kit-base-button-small {
+  @apply rounded-control-sm;
+}
+
+.dial-kit-base-button.dial-kit-base-icon-button {
+  @apply rounded-control-icon;
 }
 
 /*

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -279,6 +279,16 @@ export default {
       },
       borderRadius: {
         DEFAULT: '4px',
+        /*
+         * Control corner radii, themable like the color tokens above. Each
+         * falls back to the fully rounded pill the 2.0 buttons ship with, so a
+         * host that sets nothing keeps today's look; a host whose design calls
+         * for squarer controls sets the variable once instead of restyling
+         * every button variant.
+         */
+        control: 'var(--radius-control, 9999px)',
+        'control-sm': 'var(--radius-control-small, 9999px)',
+        'control-icon': 'var(--radius-control-icon, 9999px)',
       },
       opacity: {
         15: '15%',


### PR DESCRIPTION
## What

Routes the corner radius of the 2.0 buttons through three themable Tailwind tokens instead of a hardcoded pill:

| Token | Applies to | Default |
| --- | --- | --- |
| `--radius-control` | `Button` at standard and large size | `9999px` |
| `--radius-control-small` | `Button` at `ElementSize.Small` | `9999px` |
| `--radius-control-icon` | `IconButton`, `ToggleIconButton` — any size | `9999px` |

Every token falls back to the pill the buttons ship today, so a host that sets none of them sees no change.

## Why

`.dial-kit-base-button` carried `rounded-full`, and each variant class (`.dial-kit-primary-solid-button` and friends) inlines that rule with `@apply` — radius included. A host whose design calls for squarer buttons therefore had to out-specify every variant with its own CSS, per app.

Labelled and icon-only buttons read separate tokens because a design that squares its action buttons usually still wants its icon buttons round.

## How

- `tailwind.config.js` — `borderRadius.control`, `.control-sm`, `.control-icon` mapped to the tokens.
- `buttons.scss` — the base class uses `rounded-control`; two new rules cover the small and icon-only cases. Both selectors are compound (`.dial-kit-base-button.dial-kit-base-button-small`) on purpose: a single-class rule would tie with the variant classes that inline the base radius and resolve on source order instead of specificity.
- `Button.tsx` — adds `dial-kit-base-button-small` at `ElementSize.Small`.
- `README.md` — documents the tokens in the theming section.

Not a breaking change: no renamed or removed token, no default visual change, so no CHANGELOG or migration-guide entry per `AGENTS.md`.

## Testing

- `npx vitest run` — 2409 tests / 178 files pass.
- `Button.spec.tsx` asserts the small size carries the modifier and the standard size does not; `IconButton.spec.tsx` pins `dial-kit-base-icon-button` at all three sizes, since that class is now what keeps an icon button on its own radius token.
- `npm run build:css` output verified by hand: the base class and every variant emit `border-radius:var(--radius-control,9999px)`, and the two compound rules emit the small and icon tokens.
- `eslint . --max-warnings 0` and `prettier --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
