### PR TITLE
fix(2.0): let a host name the MarkdownEditor's textarea

### DIFF
--- a/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.spec.tsx
@@ -40,6 +40,36 @@ describe('Dial UI Kit :: MarkdownEditor', () => {
     ).toBeInTheDocument();
   });
 
+  test('Should name the textarea from ariaLabel', () => {
+    render(<MarkdownEditor value="" ariaLabel="Instructions" />);
+
+    expect(
+      screen.getByRole('textbox', { name: 'Instructions' }),
+    ).toBeInTheDocument();
+  });
+
+  test('Should let a visible label name the textarea through id', () => {
+    render(
+      <>
+        <label htmlFor="task-instructions">Instructions</label>
+        <MarkdownEditor value="" id="task-instructions" />
+      </>,
+    );
+
+    expect(screen.getByLabelText('Instructions')).toHaveAttribute(
+      'id',
+      'task-instructions',
+    );
+  });
+
+  test('Should leave the textarea unnamed when neither is given', () => {
+    render(<MarkdownEditor value="" />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).not.toHaveAttribute('aria-label');
+    expect(textarea).not.toHaveAttribute('id');
+  });
+
   test('Should render the formatting toolbar buttons', () => {
     render(<MarkdownEditor value="Hello" />);
 

--- a/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -45,6 +45,16 @@ const meta = {
       control: { type: 'text' },
       description: 'Placeholder text shown when the editor is empty',
     },
+    id: {
+      control: { type: 'text' },
+      description:
+        '`id` of the underlying textarea, so a visible `<label htmlFor>` can name it',
+    },
+    ariaLabel: {
+      control: { type: 'text' },
+      description:
+        'Accessible name for the underlying textarea, for cases with no visible label',
+    },
   },
   args: {
     value: '# Hello World\n\nThis is a **markdown** editor.',
@@ -133,4 +143,31 @@ This is a comprehensive markdown editor example.
 `,
   },
   render: renderWithContainer,
+};
+
+export const Labelled: Story = {
+  args: {
+    id: 'markdown-editor-instructions',
+    value: '',
+    placeholder: 'Describe what the task should do…',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The editor renders a plain textarea, which needs a name of its own — surrounding heading text is not associated with it. Pair `id` with a visible `<label htmlFor>`, as here, or pass `ariaLabel` where no visible label exists.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-[600px]">
+      <label
+        htmlFor="markdown-editor-instructions"
+        className="dial-body-semi-text mb-1 block text-primary"
+      >
+        Instructions
+      </label>
+      <MarkdownEditor {...args} />
+    </div>
+  ),
 };

--- a/src/components/New/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/New/MarkdownEditor/MarkdownEditor.tsx
@@ -17,6 +17,10 @@ export interface MarkdownEditorProps {
   placeholder?: string;
   /** Initial edit/live/preview mode; the toolbar lets the user switch it afterwards. */
   defaultPreview?: PreviewType;
+  /** `id` of the underlying textarea, so a visible `<label htmlFor>` can name it. */
+  id?: string;
+  /** Accessible name for the underlying textarea. Use it only where no visible label exists to pair with `id`. */
+  ariaLabel?: string;
 }
 
 /**
@@ -37,6 +41,8 @@ export interface MarkdownEditorProps {
  * @param [className] - Additional CSS classes for the container
  * @param [placeholder] - Placeholder text shown when the editor is empty
  * @param [defaultPreview='edit'] - Initial edit/live/preview mode
+ * @param [id] - `id` of the underlying textarea, for a visible `<label htmlFor>`
+ * @param [ariaLabel] - Accessible name for the underlying textarea
  */
 export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   value,
@@ -46,6 +52,8 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   className,
   placeholder,
   defaultPreview = 'edit',
+  id,
+  ariaLabel,
 }) => {
   const commands = useMemo(() => getMarkdownFormattingCommands(), []);
   const extraCommands = useMemo(() => getMarkdownExtraCommands(), []);
@@ -62,7 +70,12 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
         preview={defaultPreview}
         commands={commands}
         extraCommands={extraCommands}
-        textareaProps={{ placeholder }}
+        /*
+         * The textarea is the control a user actually operates, so its name has
+         * to live on the element itself: a heading or a label rendered next to
+         * the editor names nothing that assistive tech can associate with it.
+         */
+        textareaProps={{ placeholder, id, 'aria-label': ariaLabel }}
       />
     </div>
   );


### PR DESCRIPTION
`MarkdownEditor` renders a bare `<textarea class="w-md-editor-text-input">` that a consumer has no way to name. `textareaProps` is set internally and carries only `placeholder`, and the component accepts no `id` or `aria-label`. A heading or a label rendered above the editor names nothing the browser associates with the control, so the accessibility tree reports an unnamed textbox — a WCAG 2.1 **4.1.2 Name, Role, Value** failure that no host can work around from the outside.

Found by QA against AI DIAL Chat (scenario TC-TASK-0045, the Instructions field of the create-task form). The same gap applies to every other surface embedding this editor.

## What changed

Two optional props now reach the textarea:

- **`id`** — so a visible `<label htmlFor>` can own the name. This is the preferred pairing wherever the form already shows a label, which is the common case; it satisfies 4.1.2 and 1.3.1 together and keeps the label clickable.
- **`ariaLabel`** — for surfaces that have no visible label to point at.

Both default to `undefined`, so an editor that passes neither renders exactly as it does today.

## Compatibility

Additive and non-breaking: no prop renamed, removed or re-typed, and no change to the rendered markup when the new props are omitted. No CHANGELOG entry or migration guide is required under the breaking-change policy in `AGENTS.md`.

## Test plan

- Three tests added: `ariaLabel` names the textbox; `id` lets a visible `<label htmlFor>` name it; neither prop leaves the textarea without `aria-label` or `id`.
- A `Labelled` story demonstrates the `id` + visible label pairing, with `id` and `ariaLabel` documented in `argTypes`.
- `npx vitest run` green across the package (2410 tests, 2 skipped).
- Prettier and ESLint clean on the changed files.

Note on `npm run typecheck`: this branch was prepared in a worktree whose `node_modules` came from a sibling branch with a different lockfile, which produces 56 pre-existing errors in `use-trigger-view-create-folder.spec.tsx` — identical with and without this change, and unrelated to it. Worth a clean run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
