### PR TITLE
feat: Support controlled focus in dropdown

### DIFF
--- a/src/components/New/Dropdown/Dropdown.spec.tsx
+++ b/src/components/New/Dropdown/Dropdown.spec.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -1072,6 +1073,50 @@ describe('Dial UI Kit :: Dropdown — overlay keyboard focus', () => {
     expect(await screen.findByRole('menu')).toBeInTheDocument();
 
     expect(screen.getByRole('menuitem', { name: 'Profile' })).not.toHaveFocus();
+  });
+
+  test('initialFocus=-1 keeps focus in a controlled typeahead trigger, and Escape still dismisses', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const Harness = () => {
+      const [open, setOpen] = useState(false);
+      return (
+        <Dropdown
+          open={open}
+          trigger={[]}
+          initialFocus={-1}
+          onOpenChange={(next: boolean) => {
+            setOpen(next);
+            onOpenChange(next);
+          }}
+          renderOverlay={() => <button type="button">Copy link</button>}
+        >
+          <textarea
+            aria-label="command input"
+            onChange={(e) => setOpen(e.target.value.startsWith('/'))}
+          />
+        </Dropdown>
+      );
+    };
+
+    render(<Harness />);
+
+    const textarea = screen.getByLabelText('command input');
+    textarea.focus();
+    await user.type(textarea, '/');
+
+    expect(
+      await screen.findByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+    expect(textarea).toHaveFocus();
+
+    await user.type(textarea, 'help');
+    expect(textarea).toHaveValue('/help');
+    expect(textarea).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   test('walks the items with the arrow keys, wrapping at both ends', async () => {

--- a/src/components/New/Dropdown/Dropdown.stories.tsx
+++ b/src/components/New/Dropdown/Dropdown.stories.tsx
@@ -151,6 +151,7 @@ const meta = {
     menuFooter: { control: false },
     renderOverlay: { control: false },
     children: { control: false },
+    initialFocus: { control: false },
   },
   args: {
     trigger: [DropdownTrigger.Click],
@@ -213,6 +214,83 @@ const ControlledExample = (args: DropdownProps) => {
 export const ControlledOpen: Story = {
   args: {},
   render: ControlledExample,
+};
+
+const TYPEAHEAD_COMMANDS = [
+  { key: 'image', label: '/image — Generate an image' },
+  { key: 'code', label: '/code — Write or explain code' },
+  { key: 'summarize', label: '/summarize — Summarize the conversation' },
+];
+
+const TypeaheadExample = (args: DropdownProps) => {
+  const [value, setValue] = useState('');
+  const [open, setOpen] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const query = value.startsWith('/') ? value.slice(1).toLowerCase() : null;
+  const matches =
+    query !== null
+      ? TYPEAHEAD_COMMANDS.filter((c) => c.key.startsWith(query))
+      : [];
+
+  return (
+    <div className="w-[360px]">
+      <Dropdown
+        {...args}
+        trigger={[]}
+        open={open && matches.length > 0}
+        onOpenChange={setOpen}
+        initialFocus={-1}
+        outsidePressIgnoreRef={textareaRef}
+        matchReferenceWidth
+        renderOverlay={() => (
+          <div role="none" className="py-1">
+            {matches.map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                role="menuitem"
+                className={dropdownItemBaseClassName}
+                onClick={() => {
+                  setValue(`/${c.key} `);
+                  setOpen(false);
+                  textareaRef.current?.focus();
+                }}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+        )}
+      >
+        <textarea
+          ref={textareaRef}
+          aria-label="Message"
+          className="w-full resize-none rounded border border-secondary bg-layer-1 p-2 text-primary outline-none"
+          rows={3}
+          placeholder="Type / for commands…"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setOpen(e.target.value.startsWith('/'));
+          }}
+        />
+      </Dropdown>
+    </div>
+  );
+};
+
+/**
+ * `initialFocus={-1}` keeps focus in the trigger instead of jumping into the
+ * overlay on open — the shape a `/`-command menu needs: the host opens the
+ * dropdown from a text field (here, typing `/`) and the caret must stay put
+ * so the user can keep typing to filter the list. Rows are still reachable
+ * via Tab, and Escape/outside-press still dismiss as usual.
+ */
+export const TypeaheadCommandMenu: Story = {
+  name: 'Typeahead / command menu (initialFocus=-1)',
+  args: {},
+  render: TypeaheadExample,
 };
 
 export const AllPlacements: Story = {

--- a/src/components/New/Dropdown/Dropdown.tsx
+++ b/src/components/New/Dropdown/Dropdown.tsx
@@ -82,6 +82,15 @@ export interface DropdownProps {
   anchorToMouse?: boolean;
   matchReferenceWidth?: boolean;
   maxDropdownHeight?: number | null;
+  /**
+   * Initial focus inside the overlay on open, forwarded to
+   * `FloatingFocusManager`'s `initialFocus`. `0` focuses the first tabbable
+   * element (menu behavior); `-1` leaves focus where it is (typeahead
+   * behavior, e.g. a `/`-command menu opened from a textarea). When omitted,
+   * defaults to menu behavior for click/context opens and to `-1` for hover
+   * opens, matching the pre-existing behavior.
+   */
+  initialFocus?: 0 | -1 | RefObject<HTMLElement | null>;
 }
 
 /**
@@ -188,6 +197,7 @@ const getRefWidth = (el: ReferenceElement): number => {
  * @param [anchorToMouse=false] - Whether to anchor the dropdown to the mouse position
  * @param [matchReferenceWidth=true] - Whether to match the reference element's width
  * @param [maxDropdownHeight] - Maximum height of the dropdown menu; when omitted, no limit is applied
+ * @param [initialFocus] - Initial focus target inside the overlay on open, forwarded to `FloatingFocusManager`; when omitted, matches pre-existing behavior
  */
 export const Dropdown: FC<DropdownProps> = ({
   children,
@@ -214,6 +224,7 @@ export const Dropdown: FC<DropdownProps> = ({
   anchorToMouse = false,
   matchReferenceWidth = true,
   maxDropdownHeight,
+  initialFocus,
 }) => {
   const themeScope = useThemeScope();
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
@@ -602,10 +613,19 @@ export const Dropdown: FC<DropdownProps> = ({
             <FloatingFocusManager
               context={context}
               modal={false}
-              /* 0 puts focus on the overlay's first control, falling back to the
-                 overlay itself when it holds none; -1 leaves focus where it is,
+              /* An explicit `initialFocus` prop wins outright — it's how a
+                 host (e.g. a typeahead/command menu opened from a textarea)
+                 opts out of focus theft entirely. Otherwise 0 puts focus on
+                 the overlay's first control, falling back to the overlay
+                 itself when it holds none; -1 leaves focus where it is,
                  which is only right for a menu the pointer opened on hover. */
-              initialFocus={shouldFocusOverlay ? 0 : -1}
+              initialFocus={
+                initialFocus !== undefined
+                  ? initialFocus
+                  : shouldFocusOverlay
+                    ? 0
+                    : -1
+              }
               returnFocus
             >
               <div


### PR DESCRIPTION
**Description and UI changes:**

Make autofocus in dropdown controllable via property

use case - open dropdown from typing in the input and don't lose focus
<img width="1916" height="944" alt="image" src="https://github.com/user-attachments/assets/3f1c8cff-1556-4ce1-90c9-3022e7674827" />


Issues:

- Issue #<TICKET_ID>

**Checklist:**

- [X] the pull request name complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] the pull request name ends with `(Issue #<TICKET_ID>)` (comma-separated list of issues)

**New Component Checklist:**
- [ ] component name starts with Dial
- [ ] custom css classes has dial- prefix
- [ ] component export added to index.ts
- [ ] jsdoc is added for component
- [ ] absolute paths are used for imports
 e.g. `import { Button } from '@/components/Button/Button` instead of `import { Button } from '../../Button/Button`
- [ ] stories are added
- [ ] tests are added