### PR TITLE
fix: let a consumer's own radius class win over the control tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ look:
 Labelled and icon-only buttons read separate variables on purpose: a design that
 wants squarer action buttons usually still wants its icon buttons round.
 
+These are defaults, not overrides: a `rounded-*` utility passed to a single
+control through `className` still wins, because a consumer's utilities are
+emitted after this package's stylesheet.
+
 ## ♿ Accessibility
 
 ### Naming icon-only controls

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -14,26 +14,6 @@
 }
 
 /*
- * Per-size and icon-only corner radii. Both selectors are compound on purpose:
- * every variant class inlines `.dial-kit-base-button` with `@apply`, so a
- * single-class rule here would carry the same specificity as
- * `.dial-kit-primary-solid-button` and lose or win purely on source order.
- *
- * `Button` adds `.dial-kit-base-button-small` at `ElementSize.Small`;
- * `IconButton` and `ToggleIconButton` always carry
- * `.dial-kit-base-icon-button`, and an icon-only control stays on its own token
- * so a host can square the labelled buttons while leaving round icon buttons
- * round. All three tokens default to the same pill.
- */
-.dial-kit-base-button.dial-kit-base-button-small {
-  @apply rounded-control-sm;
-}
-
-.dial-kit-base-button.dial-kit-base-icon-button {
-  @apply rounded-control-icon;
-}
-
-/*
  * A `Button` given an `href` renders an `<a>`, which has no disabled state and
  * so never matches `:disabled`. It carries `aria-disabled` instead.
  *
@@ -538,4 +518,31 @@
   &:disabled {
     @apply dial-button-disable border-transparent text-controls-primary-disable bg-controls-disable;
   }
+}
+
+/*
+ * Per-size and icon-only corner radii. Position and specificity both matter
+ * here, so keep these two rules last in this file and keep them at a single
+ * class:
+ *
+ * - Last, because every variant class above pulls `.dial-kit-base-button` in
+ *   with `@apply` — its radius included — so a rule placed earlier would lose
+ *   to `.dial-kit-primary-solid-button` and friends.
+ * - Single-class, because a consumer that squares off a control with its own
+ *   `rounded-*` utility has to keep winning: those utilities are emitted after
+ *   this stylesheet, and a compound selector here would silently outrank them.
+ *   The navigation rail's icon buttons are the reference case.
+ *
+ * `Button` carries `.dial-kit-base-button-small` at `ElementSize.Small`;
+ * `IconButton` and `ToggleIconButton` always carry
+ * `.dial-kit-base-icon-button`, and an icon-only control keeps its own token so
+ * a host can square its labelled buttons while leaving round icon buttons
+ * round. All three tokens default to the same pill.
+ */
+.dial-kit-base-button-small {
+  @apply rounded-control-sm;
+}
+
+.dial-kit-base-icon-button {
+  @apply rounded-control-icon;
 }


### PR DESCRIPTION
## The regression

#845 routed the button radius through tokens and added two rules for the cases the base class cannot cover:

```scss
.dial-kit-base-button.dial-kit-base-button-small { … }
.dial-kit-base-button.dial-kit-base-icon-button { … }
```

Compound selectors were a mistake. At two classes they outrank any single-class `rounded-*` utility a consumer puts on a control, so **every icon button that a host or a sibling library had squared off with a class turned back into a circle**.

The visible case is the navigation rail: `@epam/ai-dial-navigation-panel` renders its items as `IconButton`s with `className={mergeClasses(styles.item, 'rounded-xl', …)}`. Before #845 that utility won over `.dial-kit-base-button` (one class each, consumer emitted later) and the items were 12px tiles. After #845 they became pills, with no code change on the consumer side.

## The fix

Both rules move to the end of `buttons.scss` and drop to a single class:

```scss
.dial-kit-base-button-small { @apply rounded-control-sm; }
.dial-kit-base-icon-button { @apply rounded-control-icon; }
```

Position and specificity each carry one requirement, and the comment in the file spells both out:

- **Last in the file** — every variant class above pulls `.dial-kit-base-button` in with `@apply`, radius included, so a rule placed earlier would lose to `.dial-kit-primary-solid-button` and friends. That was the reason for the compound selectors in the first place; source order solves it without the specificity side effect.
- **Single class** — a consumer's utilities are emitted after this stylesheet, so they win again, which is what they did before #845.

Net effect on the token feature: unchanged. `--radius-control`, `--radius-control-small` and `--radius-control-icon` still theme every 2.0 button, and still default to the pill.

## Testing

- `vitest run src/components/New/Button src/components/New/IconButton src/components/New/ToggleIconButton` — 82 tests / 5 files pass. The class-presence tests from #845 are untouched; CSS precedence is not observable in jsdom, so the built stylesheet was checked by hand instead:
  - `.dial-kit-base-button-small{border-radius:var(--radius-control-small,9999px)}` at byte 22265
  - `.dial-kit-base-icon-button{border-radius:var(--radius-control-icon,9999px)}` at byte 22342
  - the last variant class carrying an inlined radius sits at ~12600, so both rules are after every variant, and no compound `.dial-kit-base-button.dial-kit-base-*` selector remains.
- `eslint . --max-warnings 0` and `prettier --check` clean.
- README's theming section gained a sentence saying these are defaults a per-control `rounded-*` class still overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
