### PR TITLE
feat: Allow Textarea to resize in only one direction

### DIFF
--- a/src/components/New/Textarea/Textarea.spec.tsx
+++ b/src/components/New/Textarea/Textarea.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
-import { Textarea } from './Textarea';
+import { Textarea, TextareaResize } from './Textarea';
 
 describe('Dial UI Kit :: DialTextarea', () => {
   test('Should render successfully', () => {
@@ -39,5 +39,36 @@ describe('Dial UI Kit :: DialTextarea', () => {
     expect(Number(input.value)).toBe(1);
     fireEvent.change(input, { target: { value: 2 } });
     expect(value).toBe(2);
+  });
+
+  test('Should default to non-resizable', () => {
+    const res = render(<Textarea id="testArea" />);
+    const input = res.getByRole('textbox');
+    expect(input.className).toContain('resize-none');
+  });
+
+  test('Should resize both directions when resize is true', () => {
+    const res = render(<Textarea id="testArea" resize={true} />);
+    const input = res.getByRole('textbox');
+    expect(input.className).toContain('resize');
+    expect(input.className).not.toContain('resize-none');
+    expect(input.className).not.toContain('resize-x');
+    expect(input.className).not.toContain('resize-y');
+  });
+
+  test('Should resize only horizontally when resize is TextareaResize.Horizontal', () => {
+    const res = render(
+      <Textarea id="testArea" resize={TextareaResize.Horizontal} />,
+    );
+    const input = res.getByRole('textbox');
+    expect(input.className).toContain('resize-x');
+  });
+
+  test('Should resize only vertically when resize is TextareaResize.Vertical', () => {
+    const res = render(
+      <Textarea id="testArea" resize={TextareaResize.Vertical} />,
+    );
+    const input = res.getByRole('textbox');
+    expect(input.className).toContain('resize-y');
   });
 });

--- a/src/components/New/Textarea/Textarea.stories.tsx
+++ b/src/components/New/Textarea/Textarea.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { Textarea, type TextareaProps } from './Textarea';
+import { Textarea, TextareaResize, type TextareaProps } from './Textarea';
 
 const InteractiveTextarea = (args: TextareaProps) => {
   const [value, setValue] = useState(args.value || '');
@@ -59,6 +59,12 @@ const meta = {
       control: false,
       description: 'Callback function called when the textarea value changes',
     },
+    resize: {
+      control: 'select',
+      options: [true, false, ...Object.values(TextareaResize)],
+      description:
+        'Whether/how the textarea can be resized: a boolean (both directions or none) or a single-axis TextareaResize value',
+    },
   },
 } satisfies Meta<typeof Textarea>;
 
@@ -80,6 +86,26 @@ export const Resize: Story = {
     placeholder: 'Enter text...',
     value: 'This textarea can be resized',
     resize: true,
+  },
+};
+
+export const ResizeHorizontal: Story = {
+  render: InteractiveTextarea,
+  args: {
+    id: 'resize-horizontal-textarea',
+    placeholder: 'Enter text...',
+    value: 'This textarea can only be resized horizontally',
+    resize: TextareaResize.Horizontal,
+  },
+};
+
+export const ResizeVertical: Story = {
+  render: InteractiveTextarea,
+  args: {
+    id: 'resize-vertical-textarea',
+    placeholder: 'Enter text...',
+    value: 'This textarea can only be resized vertically',
+    resize: TextareaResize.Vertical,
   },
 };
 

--- a/src/components/New/Textarea/Textarea.tsx
+++ b/src/components/New/Textarea/Textarea.tsx
@@ -8,6 +8,13 @@ import { mergeClasses } from '@/utils/merge-classes';
 import { CaptionText, ErrorText } from '../CaptionText/CaptionText';
 import { Label, type LabelProps } from '../Label/Label';
 
+export enum TextareaResize {
+  None = 'none',
+  Both = 'both',
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
+
 export interface TextareaProps extends DetailedHTMLProps<
   Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'>,
   HTMLTextAreaElement
@@ -15,11 +22,26 @@ export interface TextareaProps extends DetailedHTMLProps<
   labelProps?: LabelProps;
   invalid?: boolean;
   containerClassName?: string;
-  resize?: boolean;
+  resize?: boolean | TextareaResize;
   error?: string;
   caption?: string;
   onChange?: (value: string) => void;
 }
+
+const resizeClassNames: Record<TextareaResize, string> = {
+  [TextareaResize.None]: 'resize-none',
+  [TextareaResize.Both]: 'resize',
+  [TextareaResize.Horizontal]: 'resize-x',
+  [TextareaResize.Vertical]: 'resize-y',
+};
+
+const resolveResizeClassName = (resize: boolean | TextareaResize): string => {
+  if (typeof resize === 'boolean') {
+    return resizeClassNames[resize ? TextareaResize.Both : TextareaResize.None];
+  }
+
+  return resizeClassNames[resize];
+};
 
 /**
  * A flexible textarea component with validation support and consistent styling
@@ -44,7 +66,7 @@ export interface TextareaProps extends DetailedHTMLProps<
  * @param [className=""] - Additional CSS classes to apply to the textarea element
  * @param [containerClassName=""] - Additional CSS classes to apply to the container div
  * @param [invalid=false] - Whether the textarea has validation errors (applies error styling)
- * @param [resize=false] - Whether the textarea has possibility to resize
+ * @param [resize=false] - Whether/how the textarea can be resized. Accepts a boolean (`true` = both directions, `false` = none) or a {@link TextareaResize} value for a single axis (`horizontal`/`vertical`)
  * @param [error] - Error message to display below the textarea (also adds error styling)
  * @param [caption] - Optional caption text to display below the textarea
  */
@@ -64,7 +86,7 @@ export const Textarea: FC<TextareaProps> = ({
     'dial-kit-textarea dial-kit-input px-3 py-2',
     props.invalid && 'dial-kit-input-error',
     props.disabled && 'dial-kit-input-disable',
-    resize ? 'resize' : 'resize-none',
+    resolveResizeClassName(resize),
     className,
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,7 +342,7 @@ export { InfoButton } from './components/New/InfoButton/InfoButton';
 export type { InfoButtonProps } from './components/New/InfoButton/InfoButton';
 export type { LabelProps } from './components/New/Label/Label';
 export { Label } from './components/New/Label/Label';
-export { Textarea } from './components/New/Textarea/Textarea';
+export { Textarea, TextareaResize } from './components/New/Textarea/Textarea';
 export { Input } from './components/New/Input/Input';
 export type { InputProps } from './components/New/Input/Input';
 export { PasswordInput } from './components/New/PasswordInput/PasswordInput';


### PR DESCRIPTION
**Description and UI changes:**

Textarea allowed resize in both directions or none. Added possibility to allow only vertical or horizontal resize.
<img width="1912" height="985" alt="image" src="https://github.com/user-attachments/assets/5ea88e1e-0591-40e2-a03f-a7fa39fa2332" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added