### PR TITLE
fix: Don't close Select on interactive tooltip hover

### DIFF
--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -1471,3 +1471,148 @@ describe('Dial UI Kit :: Dropdown — marked items', () => {
     expect(screen.getAllByRole('menu')).toHaveLength(2);
   });
 });
+
+describe('Dial UI Kit :: Dropdown — interactiveTooltip', () => {
+  test('opens next to a top-level item on hover', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'web-search',
+            label: 'Web Search',
+            interactiveTooltip: { content: 'More about Web Search' },
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    await user.hover(screen.getByRole('menuitem', { name: 'Web Search' }));
+
+    expect(
+      await screen.findByText('More about Web Search'),
+    ).toBeInTheDocument();
+  });
+
+  test('does not render a panel for an item without interactiveTooltip', () => {
+    render(
+      <Dropdown items={items}>
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    expect(
+      screen.queryByText('More about Web Search'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('opens next to a sub-menu child item on hover', async () => {
+    const user = userEvent.setup();
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'more',
+            label: 'More actions',
+            children: [
+              {
+                key: 'archive',
+                label: 'Archive',
+                interactiveTooltip: { content: 'More about Archive' },
+              },
+            ],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    await user.hover(screen.getByRole('menuitem', { name: /more actions/i }));
+    await user.hover(await screen.findByRole('menuitem', { name: 'Archive' }));
+
+    expect(
+      await screen.findByText('More about Archive'),
+    ).toBeInTheDocument();
+  });
+
+  test('lets a control inside the panel be clicked without firing the item or closing the menu', async () => {
+    const user = userEvent.setup();
+    const onItemClick = vi.fn();
+    const onDetailsClick = vi.fn();
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'web-search',
+            label: 'Web Search',
+            onClick: onItemClick,
+            interactiveTooltip: {
+              content: <button onClick={onDetailsClick}>View details</button>,
+            },
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    await user.hover(screen.getByRole('menuitem', { name: 'Web Search' }));
+    // `fireEvent.click` rather than `user.click`: the latter moves the
+    // pointer there first, and jsdom gives every element a zero-sized rect
+    // at the origin, which breaks the real geometry `safePolygon` needs to
+    // tell the move was still headed into the panel.
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'View details' }),
+    );
+
+    expect(onDetailsClick).toHaveBeenCalledTimes(1);
+    expect(onItemClick).not.toHaveBeenCalled();
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  test('a control inside a panel nested in a sub-menu can be clicked without closing the sub-menu', async () => {
+    const user = userEvent.setup();
+    const onDetailsClick = vi.fn();
+    render(
+      <Dropdown
+        items={[
+          {
+            key: 'more',
+            label: 'More actions',
+            children: [
+              {
+                key: 'archive',
+                label: 'Archive',
+                interactiveTooltip: {
+                  content: (
+                    <button onClick={onDetailsClick}>View details</button>
+                  ),
+                },
+              },
+            ],
+          },
+        ]}
+      >
+        <button type="button">Open</button>
+      </Dropdown>,
+    );
+    openByClick();
+
+    await user.hover(screen.getByRole('menuitem', { name: /more actions/i }));
+    await user.hover(await screen.findByRole('menuitem', { name: 'Archive' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'View details' }),
+    );
+
+    expect(onDetailsClick).toHaveBeenCalledTimes(1);
+    // Both the root menu and the sub-menu are still open.
+    expect(screen.getAllByRole('menu')).toHaveLength(2);
+  });
+});

--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -1505,9 +1505,7 @@ describe('Dial UI Kit :: Dropdown — interactiveTooltip', () => {
     );
     openByClick();
 
-    expect(
-      screen.queryByText('More about Web Search'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('More about Web Search')).not.toBeInTheDocument();
   });
 
   test('opens next to a sub-menu child item on hover', async () => {
@@ -1536,9 +1534,7 @@ describe('Dial UI Kit :: Dropdown — interactiveTooltip', () => {
     await user.hover(screen.getByRole('menuitem', { name: /more actions/i }));
     await user.hover(await screen.findByRole('menuitem', { name: 'Archive' }));
 
-    expect(
-      await screen.findByText('More about Archive'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('More about Archive')).toBeInTheDocument();
   });
 
   test('lets a control inside the panel be clicked without firing the item or closing the menu', async () => {

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tabler/icons-react';
 import { useRef, useState, type ReactNode } from 'react';
 
+import { Button } from '@/components/New/Button/Button';
 import {
   NeutralButton,
   PrimaryButton,
@@ -24,6 +25,7 @@ import { DangerIconButton } from '@/components/New/IconButton/IconButtonWrappers
 import { Tooltip } from '@/components/New/Tooltip/Tooltip';
 import { DIAL_ICON_SIZE } from '@/constants/icon';
 import { type DropdownItem } from '@/models/dropdown';
+import { ButtonAppearance, ButtonVariant } from '@/types/button';
 import { DropdownItemType, DropdownTrigger } from '@/types/dropdown';
 import { MenuItemMark } from '@/types/menu-item';
 import { ElementSize } from '@/types/size';
@@ -962,5 +964,83 @@ export const MarkedItems: Story = {
     };
 
     return <MarkedExample />;
+  },
+};
+
+const viewDetailsButton = (
+  <Button
+    variant={ButtonVariant.Primary}
+    appearance={ButtonAppearance.Link}
+    label="View details"
+  />
+);
+
+/**
+ * An item's `interactiveTooltip` opens an {@link InteractiveTooltip} next to
+ * its row on hover or focus. Unlike a plain `label`, its content can hold
+ * controls of its own — hover "Web Search" (or tab to it) and the panel stays
+ * open long enough to reach the "View details" link inside it, and it will
+ * not close the menu underneath it while you do.
+ */
+export const WithInteractiveTooltip: Story = {
+  name: 'Item with an interactive tooltip',
+  args: {
+    placement: 'bottom-start',
+    items: [
+      {
+        key: 'web-search',
+        label: 'Web Search',
+        interactiveTooltip: {
+          content: (
+            <div className="flex flex-col gap-3">
+              <p>
+                Looks things up on the web instead of answering from memory.
+                Useful for anything that may have changed since training —
+                current events, prices, recent releases.
+              </p>
+              {viewDetailsButton}
+            </div>
+          ),
+        },
+      },
+      { key: 'file-reader', label: 'file-reader' },
+      { key: 'skill-creator', label: 'skill-creator' },
+    ],
+  },
+};
+
+/**
+ * The same `interactiveTooltip` field works on a sub-menu's own items, opened
+ * next to a child row instead of a top-level one.
+ */
+export const WithInteractiveTooltipInSubMenu: Story = {
+  name: 'Interactive tooltip on a sub-menu item',
+  args: {
+    placement: 'bottom-start',
+    items: [
+      { key: 'file-reader', label: 'file-reader' },
+      {
+        key: 'productivity',
+        label: 'Productivity',
+        children: [
+          {
+            key: 'good-morning-breakfast',
+            label: 'good-morning-breakfast',
+            interactiveTooltip: {
+              content: (
+                <div className="flex flex-col gap-3">
+                  <p>
+                    Puts together a breakfast plan and a morning briefing before
+                    you ask for one.
+                  </p>
+                  {viewDetailsButton}
+                </div>
+              ),
+            },
+          },
+          { key: 'skill-creator', label: 'skill-creator' },
+        ],
+      },
+    ],
   },
 };

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -1,15 +1,19 @@
 import {
   FloatingFocusManager,
+  FloatingNode,
   FloatingPortal,
+  FloatingTree,
   autoPlacement,
   autoUpdate,
   flip,
   offset,
+  safePolygon,
   shift,
   size as fuiSize,
   useClick,
   useDismiss,
   useFloating,
+  useFloatingNodeId,
   useHover,
   useInteractions,
   useRole,
@@ -20,6 +24,7 @@ import type {
   ReferenceElement,
 } from '@floating-ui/react';
 import {
+  Fragment,
   useCallback,
   useEffect,
   useId,
@@ -33,6 +38,7 @@ import {
   type RefObject,
 } from 'react';
 
+import { InteractiveTooltip } from '@/components/New/InteractiveTooltip/InteractiveTooltip';
 import { DropdownTrigger, DropdownItemType } from '@/types/dropdown';
 import { MenuItemMark } from '@/types/menu-item';
 
@@ -237,8 +243,17 @@ export const Dropdown: FC<DropdownProps> = ({
 
   const listId = useId();
   const useAuto = placement === undefined;
+  /*
+   * Registered with the `FloatingTree` this component provides below, so a
+   * nested `InteractiveTooltip` (on an item or submenu item) is recognized as
+   * this menu's own floating descendant rather than something outside it —
+   * without this, hovering into the tooltip's panel or clicking a control
+   * inside it would read as "left"/"outside" and close the menu underneath it.
+   */
+  const nodeId = useFloatingNodeId();
 
   const { refs, floatingStyles, context } = useFloating({
+    nodeId,
     placement,
     open: isOpen,
     onOpenChange: setOpen,
@@ -291,6 +306,7 @@ export const Dropdown: FC<DropdownProps> = ({
     enabled: trigger.includes(DropdownTrigger.Hover) && !disabled,
     move: false,
     restMs: 40,
+    handleClose: safePolygon(),
     delay: { open: 80, close: 80 },
   });
 
@@ -473,9 +489,8 @@ export const Dropdown: FC<DropdownProps> = ({
             const mark = resolveItemMark(it);
             const role = getItemRole(it);
 
-            return (
+            const row = (
               <MenuItem
-                key={it.key}
                 role={role}
                 aria-checked={role === 'menuitem' ? undefined : !!it.checked}
                 aria-current={
@@ -496,6 +511,23 @@ export const Dropdown: FC<DropdownProps> = ({
               >
                 {it.renderItem?.(it)}
               </MenuItem>
+            );
+
+            return (
+              <Fragment key={it.key}>
+                {it.interactiveTooltip ? (
+                  <InteractiveTooltip
+                    asChild
+                    placement={it.interactiveTooltip.placement}
+                    content={it.interactiveTooltip.content}
+                    contentClassName={it.interactiveTooltip.contentClassName}
+                  >
+                    {row}
+                  </InteractiveTooltip>
+                ) : (
+                  row
+                )}
+              </Fragment>
             );
           })}
         </div>
@@ -548,62 +580,64 @@ export const Dropdown: FC<DropdownProps> = ({
   }, [isOpen, refs.reference, setOpen]);
 
   return (
-    <>
-      <span
-        ref={refs.setReference}
-        className={mergeClasses(
-          dropdownBaseClassName,
-          disabled && '!cursor-not-allowed opacity-75',
-          className,
-        )}
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        aria-controls={listId}
-        {...referenceProps}
-      >
-        {children}
-      </span>
+    <FloatingTree>
+      <FloatingNode id={nodeId}>
+        <span
+          ref={refs.setReference}
+          className={mergeClasses(
+            dropdownBaseClassName,
+            disabled && '!cursor-not-allowed opacity-75',
+            className,
+          )}
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          aria-controls={listId}
+          {...referenceProps}
+        >
+          {children}
+        </span>
 
-      {isOpen && (
-        <FloatingPortal>
-          <FloatingFocusManager
-            context={context}
-            modal={false}
-            /* 0 puts focus on the overlay's first control, falling back to the
-               overlay itself when it holds none; -1 leaves focus where it is,
-               which is only right for a menu the pointer opened on hover. */
-            initialFocus={shouldFocusOverlay ? 0 : -1}
-            returnFocus
-          >
-            <div
-              id={listId}
-              ref={refs.setFloating}
-              style={floatingStyles}
-              className={mergeClasses(
-                dropdownListBaseClassName,
-                !matchReferenceWidth && 'w-max',
-                'overflow-auto',
-                themeScope,
-                listClassName,
-              )}
-              {...getFloatingProps({ onKeyDown: handleFloatingKeyDown })}
+        {isOpen && (
+          <FloatingPortal>
+            <FloatingFocusManager
+              context={context}
+              modal={false}
+              /* 0 puts focus on the overlay's first control, falling back to the
+                 overlay itself when it holds none; -1 leaves focus where it is,
+                 which is only right for a menu the pointer opened on hover. */
+              initialFocus={shouldFocusOverlay ? 0 : -1}
+              returnFocus
             >
-              {closable && (
-                <div className="flex items-center justify-between px-2 pt-2">
-                  <CloseButton
-                    ariaLabel="Close dropdown"
-                    onClose={(e) => {
-                      onClose?.(e);
-                      setOpen(false);
-                    }}
-                  />
-                </div>
-              )}
-              {overlayContent}
-            </div>
-          </FloatingFocusManager>
-        </FloatingPortal>
-      )}
-    </>
+              <div
+                id={listId}
+                ref={refs.setFloating}
+                style={floatingStyles}
+                className={mergeClasses(
+                  dropdownListBaseClassName,
+                  !matchReferenceWidth && 'w-max',
+                  'overflow-auto',
+                  themeScope,
+                  listClassName,
+                )}
+                {...getFloatingProps({ onKeyDown: handleFloatingKeyDown })}
+              >
+                {closable && (
+                  <div className="flex items-center justify-between px-2 pt-2">
+                    <CloseButton
+                      ariaLabel="Close dropdown"
+                      onClose={(e) => {
+                        onClose?.(e);
+                        setOpen(false);
+                      }}
+                    />
+                  </div>
+                )}
+                {overlayContent}
+              </div>
+            </FloatingFocusManager>
+          </FloatingPortal>
+        )}
+      </FloatingNode>
+    </FloatingTree>
   );
 };

--- a/src/components/New/Dropdown/DropdownSubMenuItem.tsx
+++ b/src/components/New/Dropdown/DropdownSubMenuItem.tsx
@@ -1,5 +1,7 @@
-import { useCallback, type FC, type MouseEvent } from 'react';
+import { FloatingNode } from '@floating-ui/react';
+import { Fragment, useCallback, type FC, type MouseEvent } from 'react';
 
+import { InteractiveTooltip } from '@/components/New/InteractiveTooltip/InteractiveTooltip';
 import { MenuItem } from '@/components/New/MenuItem/MenuItem';
 import { type DropdownItem } from '@/models/dropdown';
 import { MenuItemMark } from '@/types/menu-item';
@@ -25,6 +27,7 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
 }) => {
   const {
     isOpen,
+    nodeId,
     refs,
     floatingStyles,
     context,
@@ -43,23 +46,38 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
     [onRootClose],
   );
 
+  const trigger = (
+    <MenuItem
+      ref={refs.setReference}
+      role="menuitem"
+      aria-haspopup="menu"
+      aria-expanded={isOpen}
+      aria-disabled={!!item.disabled}
+      disabled={item.disabled}
+      icon={item.icon}
+      label={item.label}
+      trailing={submenuCaretIcon}
+      className={item.className}
+      {...getReferenceProps()}
+    >
+      {item.renderItem?.(item)}
+    </MenuItem>
+  );
+
   return (
-    <>
-      <MenuItem
-        ref={refs.setReference}
-        role="menuitem"
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        aria-disabled={!!item.disabled}
-        disabled={item.disabled}
-        icon={item.icon}
-        label={item.label}
-        trailing={submenuCaretIcon}
-        className={item.className}
-        {...getReferenceProps()}
-      >
-        {item.renderItem?.(item)}
-      </MenuItem>
+    <FloatingNode id={nodeId}>
+      {item.interactiveTooltip ? (
+        <InteractiveTooltip
+          asChild
+          placement={item.interactiveTooltip.placement}
+          content={item.interactiveTooltip.content}
+          contentClassName={item.interactiveTooltip.contentClassName}
+        >
+          {trigger}
+        </InteractiveTooltip>
+      ) : (
+        trigger
+      )}
 
       {isOpen && (
         <SubMenuPanel
@@ -82,9 +100,8 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
               {item.children!.map((child) => {
                 const role = getItemRole(child);
 
-                return (
+                const childRow = (
                   <MenuItem
-                    key={child.key}
                     role={role}
                     aria-checked={
                       role === 'menuitem' ? undefined : !!child.checked
@@ -109,6 +126,25 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
                     {child.renderItem?.(child)}
                   </MenuItem>
                 );
+
+                return (
+                  <Fragment key={child.key}>
+                    {child.interactiveTooltip ? (
+                      <InteractiveTooltip
+                        asChild
+                        placement={child.interactiveTooltip.placement}
+                        content={child.interactiveTooltip.content}
+                        contentClassName={
+                          child.interactiveTooltip.contentClassName
+                        }
+                      >
+                        {childRow}
+                      </InteractiveTooltip>
+                    ) : (
+                      childRow
+                    )}
+                  </Fragment>
+                );
               })}
 
               {item.menuFooter &&
@@ -119,6 +155,6 @@ export const DropdownSubMenuItem: FC<DropdownSubMenuItemProps> = ({
           )}
         </SubMenuPanel>
       )}
-    </>
+    </FloatingNode>
   );
 };

--- a/src/components/New/InteractiveTooltip/InteractiveTooltip.tsx
+++ b/src/components/New/InteractiveTooltip/InteractiveTooltip.tsx
@@ -8,6 +8,7 @@ import {
   shift,
   useDismiss,
   useFloating,
+  useFloatingNodeId,
   useFocus,
   useHover,
   useInteractions,
@@ -129,7 +130,17 @@ export const InteractiveTooltip: FC<InteractiveTooltipProps> = ({
   const open = controlledOpen ?? uncontrolledOpen;
   const setOpen = setControlledOpen ?? setUncontrolledOpen;
 
+  /*
+   * Registers this panel as a node of the ancestor `FloatingTree` (when one
+   * wraps a Dropdown/Select the trigger sits inside), so that trigger's own
+   * hover/dismiss logic knows this panel is a nested floating element rather
+   * than something entirely outside it — see `Dropdown` and
+   * `useSubMenuFloating`.
+   */
+  const nodeId = useFloatingNodeId();
+
   const { refs, floatingStyles, context } = useFloating({
+    nodeId,
     placement,
     open,
     onOpenChange: setOpen,

--- a/src/components/New/Select/SelectSubMenuItem.tsx
+++ b/src/components/New/Select/SelectSubMenuItem.tsx
@@ -1,3 +1,4 @@
+import { FloatingNode } from '@floating-ui/react';
 import { Fragment, type FC } from 'react';
 
 import { InteractiveTooltip } from '@/components/New/InteractiveTooltip/InteractiveTooltip';
@@ -32,6 +33,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
 }) => {
   const {
     isOpen,
+    nodeId,
     refs,
     floatingStyles,
     context,
@@ -66,7 +68,7 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
   );
 
   return (
-    <>
+    <FloatingNode id={nodeId}>
       {opt.interactiveTooltip ? (
         <InteractiveTooltip
           asChild
@@ -125,6 +127,6 @@ export const SelectSubMenuItem: FC<SelectSubMenuItemProps> = ({
           })}
         </SubMenuPanel>
       )}
-    </>
+    </FloatingNode>
   );
 };

--- a/src/models/dropdown.ts
+++ b/src/models/dropdown.ts
@@ -1,5 +1,6 @@
 import type { DropdownItemType } from '@/types/dropdown';
 import type { MenuItemMark } from '@/types/menu-item';
+import type { TooltipPlacement } from '@/types/tooltip';
 import type { ReactNode, MouseEvent } from 'react';
 
 export interface DropdownSubMenuHoverOptions {
@@ -7,6 +8,23 @@ export interface DropdownSubMenuHoverOptions {
   delay?: number | { open?: number; close?: number };
   /** Whether pointer movement (not just rest) can trigger the hover open. Defaults to `false`. */
   move?: boolean;
+}
+
+/**
+ * Data for the interactive panel {@link Dropdown} anchors to an item's row —
+ * unlike a plain tooltip, its content can hold controls of its own (a "View
+ * details" link, for example), which is why it takes a full node rather than
+ * a string.
+ */
+export interface DropdownItemInteractiveTooltip {
+  content: ReactNode;
+  /** @default TooltipPlacement.Right */
+  placement?: TooltipPlacement;
+  /**
+   * Additional CSS classes for the panel — e.g. a wider `max-w-*` for content
+   * that does not fit the default 320px.
+   */
+  contentClassName?: string;
 }
 
 export interface DropdownItem {
@@ -62,4 +80,10 @@ export interface DropdownItem {
   renderItem?: (item: DropdownItem) => ReactNode;
   /** Overrides the default hover-open behavior of this item's submenu. */
   subMenuHoverOptions?: DropdownSubMenuHoverOptions;
+  /**
+   * Anchors an {@link InteractiveTooltip} to this item's row, open on hover
+   * or focus. Use it for content too rich for a plain label — an explanation
+   * with its own link or button.
+   */
+  interactiveTooltip?: DropdownItemInteractiveTooltip;
 }

--- a/src/utils/sub-menu-floating.tsx
+++ b/src/utils/sub-menu-floating.tsx
@@ -4,10 +4,12 @@ import {
   autoUpdate,
   flip,
   offset,
+  safePolygon,
   shift,
   useClick,
   useDismiss,
   useFloating,
+  useFloatingNodeId,
   useHover,
   useInteractions,
   useRole,
@@ -37,8 +39,10 @@ export function useSubMenuFloating(
   hoverOptions?: SubMenuHoverOptions,
 ) {
   const [isOpen, setIsOpen] = useState(false);
+  const nodeId = useFloatingNodeId();
 
   const { refs, floatingStyles, context } = useFloating({
+    nodeId,
     placement: 'right-start',
     open: isOpen,
     onOpenChange: setIsOpen,
@@ -53,6 +57,11 @@ export function useSubMenuFloating(
   const hover = useHover(context, {
     enabled: !disabled,
     move: hoverOptions?.move ?? false,
+    /* Lets the pointer travel into a nested floating element — an
+       InteractiveTooltip anchored to this menu's trigger or a child row —
+       without closing this menu; requires the `FloatingTree`/`FloatingNode`
+       wiring the trigger's own `nodeId` connects to. */
+    handleClose: safePolygon(),
     delay: hoverOptions?.delay ?? { open: 80, close: 80 },
   });
   const click = useClick(context, { enabled: !disabled });
@@ -70,6 +79,7 @@ export function useSubMenuFloating(
 
   return {
     isOpen,
+    nodeId,
     refs,
     floatingStyles,
     context,


### PR DESCRIPTION
**Description and UI changes:**

Two changes: 
1) Fixed problem that Select closed when interactive tooltip was hovered
2) Added interactive tooltip support for Dropdown as well
<img width="1095" height="494" alt="image" src="https://github.com/user-attachments/assets/a28faa4b-7fdb-4722-8581-e406bbcb59f1" />

Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added