### PR TITLE
fix: Two small visual fixes

### DIFF
--- a/src/components/New/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/New/SegmentedControl/SegmentedControl.stories.tsx
@@ -134,6 +134,17 @@ export const LabelsOnly: Story = {
   ),
 };
 
+const LONG_LABEL_ITEMS = VIEW_ITEMS.map((item) =>
+  item.value === 'grid'
+    ? { ...item, label: 'Grid view with a very long segment label' }
+    : item,
+);
+
+export const LongLabel: Story = {
+  args: { items: LONG_LABEL_ITEMS, value: 'list', onChange: () => {} },
+  render: () => <Interactive items={LONG_LABEL_ITEMS} initialValue="list" />,
+};
+
 export const Disabled: Story = {
   args: {
     items: VIEW_ITEMS,

--- a/src/components/New/SegmentedControl/constants.ts
+++ b/src/components/New/SegmentedControl/constants.ts
@@ -13,7 +13,7 @@ export const containerClassName =
   'inline-flex w-fit items-center gap-1 rounded-full border border-tertiary bg-layer-sunken p-[3px]';
 
 export const segmentClassName =
-  'flex h-8 min-w-8 flex-1 shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-full px-4 dial-small-text transition-colors duration-200 outline-offset-0 focus-visible:outline focus-visible:outline-focus';
+  'flex h-8 min-w-8 grow shrink-0 basis-auto items-center justify-center gap-2 whitespace-nowrap rounded-full px-4 dial-small-text transition-colors duration-200 outline-offset-0 focus-visible:outline focus-visible:outline-focus';
 
 /** Selected lifts off the track on a raised surface and keeps the accent at rest. */
 export const segmentSelectedClassName = 'bg-layer-raised text-accent shadow-xs';

--- a/src/components/New/Select/MultiSelectTags.tsx
+++ b/src/components/New/Select/MultiSelectTags.tsx
@@ -39,7 +39,7 @@ export const MultiSelectTags: FC<MultiSelectTagsProps> = ({
             // `Tag` wraps the icon in its own `aria-hidden` box, so it needs no
             // wrapper of its own here.
             icon={option?.icon}
-            className="max-w-full"
+            className="max-w-full border border-tertiary"
           />
         );
       })}


### PR DESCRIPTION
**Description and UI changes:**

before
<img width="539" height="142" alt="image" src="https://github.com/user-attachments/assets/2bc04efd-de24-437c-8ed5-f38e436e5704" />
<img width="697" height="129" alt="image" src="https://github.com/user-attachments/assets/1c0dc217-6d89-4bcb-a4c5-43b613fb8c3d" />


after
<img width="602" height="166" alt="image" src="https://github.com/user-attachments/assets/8a506fdb-18a1-4e4a-8ae4-64b214b07cfe" />

<img width="1326" height="295" alt="image" src="https://github.com/user-attachments/assets/8f5f9af3-2f96-4156-8b0c-2c72affba0b9" />


Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added