### PR TITLE
ci(deps): bump epam/ai-dial-ci from 4.10.0 to 4.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,8 @@ updates:
       day: "wednesday"
       time: "09:00"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "ci"
+      include: scope
     groups:
       ai-dial-ci:
         applies-to: version-updates

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -15,6 +15,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.11.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/node_pr.yml@4.11.0
     secrets: inherit
     with:
       node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.10.0
+    uses: epam/ai-dial-ci/.github/workflows/node_release.yml@4.11.0
     with:
       promote: true # HACK: skip RC phase, project does not require stabilization period before releasing stable versions
       docker-build-enabled: false

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open'
     steps:
       - name: Slash Command Dispatch
         id: scd

--- a/.ort.yml
+++ b/.ort.yml
@@ -3,8 +3,14 @@ analyzer:
   skip_excluded: true
 excludes:
   paths:
-    - pattern: 'fixtures/**'
-      reason: 'TEST_OF'
+    - pattern: "package-lock.json"
+      reason: "BUILD_TOOL_OF"
+    - pattern: "fixtures/**"
+      reason: "TEST_OF"
       comment: >-
         Consumer fixtures verify the packed distribution and are not part of
         the published package.
+  scopes:
+    - pattern: "devDependencies"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Packages for development only."

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,8 +19,9 @@ package-lock.json
 
 # Config files
 .prettierrc
-
 .github
+.ort.yml
+
 CONTRIBUTING.md
 README.md
 SECURITY.md


### PR DESCRIPTION
### Description of changes

- bump epam/ai-dial-ci from `4.10.0` to `4.11.0`
- align workflows with recommended configuration; this delivers minor fixes
- drop ORT resolutions in favor of shared curations in [ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config/)